### PR TITLE
feat(planner): implement YAMLPlanner Parse+DAG+Plan (RFC 0001, PR 3a/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ htmlcov/
 
 # PR review reports (local analysis artifacts)
 docs/pr-reviews/
+orchestrator.exe

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -2,7 +2,33 @@
 // and topological sort for execution ordering.
 package planner
 
-import "context"
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v3"
+)
+
+// stepIDPattern is the canonical step ID format pattern, shared between
+// Parse validation and ResolveInputs template capture group.
+const stepIDPattern = `[a-z0-9]([a-z0-9_-]*[a-z0-9])?`
+
+// maxYAMLSize is the maximum allowed YAML file size (1 MB).
+const maxYAMLSize = 1 << 20
+
+var (
+	workflowIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+	agentIDRegex    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+	stepIDRegex     = regexp.MustCompile(`^` + stepIDPattern + `$`)
+	outputKeyRegex  = regexp.MustCompile(`^` + stepIDPattern + `$`)
+)
 
 // Workflow represents a parsed workflow definition.
 type Workflow struct {
@@ -36,6 +62,279 @@ type Planner interface {
 	ValidateDAG(ctx context.Context, workflow *Workflow) error
 }
 
-// TODO: Implement YAMLPlanner
-// TODO: Implement template variable resolution ({{ steps.X.output }})
+// WorkflowFile is the top-level YAML structure wrapping schema_version and workflow.
+type WorkflowFile struct {
+	SchemaVersion string   `yaml:"schema_version"`
+	Workflow      Workflow `yaml:"workflow"`
+}
+
+// YAMLPlanner implements the Planner interface by parsing YAML workflow files,
+// validating the DAG, and producing topologically sorted execution plans.
+type YAMLPlanner struct {
+	logger *zap.Logger
+}
+
+// NewYAMLPlanner creates a new YAMLPlanner with the given logger.
+func NewYAMLPlanner(logger *zap.Logger) *YAMLPlanner {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &YAMLPlanner{logger: logger}
+}
+
+// Parse reads a workflow YAML file, validates its structure, and returns the Workflow.
+func (p *YAMLPlanner) Parse(_ context.Context, yamlPath string) (*Workflow, error) {
+	cleanPath := filepath.Clean(yamlPath)
+
+	f, err := os.Open(cleanPath)
+	if err != nil {
+		return nil, fmt.Errorf("open workflow file: %w", err)
+	}
+	defer f.Close()
+
+	// Read up to maxYAMLSize+1 bytes to detect overflow.
+	limited := io.LimitReader(f, maxYAMLSize+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, fmt.Errorf("read workflow file: %w", err)
+	}
+	if len(data) > maxYAMLSize {
+		return nil, fmt.Errorf("workflow file exceeds maximum size of %d bytes", maxYAMLSize)
+	}
+
+	// 2-pass YAML decode: first decode to yaml.Node tree to reject anchors/aliases,
+	// then decode the validated node to the target struct.
+	var node yaml.Node
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return nil, fmt.Errorf("unmarshal YAML: %w", err)
+	}
+
+	if err := rejectAliases(&node); err != nil {
+		return nil, err
+	}
+
+	var wf WorkflowFile
+	if err := node.Decode(&wf); err != nil {
+		return nil, fmt.Errorf("decode workflow: %w", err)
+	}
+
+	if err := p.validate(&wf); err != nil {
+		return nil, err
+	}
+
+	p.logger.Debug("workflow parsed",
+		zap.String("id", wf.Workflow.ID),
+		zap.String("name", wf.Workflow.Name),
+		zap.Int("steps", len(wf.Workflow.Steps)),
+	)
+
+	return &wf.Workflow, nil
+}
+
+// validate checks required fields, formats, and referential integrity.
+func (p *YAMLPlanner) validate(wf *WorkflowFile) error {
+	if wf.SchemaVersion != "0.1" {
+		return fmt.Errorf("unsupported schema version: %q (expected \"0.1\")", wf.SchemaVersion)
+	}
+
+	w := &wf.Workflow
+
+	if w.ID == "" {
+		return errors.New("workflow id is required")
+	}
+	if !workflowIDRegex.MatchString(w.ID) {
+		return fmt.Errorf("invalid workflow id %q: must match %s", w.ID, workflowIDRegex.String())
+	}
+
+	if w.Name == "" {
+		return errors.New("workflow name is required")
+	}
+
+	if len(w.Steps) == 0 {
+		return errors.New("workflow must have at least one step")
+	}
+
+	stepIDs := make(map[string]bool, len(w.Steps))
+	outputKeys := make(map[string]string) // output_key -> step ID
+
+	for i, step := range w.Steps {
+		if step.ID == "" {
+			return fmt.Errorf("step %d: id is required", i)
+		}
+		if !stepIDRegex.MatchString(step.ID) {
+			return fmt.Errorf("step %d: invalid step id %q: must match %s", i, step.ID, stepIDRegex.String())
+		}
+		if stepIDs[step.ID] {
+			return fmt.Errorf("step %d: duplicate step id %q", i, step.ID)
+		}
+		stepIDs[step.ID] = true
+
+		if step.AgentID == "" {
+			return fmt.Errorf("step %q: agent is required", step.ID)
+		}
+		if !agentIDRegex.MatchString(step.AgentID) {
+			return fmt.Errorf("step %q: invalid agent id %q: must match %s", step.ID, step.AgentID, agentIDRegex.String())
+		}
+
+		if step.Input == "" {
+			return fmt.Errorf("step %q: input is required", step.ID)
+		}
+
+		if step.OutputKey != "" {
+			if !outputKeyRegex.MatchString(step.OutputKey) {
+				return fmt.Errorf("step %q: invalid output_key %q: must match %s", step.ID, step.OutputKey, outputKeyRegex.String())
+			}
+			if existing, ok := outputKeys[step.OutputKey]; ok {
+				return fmt.Errorf("step %q: duplicate output_key %q (already used by step %q)", step.ID, step.OutputKey, existing)
+			}
+			outputKeys[step.OutputKey] = step.ID
+		}
+	}
+
+	// Validate depends_on references point to existing step IDs.
+	for _, step := range w.Steps {
+		for _, dep := range step.DependsOn {
+			if !stepIDs[dep] {
+				return fmt.Errorf("step %q: depends_on references nonexistent step %q", step.ID, dep)
+			}
+		}
+	}
+
+	return nil
+}
+
+// rejectAliases walks the yaml.Node tree and rejects any alias nodes.
+func rejectAliases(node *yaml.Node) error {
+	if node.Kind == yaml.AliasNode {
+		return fmt.Errorf("YAML anchors/aliases are not allowed (found alias %q)", node.Value)
+	}
+	for _, child := range node.Content {
+		if err := rejectAliases(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateDAG checks for cycles in the workflow's step dependency graph.
+func (p *YAMLPlanner) ValidateDAG(_ context.Context, workflow *Workflow) error {
+	// Build adjacency list: step ID -> list of step IDs it depends on.
+	adj := make(map[string][]string, len(workflow.Steps))
+	for _, step := range workflow.Steps {
+		adj[step.ID] = step.DependsOn
+	}
+
+	const (
+		white = 0 // unvisited
+		gray  = 1 // in current DFS path
+		black = 2 // fully explored
+	)
+
+	color := make(map[string]int, len(workflow.Steps))
+	parent := make(map[string]string)
+
+	var dfs func(id string) error
+	dfs = func(id string) error {
+		color[id] = gray
+		for _, dep := range adj[id] {
+			switch color[dep] {
+			case gray:
+				// Cycle found — reconstruct cycle path.
+				cycle := []string{dep, id}
+				cur := id
+				for cur != dep {
+					cur = parent[cur]
+					cycle = append(cycle, cur)
+				}
+				// Reverse to get readable order.
+				for i, j := 0, len(cycle)-1; i < j; i, j = i+1, j-1 {
+					cycle[i], cycle[j] = cycle[j], cycle[i]
+				}
+				return fmt.Errorf("cycle detected: %s", strings.Join(cycle, " → "))
+			case white:
+				parent[dep] = id
+				if err := dfs(dep); err != nil {
+					return err
+				}
+			}
+		}
+		color[id] = black
+		return nil
+	}
+
+	for _, step := range workflow.Steps {
+		if color[step.ID] == white {
+			if err := dfs(step.ID); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Plan produces a topologically sorted ExecutionPlan using Kahn's algorithm.
+// Precondition: workflow must have passed ValidateDAG.
+func (p *YAMLPlanner) Plan(_ context.Context, workflow *Workflow) (*ExecutionPlan, error) {
+	stepMap := make(map[string]Step, len(workflow.Steps))
+	inDegree := make(map[string]int, len(workflow.Steps))
+	dependents := make(map[string][]string) // step ID -> IDs that depend on it
+
+	for _, step := range workflow.Steps {
+		stepMap[step.ID] = step
+		inDegree[step.ID] = len(step.DependsOn)
+		for _, dep := range step.DependsOn {
+			dependents[dep] = append(dependents[dep], step.ID)
+		}
+	}
+
+	// Seed with steps that have no dependencies.
+	var queue []string
+	for _, step := range workflow.Steps {
+		if inDegree[step.ID] == 0 {
+			queue = append(queue, step.ID)
+		}
+	}
+
+	var stages [][]Step
+	emitted := 0
+
+	for len(queue) > 0 {
+		stage := make([]Step, 0, len(queue))
+		for _, id := range queue {
+			stage = append(stage, stepMap[id])
+		}
+		stages = append(stages, stage)
+		emitted += len(queue)
+
+		var next []string
+		for _, id := range queue {
+			for _, dep := range dependents[id] {
+				inDegree[dep]--
+				if inDegree[dep] == 0 {
+					next = append(next, dep)
+				}
+			}
+		}
+		queue = next
+	}
+
+	// Defensive node-count check: catches cycles that slipped past a missing ValidateDAG call.
+	if emitted != len(workflow.Steps) {
+		return nil, fmt.Errorf("plan produced %d steps but workflow has %d (possible cycle)", emitted, len(workflow.Steps))
+	}
+
+	p.logger.Debug("execution plan created",
+		zap.String("workflowID", workflow.ID),
+		zap.Int("stages", len(stages)),
+		zap.Int("totalSteps", emitted),
+	)
+
+	return &ExecutionPlan{
+		WorkflowID: workflow.ID,
+		Stages:     stages,
+	}, nil
+}
+
+// TODO: Implement template variable resolution ({{ steps.X.output }}) — PR 3b
 // TODO: Implement condition evaluation

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -1,0 +1,624 @@
+package planner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+// Compile-time check: YAMLPlanner implements Planner.
+var _ Planner = (*YAMLPlanner)(nil)
+
+func newTestPlanner() *YAMLPlanner {
+	return NewYAMLPlanner(zap.NewNop())
+}
+
+// --- Parse tests ---
+
+func TestParse_ValidWorkflow(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "valid_workflow.yaml"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "feature-builder", wf.ID)
+	assert.Equal(t, "Build a Feature End-to-End", wf.Name)
+	assert.Equal(t, "manual", wf.Trigger)
+	assert.Len(t, wf.Steps, 4)
+
+	assert.Equal(t, "plan", wf.Steps[0].ID)
+	assert.Equal(t, "planner", wf.Steps[0].AgentID)
+	assert.Equal(t, "{{ user_request }}", wf.Steps[0].Input)
+	assert.Equal(t, "plan", wf.Steps[0].OutputKey)
+
+	assert.Equal(t, "implement", wf.Steps[1].ID)
+	assert.Equal(t, []string{"plan"}, wf.Steps[1].DependsOn)
+
+	assert.Equal(t, "revise", wf.Steps[3].ID)
+	assert.Equal(t, []string{"review"}, wf.Steps[3].DependsOn)
+	assert.Equal(t, "{{ steps.review.output.approved == false }}", wf.Steps[3].Condition)
+}
+
+func TestParse_SingleStep(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "single_step.yaml"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "single-step", wf.ID)
+	assert.Len(t, wf.Steps, 1)
+	assert.Equal(t, "do", wf.Steps[0].ID)
+}
+
+func TestParse_MissingWorkflowID(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  name: "No ID"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workflow id is required")
+}
+
+func TestParse_MissingWorkflowName(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workflow name is required")
+}
+
+func TestParse_EmptySteps(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Empty steps"
+  steps: []
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one step")
+}
+
+func TestParse_MissingStepID(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Missing step ID"
+  steps:
+    - agent: "planner"
+      input: "hello"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "id is required")
+}
+
+func TestParse_MissingStepAgent(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Missing agent"
+  steps:
+    - id: "s1"
+      input: "hello"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "agent is required")
+}
+
+func TestParse_MissingStepInput(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Missing input"
+  steps:
+    - id: "s1"
+      agent: "planner"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "input is required")
+}
+
+func TestParse_InvalidWorkflowID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"uppercase", "Test-WF"},
+		{"starts with hyphen", "-test"},
+		{"ends with hyphen", "test-"},
+		{"spaces", "test wf"},
+		{"single char", "a"},
+		{"dots", "test.wf"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `
+schema_version: "0.1"
+workflow:
+  id: "` + tc.id + `"
+  name: "Bad ID"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+`
+			p := newTestPlanner()
+			_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid workflow id")
+		})
+	}
+}
+
+func TestParse_InvalidAgentID(t *testing.T) {
+	tests := []struct {
+		name    string
+		agentID string
+	}{
+		{"uppercase", "Planner"},
+		{"starts with hyphen", "-planner"},
+		{"single char", "p"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Bad agent"
+  steps:
+    - id: "s1"
+      agent: "` + tc.agentID + `"
+      input: "hello"
+`
+			p := newTestPlanner()
+			_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid agent id")
+		})
+	}
+}
+
+func TestParse_InvalidStepID(t *testing.T) {
+	tests := []struct {
+		name   string
+		stepID string
+	}{
+		{"uppercase", "Step1"},
+		{"dots", "step.1"},
+		{"braces", "step{1}"},
+		{"slash", "step/1"},
+		{"starts with hyphen", "-step"},
+		{"ends with hyphen", "step-"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Bad step"
+  steps:
+    - id: "` + tc.stepID + `"
+      agent: "planner"
+      input: "hello"
+`
+			p := newTestPlanner()
+			_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid step id")
+		})
+	}
+}
+
+func TestParse_DuplicateStepID(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Dup steps"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+    - id: "s1"
+      agent: "planner"
+      input: "world"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate step id")
+}
+
+func TestParse_UnknownSchemaVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{"0.2", "0.2"},
+		{"empty", ""},
+		{"1.0", "1.0"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			yaml := `
+schema_version: "` + tc.version + `"
+workflow:
+  id: "test-wf"
+  name: "Bad version"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+`
+			p := newTestPlanner()
+			_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unsupported schema version")
+		})
+	}
+}
+
+func TestParse_InvalidOutputKey(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Bad output key"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+      output_key: "BAD KEY!"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid output_key")
+}
+
+func TestParse_DuplicateOutputKey(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Dup output key"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+      output_key: "result"
+    - id: "s2"
+      agent: "planner"
+      input: "world"
+      output_key: "result"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate output_key")
+}
+
+func TestParse_InvalidDependsOnRef(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Bad dep"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+      depends_on: ["nonexistent"]
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "depends_on references nonexistent step")
+}
+
+func TestParse_FileNotFound(t *testing.T) {
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), "testdata/nonexistent.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "open workflow file")
+}
+
+func TestParse_FileTooLarge(t *testing.T) {
+	// Create a file larger than 1 MB.
+	content := strings.Repeat("x", maxYAMLSize+100)
+	path := writeTempYAML(t, content)
+
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), path)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestParse_AnchorAliasRejected(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+defaults: &defaults
+  agent: "planner"
+  input: "hello"
+workflow:
+  id: "test-wf"
+  name: "Alias test"
+  steps:
+    - id: "s1"
+      <<: *defaults
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "anchors/aliases are not allowed")
+}
+
+func TestParse_PathCleaning(t *testing.T) {
+	// filepath.Clean normalizes the path — Parse should handle it.
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "..", "testdata", "single_step.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "single-step", wf.ID)
+}
+
+func TestParse_NilLogger(t *testing.T) {
+	// NewYAMLPlanner with nil logger should not panic.
+	p := NewYAMLPlanner(nil)
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "single_step.yaml"))
+	require.NoError(t, err)
+	assert.Equal(t, "single-step", wf.ID)
+}
+
+// --- ValidateDAG tests ---
+
+func TestValidateDAG_NoCycle(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "valid_workflow.yaml"))
+	require.NoError(t, err)
+
+	err = p.ValidateDAG(context.Background(), wf)
+	assert.NoError(t, err)
+}
+
+func TestValidateDAG_SimpleCycle(t *testing.T) {
+	wf := &Workflow{
+		Steps: []Step{
+			{ID: "aa", DependsOn: []string{"bb"}},
+			{ID: "bb", DependsOn: []string{"aa"}},
+		},
+	}
+	p := newTestPlanner()
+	err := p.ValidateDAG(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestValidateDAG_ComplexCycle(t *testing.T) {
+	wf := &Workflow{
+		Steps: []Step{
+			{ID: "aa", DependsOn: []string{}},
+			{ID: "bb", DependsOn: []string{"aa"}},
+			{ID: "cc", DependsOn: []string{"bb"}},
+			{ID: "dd", DependsOn: []string{"cc", "bb"}},
+		},
+	}
+	p := newTestPlanner()
+	err := p.ValidateDAG(context.Background(), wf)
+	assert.NoError(t, err) // No cycle — dd depends on cc and bb, both reachable from aa.
+}
+
+func TestValidateDAG_ActualCycle3Nodes(t *testing.T) {
+	wf := &Workflow{
+		Steps: []Step{
+			{ID: "aa", DependsOn: []string{"cc"}},
+			{ID: "bb", DependsOn: []string{"aa"}},
+			{ID: "cc", DependsOn: []string{"bb"}},
+		},
+	}
+	p := newTestPlanner()
+	err := p.ValidateDAG(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestValidateDAG_SelfReference(t *testing.T) {
+	wf := &Workflow{
+		Steps: []Step{
+			{ID: "loop", DependsOn: []string{"loop"}},
+		},
+	}
+	p := newTestPlanner()
+	err := p.ValidateDAG(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestValidateDAG_NoDeps(t *testing.T) {
+	wf := &Workflow{
+		Steps: []Step{
+			{ID: "aa"},
+			{ID: "bb"},
+			{ID: "cc"},
+		},
+	}
+	p := newTestPlanner()
+	err := p.ValidateDAG(context.Background(), wf)
+	assert.NoError(t, err)
+}
+
+// --- Plan tests ---
+
+func TestPlan_LinearChain(t *testing.T) {
+	wf := &Workflow{
+		ID: "linear",
+		Steps: []Step{
+			{ID: "s1"},
+			{ID: "s2", DependsOn: []string{"s1"}},
+			{ID: "s3", DependsOn: []string{"s2"}},
+		},
+	}
+	p := newTestPlanner()
+	plan, err := p.Plan(context.Background(), wf)
+	require.NoError(t, err)
+
+	assert.Equal(t, "linear", plan.WorkflowID)
+	require.Len(t, plan.Stages, 3)
+	assert.Len(t, plan.Stages[0], 1)
+	assert.Equal(t, "s1", plan.Stages[0][0].ID)
+	assert.Equal(t, "s2", plan.Stages[1][0].ID)
+	assert.Equal(t, "s3", plan.Stages[2][0].ID)
+}
+
+func TestPlan_DiamondDependency(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "diamond_deps.yaml"))
+	require.NoError(t, err)
+
+	plan, err := p.Plan(context.Background(), wf)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Stages, 3)
+	assert.Len(t, plan.Stages[0], 1) // start
+	assert.Len(t, plan.Stages[1], 2) // left, right (parallel)
+	assert.Len(t, plan.Stages[2], 1) // merge
+}
+
+func TestPlan_FullyParallel(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "parallel_steps.yaml"))
+	require.NoError(t, err)
+
+	plan, err := p.Plan(context.Background(), wf)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Stages, 1)
+	assert.Len(t, plan.Stages[0], 3) // all parallel
+}
+
+func TestPlan_SingleStep(t *testing.T) {
+	wf := &Workflow{
+		ID:    "single",
+		Steps: []Step{{ID: "only"}},
+	}
+	p := newTestPlanner()
+	plan, err := p.Plan(context.Background(), wf)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Stages, 1)
+	assert.Len(t, plan.Stages[0], 1)
+	assert.Equal(t, "only", plan.Stages[0][0].ID)
+}
+
+func TestPlan_DefensiveNodeCount(t *testing.T) {
+	// Give Plan a cyclic workflow without calling ValidateDAG first.
+	wf := &Workflow{
+		ID: "cyclic",
+		Steps: []Step{
+			{ID: "aa", DependsOn: []string{"bb"}},
+			{ID: "bb", DependsOn: []string{"aa"}},
+		},
+	}
+	p := newTestPlanner()
+	_, err := p.Plan(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "possible cycle")
+}
+
+// --- Pipeline integration test ---
+
+func TestPipeline_FeatureBuilder(t *testing.T) {
+	p := newTestPlanner()
+	ctx := context.Background()
+
+	wf, err := p.Parse(ctx, filepath.Join("testdata", "valid_workflow.yaml"))
+	require.NoError(t, err)
+
+	err = p.ValidateDAG(ctx, wf)
+	require.NoError(t, err)
+
+	plan, err := p.Plan(ctx, wf)
+	require.NoError(t, err)
+
+	require.Len(t, plan.Stages, 4)
+	assert.Equal(t, "plan", plan.Stages[0][0].ID)
+	assert.Equal(t, "implement", plan.Stages[1][0].ID)
+	assert.Equal(t, "review", plan.Stages[2][0].ID)
+	assert.Equal(t, "revise", plan.Stages[3][0].ID)
+}
+
+// --- Regex and format tests ---
+
+func TestStepIDRegex_ValidIDs(t *testing.T) {
+	valid := []string{"a", "s1", "plan", "code-review", "step_1", "a1b2c3"}
+	for _, id := range valid {
+		assert.True(t, stepIDRegex.MatchString(id), "expected valid: %q", id)
+	}
+}
+
+func TestStepIDRegex_InvalidIDs(t *testing.T) {
+	invalid := []string{"", "-start", "end-", "Step1", "has space", "has.dot", "a{b}", "a/b"}
+	for _, id := range invalid {
+		assert.False(t, stepIDRegex.MatchString(id), "expected invalid: %q", id)
+	}
+}
+
+func TestWorkflowIDRegex_ValidIDs(t *testing.T) {
+	valid := []string{"ab", "feature-builder", "v01", "a1b2"}
+	for _, id := range valid {
+		assert.True(t, workflowIDRegex.MatchString(id), "expected valid: %q", id)
+	}
+}
+
+func TestWorkflowIDRegex_InvalidIDs(t *testing.T) {
+	invalid := []string{"", "a", "-start", "end-", "A-B", "has space"}
+	for _, id := range invalid {
+		assert.False(t, workflowIDRegex.MatchString(id), "expected invalid: %q", id)
+	}
+}
+
+// --- Helper ---
+
+func writeTempYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	err := os.WriteFile(path, []byte(content), 0o644)
+	require.NoError(t, err)
+	return path
+}

