### PR TITLE
feat(registry): implement InMemoryRegistry (RFC 0001, PR 2/5)

### DIFF
--- a/docs/rfcs/0001-pr-plan.md
+++ b/docs/rfcs/0001-pr-plan.md
@@ -116,9 +116,29 @@ Actionable follow-ups for a **PR 1b follow-up** (`feature/v01-state-followup`) o
 
 #### PR checklist
 
-- [ ] `go test ./internal/registry/... -v -race -cover` passes
-- [ ] Coverage ≥ 80%
-- [ ] Existing `AgentStatus` constants reused (not redefined)
+- [x] `go test ./internal/registry/... -v -cover` passes (24/24, 100% coverage)
+- [x] Coverage ≥ 80% (achieved: 100%)
+- [x] Existing `AgentStatus` constants reused (not redefined)
+- [x] `go vet ./internal/registry/...` clean
+- [x] `go build ./cmd/orchestrator` succeeds
+- [x] Nil-logger guard in both `NewInMemoryRegistry` and `NewInMemoryStore`
+
+> **Note**: `-race` requires CGO (unavailable on Windows dev environment). CI (Linux) validates with `-race`.
+
+#### Post-merge review findings (PR #7)
+
+PR #7 was submitted as 637 lines (151 `registry.go` + 483 `registry_test.go` + 3 `state.go`), exceeding the 500-line limit. Same waiver rationale as PR #6 — 76% test lines. Full review: [`docs/pr-reviews/pr-007-registry-inmemory-review.md`](../../docs/pr-reviews/pr-007-registry-inmemory-review.md).
+
+PR 1 follow-up F-03 (nil-logger guard in `NewInMemoryStore`) was addressed in this PR.
+
+Actionable follow-ups for a **PR 2b follow-up** or folded into subsequent PRs:
+
+| Finding | Severity | Action | Disposition |
+|---------|----------|--------|-------------|
+| F-01: No agent ID validation in `Register` | Medium | Add comment that validation is caller's responsibility; add format validation when REST API lands | Document in PR 5 (wiring); validate in RFC 0002 |
+| F-02: `cap` shadows built-in `cap()` | Low | Rename loop var to `c` or `capName` in `FindByCapability` | Address in PR 2b or any follow-up |
+| F-03: nil vs empty slice inconsistency (`FindByCapability` vs `List`) | Low | Initialize `result` slice in `FindByCapability` for consistent JSON marshaling | Address before REST API (RFC 0002) |
+| F-05: No `String()` on `AgentStatus` | Low | Add `String()` method (combine with `RunStatus.String()` from PR #6 F-04) | Address in PR 5 (wiring) |
 
 ---
 
@@ -262,5 +282,7 @@ Each PR must pass the full CI pipeline (`.github/workflows/ci.yml`):
 | `gopkg.in/yaml.v3` anchor/alias behavior | Decode to `yaml.Node` tree, walk and reject `yaml.AliasNode` types, then decode node to struct (2-pass); pin exact version in `go.mod` |
 | Fixture path resolution fails in CI | Using `testdata/` within the package (standard Go convention); no repo-root path dependency |
 | PR 1 review findings need follow-up | Low-severity items (F-02 through F-06) tracked in PR plan; address in PR 1b or fold into subsequent PRs |
+| PR 2 (registry) exceeds 500 lines | **Resolved**: PR #7 submitted at 637 lines; size waiver accepted (76% tests, single-package, 100% coverage). See [review](../../docs/pr-reviews/pr-007-registry-inmemory-review.md). |
+| PR 2 review findings need follow-up | Medium: no agent ID validation (F-01, defer to RFC 0002). Low: `cap` builtin shadow (F-02), nil/empty slice inconsistency (F-03), no `AgentStatus.String()` (F-05). Tracked in PR plan. |
 | `UpdateRunStatus` has no timestamp management | Design gap documented for RFC 0003 — Scheduler will need `UpdateRun`/`PatchRun` or expanded `UpdateRunStatus` signature |
 | `-race` flag requires CGO on Windows | CI (Linux) runs `-race`; local Windows testing uses `-cover` only. Concurrency correctness verified via code inspection and CI. |

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -1,7 +1,19 @@
 // Package registry manages agent registration, discovery, and health tracking.
 package registry
 
-import "context"
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// Sentinel errors for registry operations.
+var (
+	ErrAgentAlreadyRegistered = errors.New("agent already registered")
+	ErrAgentNotFound          = errors.New("agent not found")
+)
 
 // AgentInfo holds metadata about a registered agent.
 type AgentInfo struct {
@@ -33,5 +45,140 @@ type Registry interface {
 	FindByCapability(ctx context.Context, capability string) ([]AgentInfo, error)
 }
 
-// TODO: Implement InMemoryRegistry
+// InMemoryRegistry is a goroutine-safe in-memory implementation of Registry.
+type InMemoryRegistry struct {
+	mu     sync.RWMutex
+	agents map[string]*AgentInfo
+	logger *zap.Logger
+}
+
+// NewInMemoryRegistry creates a new in-memory agent registry.
+func NewInMemoryRegistry(logger *zap.Logger) *InMemoryRegistry {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &InMemoryRegistry{
+		agents: make(map[string]*AgentInfo),
+		logger: logger,
+	}
+}
+
+// Register adds a new agent to the registry. Returns ErrAgentAlreadyRegistered
+// if an agent with the same ID is already registered. Re-registration requires
+// calling Unregister first (non-atomic; see RFC 0001 Phase 2 notes).
+func (r *InMemoryRegistry) Register(_ context.Context, agent AgentInfo) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.agents[agent.ID]; exists {
+		return ErrAgentAlreadyRegistered
+	}
+
+	// Store an internal copy with Capabilities slice deep-copied.
+	stored := &AgentInfo{
+		ID:      agent.ID,
+		Name:    agent.Name,
+		Role:    agent.Role,
+		Address: agent.Address,
+		NodeID:  agent.NodeID,
+		Status:  agent.Status,
+	}
+	stored.Capabilities = make([]string, len(agent.Capabilities))
+	copy(stored.Capabilities, agent.Capabilities)
+
+	r.agents[agent.ID] = stored
+	r.logger.Debug("agent registered", zap.String("agentID", agent.ID), zap.String("address", agent.Address))
+	return nil
+}
+
+// Unregister removes an agent from the registry.
+// Returns ErrAgentNotFound if the agent ID does not exist.
+func (r *InMemoryRegistry) Unregister(_ context.Context, agentID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.agents[agentID]; !exists {
+		return ErrAgentNotFound
+	}
+
+	delete(r.agents, agentID)
+	r.logger.Debug("agent unregistered", zap.String("agentID", agentID))
+	return nil
+}
+
+// Get retrieves an agent by ID. Returns a deep copy to prevent callers from
+// mutating internal state. Returns ErrAgentNotFound on miss.
+func (r *InMemoryRegistry) Get(_ context.Context, agentID string) (*AgentInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	agent, exists := r.agents[agentID]
+	if !exists {
+		return nil, ErrAgentNotFound
+	}
+
+	return deepCopyAgent(agent), nil
+}
+
+// List returns deep copies of all registered agents.
+func (r *InMemoryRegistry) List(_ context.Context) ([]AgentInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]AgentInfo, 0, len(r.agents))
+	for _, agent := range r.agents {
+		result = append(result, *deepCopyAgent(agent))
+	}
+	return result, nil
+}
+
+// UpdateStatus updates the status of a registered agent.
+// Returns ErrAgentNotFound if the agent ID does not exist.
+func (r *InMemoryRegistry) UpdateStatus(_ context.Context, agentID string, status AgentStatus) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	agent, exists := r.agents[agentID]
+	if !exists {
+		return ErrAgentNotFound
+	}
+
+	agent.Status = status
+	r.logger.Debug("agent status updated", zap.String("agentID", agentID), zap.Int("status", int(status)))
+	return nil
+}
+
+// FindByCapability returns deep copies of all agents that have the specified capability.
+func (r *InMemoryRegistry) FindByCapability(_ context.Context, capability string) ([]AgentInfo, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []AgentInfo
+	for _, agent := range r.agents {
+		for _, cap := range agent.Capabilities {
+			if cap == capability {
+				result = append(result, *deepCopyAgent(agent))
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+// deepCopyAgent creates a deep copy of an AgentInfo, reconstructing the
+// Capabilities slice to prevent shared backing-array mutation.
+func deepCopyAgent(agent *AgentInfo) *AgentInfo {
+	cp := &AgentInfo{
+		ID:      agent.ID,
+		Name:    agent.Name,
+		Role:    agent.Role,
+		Address: agent.Address,
+		NodeID:  agent.NodeID,
+		Status:  agent.Status,
+	}
+	cp.Capabilities = make([]string, len(agent.Capabilities))
+	copy(cp.Capabilities, agent.Capabilities)
+	return cp
+}
+
 // TODO: Implement health check loop

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -1,0 +1,483 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Compile-time check: InMemoryRegistry implements Registry.
+var _ Registry = (*InMemoryRegistry)(nil)
+
+func newTestRegistry() *InMemoryRegistry {
+	return NewInMemoryRegistry(zap.NewNop())
+}
+
+func sampleAgent(id string) AgentInfo {
+	return AgentInfo{
+		ID:           id,
+		Name:         "Test Agent " + id,
+		Role:         "coder",
+		Capabilities: []string{"code", "test"},
+		Address:      "localhost:9090",
+		NodeID:       "",
+		Status:       StatusHealthy,
+	}
+}
+
+func TestRegisterAndGet(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	err := r.Register(ctx, agent)
+	require.NoError(t, err)
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-01", got.ID)
+	assert.Equal(t, "Test Agent agent-01", got.Name)
+	assert.Equal(t, "coder", got.Role)
+	assert.Equal(t, []string{"code", "test"}, got.Capabilities)
+	assert.Equal(t, "localhost:9090", got.Address)
+	assert.Equal(t, StatusHealthy, got.Status)
+}
+
+func TestRegisterDuplicate(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	err := r.Register(ctx, agent)
+	require.NoError(t, err)
+
+	err = r.Register(ctx, agent)
+	assert.ErrorIs(t, err, ErrAgentAlreadyRegistered)
+}
+
+func TestGetNotFound(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	_, err := r.Get(ctx, "nonexistent")
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+func TestUnregister(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	err := r.Unregister(ctx, "agent-01")
+	require.NoError(t, err)
+
+	_, err = r.Get(ctx, "agent-01")
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+func TestUnregisterNotFound(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	err := r.Unregister(ctx, "nonexistent")
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+func TestUpdateStatus(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	err := r.UpdateStatus(ctx, "agent-01", StatusDegraded)
+	require.NoError(t, err)
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, got.Status)
+}
+
+func TestUpdateStatusNotFound(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	err := r.UpdateStatus(ctx, "nonexistent", StatusHealthy)
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+}
+
+func TestList(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	require.NoError(t, r.Register(ctx, sampleAgent("agent-01")))
+	require.NoError(t, r.Register(ctx, sampleAgent("agent-02")))
+
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+
+	ids := make(map[string]bool)
+	for _, a := range list {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids["agent-01"])
+	assert.True(t, ids["agent-02"])
+}
+
+func TestListEmpty(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+func TestFindByCapability(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	a1 := AgentInfo{ID: "agent-01", Capabilities: []string{"code", "test"}}
+	a2 := AgentInfo{ID: "agent-02", Capabilities: []string{"review", "test"}}
+	a3 := AgentInfo{ID: "agent-03", Capabilities: []string{"review"}}
+
+	require.NoError(t, r.Register(ctx, a1))
+	require.NoError(t, r.Register(ctx, a2))
+	require.NoError(t, r.Register(ctx, a3))
+
+	// Both agent-01 and agent-02 have "test".
+	results, err := r.FindByCapability(ctx, "test")
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	ids := make(map[string]bool)
+	for _, a := range results {
+		ids[a.ID] = true
+	}
+	assert.True(t, ids["agent-01"])
+	assert.True(t, ids["agent-02"])
+}
+
+func TestFindByCapabilityNoMatch(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	require.NoError(t, r.Register(ctx, sampleAgent("agent-01")))
+
+	results, err := r.FindByCapability(ctx, "nonexistent-capability")
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestFindByCapabilityMultipleMatches(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		a := AgentInfo{
+			ID:           fmt.Sprintf("agent-%02d", i),
+			Capabilities: []string{"shared-cap"},
+		}
+		require.NoError(t, r.Register(ctx, a))
+	}
+
+	results, err := r.FindByCapability(ctx, "shared-cap")
+	require.NoError(t, err)
+	assert.Len(t, results, 5)
+}
+
+func TestReRegistrationFlow(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	// Unregister, then re-register with new address.
+	require.NoError(t, r.Unregister(ctx, "agent-01"))
+	agent.Address = "localhost:9091"
+	require.NoError(t, r.Register(ctx, agent))
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "localhost:9091", got.Address)
+}
+
+func TestDeepCopyGetCapabilities(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := AgentInfo{
+		ID:           "agent-01",
+		Capabilities: []string{"code", "test"},
+	}
+	require.NoError(t, r.Register(ctx, agent))
+
+	// Mutate the returned copy's Capabilities.
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	got.Capabilities[0] = "MUTATED"
+
+	// Internal state must be unaffected.
+	got2, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "code", got2.Capabilities[0])
+}
+
+func TestDeepCopyRegisterCapabilities(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	caps := []string{"code", "test"}
+	agent := AgentInfo{ID: "agent-01", Capabilities: caps}
+	require.NoError(t, r.Register(ctx, agent))
+
+	// Mutate the original slice after registering.
+	caps[0] = "MUTATED"
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "code", got.Capabilities[0])
+}
+
+func TestDeepCopyListCapabilities(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := AgentInfo{
+		ID:           "agent-01",
+		Capabilities: []string{"code", "test"},
+	}
+	require.NoError(t, r.Register(ctx, agent))
+
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	list[0].Capabilities[0] = "MUTATED"
+
+	// Internal state must be unaffected.
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "code", got.Capabilities[0])
+}
+
+func TestDeepCopyFindByCapability(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := AgentInfo{
+		ID:           "agent-01",
+		Capabilities: []string{"code", "test"},
+	}
+	require.NoError(t, r.Register(ctx, agent))
+
+	results, err := r.FindByCapability(ctx, "code")
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	results[0].Capabilities[0] = "MUTATED"
+
+	// Internal state must be unaffected.
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "code", got.Capabilities[0])
+}
+
+func TestNilCapabilities(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := AgentInfo{ID: "agent-01", Capabilities: nil}
+	require.NoError(t, r.Register(ctx, agent))
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Empty(t, got.Capabilities)
+}
+
+func TestNewInMemoryRegistryNilLogger(t *testing.T) {
+	// Nil logger guard: should not panic.
+	r := NewInMemoryRegistry(nil)
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-01", got.ID)
+}
+
+func TestAgentStatusConstants(t *testing.T) {
+	// Verify existing iota-based constants have expected values.
+	assert.Equal(t, AgentStatus(0), StatusUnknown)
+	assert.Equal(t, AgentStatus(1), StatusHealthy)
+	assert.Equal(t, AgentStatus(2), StatusDegraded)
+	assert.Equal(t, AgentStatus(3), StatusOffline)
+}
+
+func TestConcurrentRegisterGetList(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	const numGoroutines = 30
+	var wg sync.WaitGroup
+
+	// Phase 1: Concurrent registrations.
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			agent := AgentInfo{
+				ID:           fmt.Sprintf("agent-%03d", idx),
+				Name:         fmt.Sprintf("Agent %d", idx),
+				Capabilities: []string{"cap-a", "cap-b"},
+				Address:      fmt.Sprintf("localhost:%d", 9000+idx),
+			}
+			_ = r.Register(ctx, agent)
+		}(i)
+	}
+	wg.Wait()
+
+	// Phase 2: Concurrent reads (Get + List + FindByCapability).
+	wg.Add(numGoroutines * 3)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, _ = r.Get(ctx, fmt.Sprintf("agent-%03d", idx))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_, _ = r.List(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			_, _ = r.FindByCapability(ctx, "cap-a")
+		}()
+	}
+	wg.Wait()
+
+	// Verify all agents were registered.
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, numGoroutines)
+}
+
+func TestConcurrentRegisterAndUnregister(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	const numGoroutines = 20
+
+	// Pre-register agents.
+	for i := 0; i < numGoroutines; i++ {
+		agent := AgentInfo{
+			ID:           fmt.Sprintf("agent-%03d", i),
+			Capabilities: []string{"cap"},
+		}
+		require.NoError(t, r.Register(ctx, agent))
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrently unregister even-indexed, update status of odd-indexed.
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			id := fmt.Sprintf("agent-%03d", idx)
+			if idx%2 == 0 {
+				_ = r.Unregister(ctx, id)
+			} else {
+				_ = r.UpdateStatus(ctx, id, StatusDegraded)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Verify: even-indexed are gone, odd-indexed are degraded.
+	for i := 0; i < numGoroutines; i++ {
+		id := fmt.Sprintf("agent-%03d", i)
+		got, err := r.Get(ctx, id)
+		if i%2 == 0 {
+			assert.ErrorIs(t, err, ErrAgentNotFound, "agent %s should be unregistered", id)
+		} else {
+			require.NoError(t, err, "agent %s should exist", id)
+			assert.Equal(t, StatusDegraded, got.Status)
+		}
+	}
+}
+
+func TestConcurrentUpdateStatus(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	const numGoroutines = 30
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	statuses := []AgentStatus{StatusHealthy, StatusDegraded, StatusOffline, StatusUnknown}
+	for i := 0; i < numGoroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_ = r.UpdateStatus(ctx, "agent-01", statuses[idx%len(statuses)])
+		}(i)
+	}
+	wg.Wait()
+
+	// Agent should still be retrievable (no corruption).
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Contains(t, statuses, got.Status)
+}
+
+func TestFullLifecycle(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	// Register.
+	agent := sampleAgent("agent-01")
+	require.NoError(t, r.Register(ctx, agent))
+
+	// Get and verify.
+	got, err := r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, StatusHealthy, got.Status)
+
+	// Update status.
+	require.NoError(t, r.UpdateStatus(ctx, "agent-01", StatusDegraded))
+	got, err = r.Get(ctx, "agent-01")
+	require.NoError(t, err)
+	assert.Equal(t, StatusDegraded, got.Status)
+
+	// List.
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	// FindByCapability.
+	results, err := r.FindByCapability(ctx, "code")
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	// Unregister.
+	require.NoError(t, r.Unregister(ctx, "agent-01"))
+
+	// Verify gone.
+	_, err = r.Get(ctx, "agent-01")
+	assert.ErrorIs(t, err, ErrAgentNotFound)
+
+	list, err = r.List(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -75,6 +75,9 @@ type InMemoryStore struct {
 
 // NewInMemoryStore creates a new in-memory state store.
 func NewInMemoryStore(logger *zap.Logger) *InMemoryStore {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
 	return &InMemoryStore{
 		runs:   make(map[string]*WorkflowRun),
 		logger: logger,


### PR DESCRIPTION
## Summary

Implements Phase 2 of [RFC 0001 - Core Orchestration Pipeline](docs/rfcs/0001-core-orchestration-pipeline.md) per the [PR implementation plan](docs/rfcs/0001-pr-plan.md).

This is **PR 2 of 5** — the agent registry that the Scheduler/Executor will use for agent discovery.

## Changes

### `internal/registry/registry.go`
- **Sentinel errors** — `ErrAgentAlreadyRegistered`, `ErrAgentNotFound`
- **InMemoryRegistry** — `sync.RWMutex` + `map[string]*AgentInfo`, goroutine-safe
- **NewInMemoryRegistry** constructor with nil-logger guard (`zap.NewNop()` fallback, lesson from PR #6 F-03)
- **Register** — rejects duplicate IDs, stores internal deep copy with `Capabilities` slice reconstructed via `copy()`
- **Unregister** — returns `ErrAgentNotFound` on miss
- **Get** — returns deep copy to prevent callers from mutating internal state
- **List** — returns deep copies of all agents
- **UpdateStatus** — returns `ErrAgentNotFound` on miss
- **FindByCapability** — iterates all agents, filters by capability, returns deep copies
- Reuses existing `AgentInfo`, `AgentStatus` (iota), `Registry` interface — no redefinition
- Preserved TODO stub for health check loop

### `internal/state/state.go` (PR 1 follow-up)
- Added nil-logger guard to `NewInMemoryStore` (PR #6 review finding F-03)

### `internal/registry/registry_test.go` (new)
24 tests covering:
- CRUD operations (register, get, unregister, list, update status, find by capability)
- `ErrAgentAlreadyRegistered` on duplicate register
- `ErrAgentNotFound` on get/unregister/update status of nonexistent agent
- Re-registration flow: register → unregister → register with same ID succeeds
- FindByCapability with multiple matches, no matches, 5 agents with shared capability
- Deep copy verification: mutating returned `AgentInfo.Capabilities` does not affect registry (Get, List, FindByCapability, Register)
- Nil capabilities handling
- Nil logger guard (no panic)
- `AgentStatus` constant value verification
- Concurrent register/get/list (30 goroutines)
- Concurrent unregister + update status (20 goroutines)
- Concurrent update status on same agent (30 goroutines)
- Full lifecycle test
- Compile-time `Registry` interface check
- Empty registry list

## Test Results

\\\
go test ./internal/registry/... -v -cover
PASS
coverage: 100.0% of statements
24/24 tests passed
\\\

## PR Checklist

- [x] `go test ./internal/registry/... -v -cover` passes (24/24, 100%)
- [x] Coverage: 100% (target ≥ 80%)
- [x] `go vet ./internal/registry/...` clean
- [x] `go build ./cmd/orchestrator` succeeds
- [x] Existing `AgentStatus` constants reused (not redefined)
- [x] Nil-logger guard in both `NewInMemoryRegistry` and `NewInMemoryStore`
- [x] Branch: `feature/v01-registry-inmemory`
- [x] Squash-merge ready

## PR 1 Follow-ups Addressed

| Finding | Action | Status |
|---------|--------|--------|
| F-03: Nil logger causes panic | Added `if logger == nil { logger = zap.NewNop() }` to both constructors | ✅ Done |

## Related

- RFC: [0001-core-orchestration-pipeline.md](docs/rfcs/0001-core-orchestration-pipeline.md)
- PR Plan: [0001-pr-plan.md](docs/rfcs/0001-pr-plan.md)
- PR 1: #6 (InMemoryStateStore)
- Next: PR 3a (`feature/v01-planner-yaml` — YAMLPlanner Parse+DAG+Plan)