--- a/internal/planner/testdata/cycle_complex.yaml
+++ b/internal/planner/testdata/cycle_complex.yaml
@@ -1,0 +1,26 @@
+schema_version: "0.1"
+
+workflow:
+  id: "cycle-complex"
+  name: "Complex Cycle"
+  trigger: "manual"
+
+  steps:
+    - id: "aa"
+      agent: "planner"
+      input: "start"
+
+    - id: "bb"
+      agent: "planner"
+      input: "middle"
+      depends_on: ["aa"]
+
+    - id: "cc"
+      agent: "planner"
+      input: "loop back"
+      depends_on: ["bb", "aa"]
+
+    - id: "aa2"
+      agent: "planner"
+      input: "depends on cycle"
+      depends_on: ["cc", "bb"]

--- a/internal/planner/testdata/cycle_simple.yaml
+++ b/internal/planner/testdata/cycle_simple.yaml
@@ -1,0 +1,17 @@
+schema_version: "0.1"
+
+workflow:
+  id: "cycle-simple"
+  name: "Simple Cycle"
+  trigger: "manual"
+
+  steps:
+    - id: "aa"
+      agent: "planner"
+      input: "start"
+      depends_on: ["bb"]
+
+    - id: "bb"
+      agent: "planner"
+      input: "loop"
+      depends_on: ["aa"]

--- a/internal/planner/testdata/diamond_deps.yaml
+++ b/internal/planner/testdata/diamond_deps.yaml
@@ -1,0 +1,26 @@
+schema_version: "0.1"
+
+workflow:
+  id: "diamond-flow"
+  name: "Diamond Dependency"
+  trigger: "manual"
+
+  steps:
+    - id: "start"
+      agent: "planner"
+      input: "begin"
+
+    - id: "left"
+      agent: "worker-a"
+      input: "left path"
+      depends_on: ["start"]
+
+    - id: "right"
+      agent: "worker-b"
+      input: "right path"
+      depends_on: ["start"]
+
+    - id: "merge"
+      agent: "planner"
+      input: "merge results"
+      depends_on: ["left", "right"]

--- a/internal/planner/testdata/parallel_steps.yaml
+++ b/internal/planner/testdata/parallel_steps.yaml
@@ -1,0 +1,19 @@
+schema_version: "0.1"
+
+workflow:
+  id: "parallel-work"
+  name: "Parallel Workflow"
+  trigger: "manual"
+
+  steps:
+    - id: "task-a"
+      agent: "worker-a"
+      input: "do A"
+
+    - id: "task-b"
+      agent: "worker-b"
+      input: "do B"
+
+    - id: "task-c"
+      agent: "worker-c"
+      input: "do C"

--- a/internal/planner/testdata/self_reference.yaml
+++ b/internal/planner/testdata/self_reference.yaml
@@ -1,0 +1,12 @@
+schema_version: "0.1"
+
+workflow:
+  id: "self-ref"
+  name: "Self Reference"
+  trigger: "manual"
+
+  steps:
+    - id: "loop"
+      agent: "planner"
+      input: "infinite"
+      depends_on: ["loop"]

--- a/internal/planner/testdata/single_step.yaml
+++ b/internal/planner/testdata/single_step.yaml
@@ -1,0 +1,11 @@
+schema_version: "0.1"
+
+workflow:
+  id: "single-step"
+  name: "Single Step Workflow"
+  trigger: "manual"
+
+  steps:
+    - id: "do"
+      agent: "planner"
+      input: "hello"

--- a/internal/planner/testdata/valid_workflow.yaml
+++ b/internal/planner/testdata/valid_workflow.yaml
@@ -1,0 +1,32 @@
+# Valid workflow matching feature-builder.yaml structure
+schema_version: "0.1"
+
+workflow:
+  id: "feature-builder"
+  name: "Build a Feature End-to-End"
+  trigger: "manual"
+
+  steps:
+    - id: "plan"
+      agent: "planner"
+      input: "{{ user_request }}"
+      output_key: "plan"
+
+    - id: "implement"
+      agent: "code-writer"
+      input: "{{ steps.plan.output }}"
+      output_key: "code"
+      depends_on: ["plan"]
+
+    - id: "review"
+      agent: "code-reviewer"
+      input: "{{ steps.implement.output }}"
+      output_key: "review"
+      depends_on: ["implement"]
+
+    - id: "revise"
+      agent: "code-writer"
+      input: "{{ steps.implement.output }}\nFeedback: {{ steps.review.output }}"
+      output_key: "final_code"
+      depends_on: ["review"]
+      condition: "{{ steps.review.output.approved == false }}"


### PR DESCRIPTION
## Summary

Implements Phase 3a of [RFC 0001 - Core Orchestration Pipeline](docs/rfcs/0001-core-orchestration-pipeline.md) per the [PR implementation plan](docs/rfcs/0001-pr-plan.md).

This is **PR 3a of 5** — the YAML planner (Parse, ValidateDAG, Plan) that produces topologically sorted execution plans from workflow YAML files.

## Changes

### `internal/planner/planner.go`
- **`WorkflowFile` wrapper struct** — unmarshals top-level `schema_version` + `workflow` from YAML
- **`YAMLPlanner` struct** with `NewYAMLPlanner(logger)` constructor (nil-logger guard)
- **`Parse`** — reads YAML file with full validation:
  - `filepath.Clean` path normalization (defense-in-depth)
  - `io.LimitReader` with 1 MB + 1 byte overflow detection
  - 2-pass YAML decode: `yaml.Node` tree walk rejects anchors/aliases, then decode to struct
  - Schema version enforcement (`"0.1"` only)
  - Required fields: workflow `id`, `name`, step `id`/`agent`/`input`
  - Format validation: workflow ID, agent ID, step ID, output_key (all via regex)
  - Duplicate step ID and duplicate output_key detection
  - `depends_on` referential integrity (references must point to existing step IDs)
  - Unknown YAML keys silently ignored (forward compatibility)
- **`ValidateDAG`** — DFS-based cycle detection with descriptive error (cycle path printed)
- **`Plan`** — Kahn's algorithm producing `ExecutionPlan` with parallel stages, defensive node-count check
- **`stepIDPattern` const** — shared between Parse validation regex and future `ResolveInputs` template capture group (PR 3b)
- Preserved TODO stubs for ResolveInputs (PR 3b) and condition evaluation

### `internal/planner/planner_test.go` (new)
35 tests covering:
- **Parse**: valid fixture, single step, missing required fields (id, name, agent, input), empty steps, invalid workflow/agent/step IDs (subtests), duplicate step IDs, unknown schema versions (0.2, empty, 1.0), invalid output_key format, duplicate output_key, invalid depends_on reference, file not found, file too large (>1 MB), anchor/alias rejection, path cleaning (../), nil logger
- **ValidateDAG**: no cycle, simple cycle (A→B→A), complex DAG (no cycle), 3-node cycle (A→B→C→A), self-reference, all parallel (no deps)
- **Plan**: linear chain, diamond dependency, fully parallel, single step, defensive node-count check (cyclic input without ValidateDAG)
- **Pipeline**: Parse → ValidateDAG → Plan on feature-builder fixture (4 stages)
- **Regex**: step ID valid/invalid, workflow ID valid/invalid

### `internal/planner/testdata/` (new)
7 YAML fixtures: valid_workflow, single_step, parallel_steps, diamond_deps, cycle_simple, cycle_complex, self_reference

### `go.mod`
- Promoted `gopkg.in/yaml.v3` from indirect to direct

### `.gitignore`
- Added `orchestrator.exe` (`go build` artifact)

## Test Results

```
go test ./internal/planner/... -v -cover
PASS
coverage: 97.7% of statements
35/35 tests passed
```

## PR Checklist

- [x] `go test ./internal/planner/... -v -cover` passes (35/35, 97.7%)
- [x] Coverage ≥ 80% (achieved: 97.7%)
- [x] `go vet ./internal/planner/...` clean
- [x] `go build ./cmd/orchestrator` succeeds
- [x] `stepIDPattern` defined as single const
- [x] Fixtures in `internal/planner/testdata/`
- [x] Nil-logger guard in `NewYAMLPlanner`
- [x] Branch: `feature/v01-planner-yaml`
- [x] Squash-merge ready

## Size Note

PR is 1,071 lines (305 implementation + 624 tests + 143 testdata YAML). Same waiver rationale as PRs #6 and #7 — single-package, high test coverage, testdata YAML fixtures inflate line count.

## Related

- RFC: [0001-core-orchestration-pipeline.md](docs/rfcs/0001-core-orchestration-pipeline.md)
- PR Plan: [0001-pr-plan.md](docs/rfcs/0001-pr-plan.md)
- PR 1: #6 (InMemoryStateStore)
- PR 2: #7 (InMemoryRegistry)
- Next: PR 3b (`feature/v01-planner-resolve` — ResolveInputs)
