### PR TITLE
feat(planner): implement ResolveInputs template resolution (RFC 0001, PR 4/5)

### DIFF
--- a/docs/rfcs/0001-pr-plan.md
+++ b/docs/rfcs/0001-pr-plan.md
@@ -231,10 +231,46 @@ Actionable follow-ups for **PR 3b** or subsequent PRs:
 
 #### PR checklist
 
-- [ ] `go test ./internal/planner/... -v -race -cover` passes
-- [ ] Coverage ≥ 80%
-- [ ] `stepIDPattern` reused from PR 3a (no duplication)
-- [ ] Total PR ≤ 500 lines
+- [x] `go test ./internal/planner/... -v -cover` passes (62/62, 98.8% coverage)
+- [x] Coverage ≥ 80% (achieved: 98.8%)
+- [x] `stepIDPattern` reused from PR 3a (no duplication)
+- [x] Total PR: 500 lines (at limit)
+- [x] `go vet ./internal/planner/...` clean
+- [x] `go build ./cmd/orchestrator` succeeds
+- [x] All internal tests pass (state 98.4%, registry 100%, planner 98.8%)
+
+> **Note**: `-race` requires CGO (unavailable on Windows dev environment). CI (Linux) validates with `-race`.
+
+#### Post-merge review findings (PR #9)
+
+PR #9 was submitted as ~480 lines (79 `planner.go` new + 339 `resolve_test.go` + 62 carry-forward tests in `planner_test.go`), within the 500-line limit. Full review: [`docs/pr-reviews/pr-009-deep-review.md`](../../docs/pr-reviews/pr-009-deep-review.md).
+
+All 4 carry-forward items from PR #8 were addressed:
+
+| PR #8 Finding | Status |
+|--------------|--------|
+| F-01: Regex divergence comment | ✅ Resolved — comment at `planner.go` L27–31 |
+| F-02: Unused testdata fixtures | ✅ Resolved — 3 fixture-based tests + `cycle_complex.yaml` fixed |
+| F-05: Self-dependency check | ✅ Resolved — check in `validate()` + `TestParse_SelfDependency` |
+| F-08: Malformed YAML test | ✅ Resolved — `TestParse_MalformedYAML` added |
+
+Post-review fix commit addressed F-01 through F-04 from PR #9 review:
+
+| Finding | Severity | Action | Disposition |
+|---------|----------|--------|-------------|
+| F-01: godoc capture group numbering off by one | Low | Resolved naturally by F-03 non-capturing group change | ✅ Fixed |
+| F-02: Dead `matchedRanges` allocation and unused `warnSuspicious` parameter | Low | Removed allocation, removed unused `_ [][2]int` parameter | ✅ Fixed |
+| F-03: `stepIDPattern` capturing group inflates `templateRegex` to 4 groups | Medium | Changed to non-capturing `(?:...)` — reduces to 3 capture groups, eliminates unused group | ✅ Fixed |
+| F-04: Test case name "no spaces" misleading | Low | Renamed to "hyphen in variable name" — passthrough is due to hyphen not matching `[a-z_][a-z0-9_]*` | ✅ Fixed |
+
+Actionable follow-ups for **PR 5 (wiring)** or later:
+
+| Finding | Severity | Action | Disposition |
+|---------|----------|--------|-------------|
+| F-01: No nil-logger guard in `ResolveInputs` | Medium | Add `if logger == nil { logger = zap.NewNop() }` guard + test (inconsistent with `NewYAMLPlanner`, `NewInMemoryStore`, `NewInMemoryRegistry`) | Address in PR 5 |
+| F-02: Step ID missing from resolve error messages | Low | Add `step.ID` to error format strings for executor-level debugging | Address in PR 5 or defer |
+| F-03: No test for adjacent templates (`{{ a }}{{ b }}`) | Low | Add test to verify `lastEnd` index tracking with zero-length literal segments | Address in PR 5 or defer |
+| F-04: No test for empty-string substitution value | Low | Add test for `outputs[k] = ""` resolving cleanly | Address in PR 5 or defer |
 
 ---
 
@@ -306,5 +342,6 @@ Each PR must pass the full CI pipeline (`.github/workflows/ci.yml`):
 | PR 2 review findings need follow-up | Medium: no agent ID validation (F-01, defer to RFC 0002). Low: `cap` builtin shadow (F-02), nil/empty slice inconsistency (F-03), no `AgentStatus.String()` (F-05). Tracked in PR plan. |
 | PR 3a (planner) exceeds 500 lines | **Resolved**: PR #8 submitted at 1,071 lines; size waiver accepted (single-package, 97.7% coverage, 143 lines testdata YAML). See [review](../../docs/pr-reviews/pr-008-planner-yaml-review.md). |
 | PR 3a review findings need follow-up | Medium: unused testdata fixtures (F-02, address in PR 3b), regex comment (F-01, PR 3b). Low: self-dep check (F-05), malformed YAML test (F-08). Tracked in PR plan. |
+| PR 3b review findings need follow-up | Medium: nil-logger guard in `ResolveInputs` (F-01, address in PR 5). Low: step ID in error messages (F-02), adjacent template test (F-03), empty substitution test (F-04). Tracked in PR plan. |
 | `UpdateRunStatus` has no timestamp management | Design gap documented for RFC 0003 — Scheduler will need `UpdateRun`/`PatchRun` or expanded `UpdateRunStatus` signature |
 | `-race` flag requires CGO on Windows | CI (Linux) runs `-race`; local Windows testing uses `-cover` only. Concurrency correctness verified via code inspection and CI. |

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -18,7 +18,8 @@ import (
 
 // stepIDPattern is the canonical step ID format pattern, shared between
 // Parse validation and ResolveInputs template capture group.
-const stepIDPattern = `[a-z0-9]([a-z0-9_-]*[a-z0-9])?`
+// Uses non-capturing (?:...) to avoid creating an extra capture group in templateRegex.
+const stepIDPattern = `[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?`
 
 // maxYAMLSize is the maximum allowed YAML file size (1 MB).
 const maxYAMLSize = 1 << 20
@@ -346,7 +347,8 @@ func (p *YAMLPlanner) Plan(_ context.Context, workflow *Workflow) (*ExecutionPla
 
 // templateRegex matches {{ steps.<id>.output }} and {{ variable }} patterns.
 // Group 2 captures the step ID for output references; group 3 captures plain variable names.
-// The step ID sub-pattern reuses stepIDPattern to stay consistent with Parse validation.
+// The step ID sub-pattern reuses stepIDPattern (with non-capturing group) to stay
+// consistent with Parse validation without introducing extra capture groups.
 var templateRegex = regexp.MustCompile(
 	`\{\{\s*(steps\.(` + stepIDPattern + `)\.output|([a-z_][a-z0-9_]*))\s*\}\}`,
 )
@@ -367,7 +369,7 @@ func ResolveInputs(step Step, outputs map[string]string, vars map[string]string,
 	matches := templateRegex.FindAllStringSubmatchIndex(input, -1)
 	if len(matches) == 0 {
 		// No templates found — check for suspicious patterns before returning.
-		warnSuspicious(input, nil, logger)
+		warnSuspicious(input, logger)
 		return input, nil
 	}
 
@@ -375,16 +377,11 @@ func ResolveInputs(step Step, outputs map[string]string, vars map[string]string,
 	b.Grow(len(input))
 	lastEnd := 0
 
-	// Track matched ranges for suspicious-pattern detection.
-	matchedRanges := make([][2]int, 0, len(matches))
-
 	for _, loc := range matches {
 		// loc indices: [0]=full match start, [1]=full match end,
 		// [2]=group1 start, [3]=group1 end (full inner match),
 		// [4]=group2 start, [5]=group2 end (step ID — may be -1),
-		// [6]=group3 start, [7]=group3 end (step ID inner group — may be -1),
-		// [8]=group4 start, [9]=group4 end (variable name — may be -1).
-		matchedRanges = append(matchedRanges, [2]int{loc[0], loc[1]})
+		// [6]=group3 start, [7]=group3 end (variable name — may be -1).
 
 		// Write literal text before this match.
 		b.WriteString(input[lastEnd:loc[0]])
@@ -397,9 +394,9 @@ func ResolveInputs(step Step, outputs map[string]string, vars map[string]string,
 				return "", fmt.Errorf("unresolved step output reference: steps.%s.output (step %q not in outputs map)", stepID, stepID)
 			}
 			b.WriteString(val)
-		} else if loc[8] >= 0 {
-			// {{ variable }} — group 4 is the variable name.
-			varName := input[loc[8]:loc[9]]
+		} else if loc[6] >= 0 {
+			// {{ variable }} — group 3 is the variable name.
+			varName := input[loc[6]:loc[7]]
 			val, ok := vars[varName]
 			if !ok {
 				return "", fmt.Errorf("unresolved variable reference: %s (not in vars map)", varName)
@@ -416,18 +413,17 @@ func ResolveInputs(step Step, outputs map[string]string, vars map[string]string,
 	result := b.String()
 
 	// Warn about suspicious patterns that were not matched.
-	warnSuspicious(result, matchedRanges, logger)
+	warnSuspicious(result, logger)
 
 	return result, nil
 }
 
 // warnSuspicious emits logger.Warn for {{ ... }} patterns in text that were not
-// matched by templateRegex. The skipRanges parameter (relative to the original
-// input, before substitution) is unused here — we scan the final result string
-// for any remaining {{ ... }} occurrences since substituted values are not
-// re-scanned (single-pass guarantee means any {{ }} in the result is either
-// from unmatched original patterns or from substituted output values).
-func warnSuspicious(text string, _ [][2]int, logger *zap.Logger) {
+// matched by templateRegex. It scans the final result string for any remaining
+// {{ ... }} occurrences since substituted values are not re-scanned (single-pass
+// guarantee means any {{ }} in the result is either from unmatched original
+// patterns or from substituted output values).
+func warnSuspicious(text string, logger *zap.Logger) {
 	for _, loc := range suspiciousRegex.FindAllStringIndex(text, -1) {
 		logger.Warn("suspicious unresolved template pattern in step input",
 			zap.String("pattern", text[loc[0]:loc[1]]),

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -23,6 +23,11 @@ const stepIDPattern = `[a-z0-9]([a-z0-9_-]*[a-z0-9])?`
 // maxYAMLSize is the maximum allowed YAML file size (1 MB).
 const maxYAMLSize = 1 << 20
 
+// workflowIDRegex and agentIDRegex require minimum 2 characters and no underscores
+// (matching the agent ID convention: ^[a-z0-9][a-z0-9-]*[a-z0-9]$).
+// stepIDRegex intentionally allows underscores and single-character IDs (e.g. "a",
+// "step_1") because step IDs are workflow-internal identifiers, not externally
+// visible names. The patterns are kept separate for clearer error messages.
 var (
 	workflowIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 	agentIDRegex    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
@@ -191,9 +196,12 @@ func (p *YAMLPlanner) validate(wf *WorkflowFile) error {
 		}
 	}
 
-	// Validate depends_on references point to existing step IDs.
+	// Validate depends_on references point to existing step IDs and are not self-referential.
 	for _, step := range w.Steps {
 		for _, dep := range step.DependsOn {
+			if dep == step.ID {
+				return fmt.Errorf("step %q: depends_on references itself", step.ID)
+			}
 			if !stepIDs[dep] {
 				return fmt.Errorf("step %q: depends_on references nonexistent step %q", step.ID, dep)
 			}
@@ -336,5 +344,95 @@ func (p *YAMLPlanner) Plan(_ context.Context, workflow *Workflow) (*ExecutionPla
 	}, nil
 }
 
-// TODO: Implement template variable resolution ({{ steps.X.output }}) — PR 3b
+// templateRegex matches {{ steps.<id>.output }} and {{ variable }} patterns.
+// Group 2 captures the step ID for output references; group 3 captures plain variable names.
+// The step ID sub-pattern reuses stepIDPattern to stay consistent with Parse validation.
+var templateRegex = regexp.MustCompile(
+	`\{\{\s*(steps\.(` + stepIDPattern + `)\.output|([a-z_][a-z0-9_]*))\s*\}\}`,
+)
+
+// suspiciousRegex matches anything that looks like {{ ... }} but was not matched
+// by templateRegex. Used to emit warnings for potential typos in workflow YAML.
+var suspiciousRegex = regexp.MustCompile(`\{\{.*?\}\}`)
+
+// ResolveInputs substitutes template variables in step.Input with actual values.
+// It resolves {{ steps.<id>.output }} from the outputs map and {{ variable }}
+// from the vars map. Returns the resolved input string or an error if any
+// referenced step ID or variable is missing. Resolution is single-pass —
+// substituted values are not re-scanned for template patterns.
+func ResolveInputs(step Step, outputs map[string]string, vars map[string]string, logger *zap.Logger) (string, error) {
+	input := step.Input
+
+	// Find all template matches and their positions for single-pass replacement.
+	matches := templateRegex.FindAllStringSubmatchIndex(input, -1)
+	if len(matches) == 0 {
+		// No templates found — check for suspicious patterns before returning.
+		warnSuspicious(input, nil, logger)
+		return input, nil
+	}
+
+	var b strings.Builder
+	b.Grow(len(input))
+	lastEnd := 0
+
+	// Track matched ranges for suspicious-pattern detection.
+	matchedRanges := make([][2]int, 0, len(matches))
+
+	for _, loc := range matches {
+		// loc indices: [0]=full match start, [1]=full match end,
+		// [2]=group1 start, [3]=group1 end (full inner match),
+		// [4]=group2 start, [5]=group2 end (step ID — may be -1),
+		// [6]=group3 start, [7]=group3 end (step ID inner group — may be -1),
+		// [8]=group4 start, [9]=group4 end (variable name — may be -1).
+		matchedRanges = append(matchedRanges, [2]int{loc[0], loc[1]})
+
+		// Write literal text before this match.
+		b.WriteString(input[lastEnd:loc[0]])
+
+		if loc[4] >= 0 {
+			// steps.<id>.output — group 2 is the step ID.
+			stepID := input[loc[4]:loc[5]]
+			val, ok := outputs[stepID]
+			if !ok {
+				return "", fmt.Errorf("unresolved step output reference: steps.%s.output (step %q not in outputs map)", stepID, stepID)
+			}
+			b.WriteString(val)
+		} else if loc[8] >= 0 {
+			// {{ variable }} — group 4 is the variable name.
+			varName := input[loc[8]:loc[9]]
+			val, ok := vars[varName]
+			if !ok {
+				return "", fmt.Errorf("unresolved variable reference: %s (not in vars map)", varName)
+			}
+			b.WriteString(val)
+		}
+
+		lastEnd = loc[1]
+	}
+
+	// Write trailing literal text.
+	b.WriteString(input[lastEnd:])
+
+	result := b.String()
+
+	// Warn about suspicious patterns that were not matched.
+	warnSuspicious(result, matchedRanges, logger)
+
+	return result, nil
+}
+
+// warnSuspicious emits logger.Warn for {{ ... }} patterns in text that were not
+// matched by templateRegex. The skipRanges parameter (relative to the original
+// input, before substitution) is unused here — we scan the final result string
+// for any remaining {{ ... }} occurrences since substituted values are not
+// re-scanned (single-pass guarantee means any {{ }} in the result is either
+// from unmatched original patterns or from substituted output values).
+func warnSuspicious(text string, _ [][2]int, logger *zap.Logger) {
+	for _, loc := range suspiciousRegex.FindAllStringIndex(text, -1) {
+		logger.Warn("suspicious unresolved template pattern in step input",
+			zap.String("pattern", text[loc[0]:loc[1]]),
+		)
+	}
+}
+
 // TODO: Implement condition evaluation

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -482,6 +482,76 @@ func TestValidateDAG_NoDeps(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// --- Fixture-based ValidateDAG tests (PR 3a F-02) ---
+
+func TestValidateDAG_FixtureCycleSimple(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "cycle_simple.yaml"))
+	require.NoError(t, err)
+
+	err = p.ValidateDAG(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestValidateDAG_FixtureCycleComplex(t *testing.T) {
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), filepath.Join("testdata", "cycle_complex.yaml"))
+	require.NoError(t, err)
+
+	err = p.ValidateDAG(context.Background(), wf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle detected")
+}
+
+func TestValidateDAG_FixtureSelfReference(t *testing.T) {
+	p := newTestPlanner()
+	// self_reference.yaml has depends_on: ["loop"] on step "loop",
+	// which is now caught by validate() as self-dependency.
+	_, err := p.Parse(context.Background(), filepath.Join("testdata", "self_reference.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "depends_on references itself")
+}
+
+// --- Parse: self-dependency check (PR 3a F-05) ---
+
+func TestParse_SelfDependency(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Self dep"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+      depends_on: ["s1"]
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "depends_on references itself")
+}
+
+// --- Parse: malformed YAML syntax (PR 3a F-08) ---
+
+func TestParse_MalformedYAML(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Bad YAML
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+`
+	p := newTestPlanner()
+	_, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unmarshal YAML")
+}
+
 // --- Plan tests ---
 
 func TestPlan_LinearChain(t *testing.T) {

--- a/internal/planner/resolve_test.go
+++ b/internal/planner/resolve_test.go
@@ -1,0 +1,327 @@
+package planner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func nopLogger() *zap.Logger {
+	return zap.NewNop()
+}
+
+func observedLogger() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	return zap.New(core), logs
+}
+
+// --- ResolveInputs: step output references ---
+
+func TestResolveInputs_StepOutput(t *testing.T) {
+	step := Step{ID: "review", Input: "Review this: {{ steps.implement.output }}"}
+	outputs := map[string]string{"implement": "func main() {}"}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "Review this: func main() {}", result)
+}
+
+func TestResolveInputs_MultipleStepOutputs(t *testing.T) {
+	step := Step{
+		ID:    "revise",
+		Input: "{{ steps.implement.output }}\nFeedback: {{ steps.review.output }}",
+	}
+	outputs := map[string]string{
+		"implement": "code here",
+		"review":    "needs changes",
+	}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "code here\nFeedback: needs changes", result)
+}
+
+func TestResolveInputs_MissingStepOutput(t *testing.T) {
+	step := Step{ID: "review", Input: "{{ steps.missing.output }}"}
+
+	_, err := ResolveInputs(step, map[string]string{}, nil, nopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unresolved step output reference")
+	assert.Contains(t, err.Error(), "missing")
+}
+
+// --- ResolveInputs: variable references ---
+
+func TestResolveInputs_Variable(t *testing.T) {
+	step := Step{ID: "plan", Input: "{{ user_request }}"}
+	vars := map[string]string{"user_request": "build a login page"}
+
+	result, err := ResolveInputs(step, nil, vars, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "build a login page", result)
+}
+
+func TestResolveInputs_MissingVariable(t *testing.T) {
+	step := Step{ID: "plan", Input: "{{ missing_var }}"}
+
+	_, err := ResolveInputs(step, nil, map[string]string{}, nopLogger())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unresolved variable reference")
+	assert.Contains(t, err.Error(), "missing_var")
+}
+
+// --- ResolveInputs: mixed references ---
+
+func TestResolveInputs_MixedStepAndVariable(t *testing.T) {
+	step := Step{
+		ID:    "implement",
+		Input: "Request: {{ user_request }}\nPlan: {{ steps.plan.output }}",
+	}
+	outputs := map[string]string{"plan": "step 1, step 2"}
+	vars := map[string]string{"user_request": "build auth"}
+
+	result, err := ResolveInputs(step, outputs, vars, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "Request: build auth\nPlan: step 1, step 2", result)
+}
+
+// --- ResolveInputs: passthrough (no templates) ---
+
+func TestResolveInputs_NoTemplates(t *testing.T) {
+	step := Step{ID: "simple", Input: "just a plain string"}
+
+	result, err := ResolveInputs(step, nil, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "just a plain string", result)
+}
+
+func TestResolveInputs_EmptyInput(t *testing.T) {
+	step := Step{ID: "empty", Input: ""}
+
+	result, err := ResolveInputs(step, nil, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+}
+
+// --- ResolveInputs: single template as entire input ---
+
+func TestResolveInputs_SingleTemplateInput(t *testing.T) {
+	step := Step{ID: "plan", Input: "{{ user_request }}"}
+	vars := map[string]string{"user_request": "hello world"}
+
+	result, err := ResolveInputs(step, nil, vars, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "hello world", result)
+}
+
+// --- ResolveInputs: empty/nil maps ---
+
+func TestResolveInputs_NilMaps(t *testing.T) {
+	step := Step{ID: "simple", Input: "no templates here"}
+
+	result, err := ResolveInputs(step, nil, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "no templates here", result)
+}
+
+func TestResolveInputs_EmptyMaps(t *testing.T) {
+	step := Step{ID: "simple", Input: "no templates here"}
+
+	result, err := ResolveInputs(step, map[string]string{}, map[string]string{}, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "no templates here", result)
+}
+
+// --- ResolveInputs: extra unused outputs ---
+
+func TestResolveInputs_ExtraUnusedOutputs(t *testing.T) {
+	step := Step{ID: "review", Input: "{{ steps.plan.output }}"}
+	outputs := map[string]string{
+		"plan":      "the plan",
+		"implement": "unused code",
+		"review":    "unused review",
+	}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "the plan", result)
+}
+
+// --- ResolveInputs: malformed patterns passthrough ---
+
+func TestResolveInputs_MalformedPatternsPassthrough(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty braces", "{{ }}"},
+		{"incomplete step ref", "{{ steps. }}"},
+		{"no spaces", "{{no-spaces}}"},
+		{"expression in condition", "{{ steps.review.output.approved == false }}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := Step{ID: "test", Input: tt.input}
+			result, err := ResolveInputs(step, map[string]string{}, map[string]string{}, nopLogger())
+			require.NoError(t, err)
+			assert.Equal(t, tt.input, result, "malformed pattern should pass through unchanged")
+		})
+	}
+}
+
+// --- ResolveInputs: single-pass (no re-scan) ---
+
+func TestResolveInputs_SinglePassNoRescan(t *testing.T) {
+	// Output value itself contains a template pattern — must NOT be re-resolved.
+	step := Step{ID: "next", Input: "{{ steps.prev.output }}"}
+	outputs := map[string]string{"prev": "{{ user_request }}"}
+	vars := map[string]string{"user_request": "should not appear"}
+
+	result, err := ResolveInputs(step, outputs, vars, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "{{ user_request }}", result, "substituted values must not be re-scanned")
+}
+
+// --- ResolveInputs: suspicious pattern warning ---
+
+func TestResolveInputs_SuspiciousPatternWarning(t *testing.T) {
+	logger, logs := observedLogger()
+
+	step := Step{ID: "test", Input: "{{ steps.review.output.approved == false }}"}
+	result, err := ResolveInputs(step, map[string]string{}, map[string]string{}, logger)
+	require.NoError(t, err)
+	assert.Equal(t, step.Input, result)
+
+	require.Equal(t, 1, logs.Len(), "expected exactly one warning")
+	entry := logs.All()[0]
+	assert.Equal(t, zapcore.WarnLevel, entry.Level)
+	assert.Contains(t, entry.Message, "suspicious")
+}
+
+func TestResolveInputs_NoWarningForValidTemplates(t *testing.T) {
+	logger, logs := observedLogger()
+
+	step := Step{ID: "review", Input: "{{ steps.plan.output }}"}
+	outputs := map[string]string{"plan": "the plan"}
+
+	_, err := ResolveInputs(step, outputs, nil, logger)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, logs.Len(), "valid templates should not produce warnings")
+}
+
+func TestResolveInputs_WarningFromSubstitutedValue(t *testing.T) {
+	// A substituted value containing {{ }} should trigger a warning
+	// (it passes through un-resolved since we don't re-scan).
+	logger, logs := observedLogger()
+
+	step := Step{ID: "next", Input: "{{ steps.prev.output }}"}
+	outputs := map[string]string{"prev": "value with {{ suspicious }}"}
+
+	result, err := ResolveInputs(step, outputs, nil, logger)
+	require.NoError(t, err)
+	assert.Equal(t, "value with {{ suspicious }}", result)
+
+	// The suspicious {{ suspicious }} in the result triggers a warning.
+	require.Equal(t, 1, logs.Len())
+	assert.Contains(t, logs.All()[0].Message, "suspicious")
+}
+
+// --- ResolveInputs: multi-line block scalar ---
+
+func TestResolveInputs_MultiLineInput(t *testing.T) {
+	step := Step{
+		ID:    "revise",
+		Input: "Code:\n{{ steps.implement.output }}\n\nReview:\n{{ steps.review.output }}",
+	}
+	outputs := map[string]string{
+		"implement": "func main() {\n\tfmt.Println(\"hello\")\n}",
+		"review":    "LGTM\nApproved",
+	}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	expected := "Code:\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n\nReview:\nLGTM\nApproved"
+	assert.Equal(t, expected, result)
+}
+
+// --- ResolveInputs: whitespace variations ---
+
+func TestResolveInputs_WhitespaceVariations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"extra spaces", "{{  user_request  }}", "hello"},
+		{"tabs", "{{\tuser_request\t}}", "hello"},
+		{"mixed whitespace", "{{  \t user_request  \t }}", "hello"},
+		{"single space", "{{ user_request }}", "hello"},
+	}
+
+	vars := map[string]string{"user_request": "hello"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			step := Step{ID: "test", Input: tt.input}
+			result, err := ResolveInputs(step, nil, vars, nopLogger())
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// --- ResolveInputs: step ID edge cases ---
+
+func TestResolveInputs_StepIDWithUnderscoresAndHyphens(t *testing.T) {
+	step := Step{ID: "test", Input: "{{ steps.my-step_01.output }}"}
+	outputs := map[string]string{"my-step_01": "result"}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "result", result)
+}
+
+func TestResolveInputs_SingleCharStepID(t *testing.T) {
+	step := Step{ID: "test", Input: "{{ steps.a.output }}"}
+	outputs := map[string]string{"a": "result"}
+
+	result, err := ResolveInputs(step, outputs, nil, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "result", result)
+}
+
+// --- ResolveInputs: variable name edge cases ---
+
+func TestResolveInputs_VariableWithUnderscore(t *testing.T) {
+	step := Step{ID: "test", Input: "{{ _private }}"}
+	vars := map[string]string{"_private": "secret"}
+
+	result, err := ResolveInputs(step, nil, vars, nopLogger())
+	require.NoError(t, err)
+	assert.Equal(t, "secret", result)
+}
+
+// --- templateRegex reuses stepIDPattern ---
+
+func TestTemplateRegex_UsesStepIDPattern(t *testing.T) {
+	// Verify that the template regex accepts the same step ID formats as stepIDRegex.
+	validIDs := []string{"a", "ab", "a-b", "a_b", "step-01", "my_step_2"}
+	for _, id := range validIDs {
+		assert.Regexp(t, stepIDRegex, id, "stepIDRegex should match %q", id)
+		input := "{{ steps." + id + ".output }}"
+		assert.Regexp(t, templateRegex, input, "templateRegex should match %q", input)
+	}
+
+	// Invalid step IDs should fail both.
+	invalidIDs := []string{"-bad", "bad-", "_bad", "bad_", "BAD", "has space"}
+	for _, id := range invalidIDs {
+		assert.NotRegexp(t, stepIDRegex, id, "stepIDRegex should NOT match %q", id)
+		input := "{{ steps." + id + ".output }}"
+		assert.NotRegexp(t, templateRegex, input, "templateRegex should NOT match %q", input)
+	}
+}

--- a/internal/planner/resolve_test.go
+++ b/internal/planner/resolve_test.go
@@ -160,7 +160,7 @@ func TestResolveInputs_MalformedPatternsPassthrough(t *testing.T) {
 	}{
 		{"empty braces", "{{ }}"},
 		{"incomplete step ref", "{{ steps. }}"},
-		{"no spaces", "{{no-spaces}}"},
+		{"hyphen in variable name", "{{no-spaces}}"},
 		{"expression in condition", "{{ steps.review.output.approved == false }}"},
 	}
 

--- a/internal/planner/testdata/cycle_complex.yaml
+++ b/internal/planner/testdata/cycle_complex.yaml
@@ -9,6 +9,7 @@ workflow:
     - id: "aa"
       agent: "planner"
       input: "start"
+      depends_on: ["cc"]
 
     - id: "bb"
       agent: "planner"
@@ -18,9 +19,9 @@ workflow:
     - id: "cc"
       agent: "planner"
       input: "loop back"
-      depends_on: ["bb", "aa"]
+      depends_on: ["bb"]
 
-    - id: "aa2"
+    - id: "dd"
       agent: "planner"
       input: "depends on cycle"
       depends_on: ["cc", "bb"]


### PR DESCRIPTION
## Summary

Implements Phase 3b of [RFC 0001 - Core Orchestration Pipeline](docs/rfcs/0001-core-orchestration-pipeline.md) per the [PR implementation plan](docs/rfcs/0001-pr-plan.md).

This is **PR 4 of 5** — the template variable resolution function that the Scheduler/Executor will call at runtime.

## Changes

### `internal/planner/planner.go`
- **`ResolveInputs`** package-level function — substitutes `{{ steps.<id>.output }}` and `{{ variable }}` patterns in `Step.Input`
- **`templateRegex`** — combined regex `\{\{\s*(steps\.(<stepIDPattern>)\.output|([a-z_][a-z0-9_]*))\s*\}\}` reusing `stepIDPattern` const
- **`suspiciousRegex`** — detects remaining `{{ ... }}` patterns for warning logs
- **`warnSuspicious`** helper — emits `logger.Warn` for unresolved template-like patterns
- Single-pass replacement (substituted values are NOT re-scanned for templates)
- Fail-fast on missing step outputs or variables (returns error)
- Malformed patterns (empty braces, condition expressions, no-space delimiters) pass through unchanged

### PR 3a carry-forward items addressed
- **F-01**: Added clarifying comment above regex block explaining intentional divergence between `stepIDRegex` (allows underscores, single-char) and `workflowIDRegex`/`agentIDRegex` (minimum 2 chars, no underscores)
- **F-02**: Added fixture-based `Parse`→`ValidateDAG` pipeline tests for `cycle_simple.yaml`, `cycle_complex.yaml`, `self_reference.yaml`; fixed `cycle_complex.yaml` to actually contain a cycle (was acyclic)
- **F-05**: Added self-dependency check in `validate()` — `depends_on` referencing own step ID now returns clear error before reaching `ValidateDAG`
- **F-08**: Added malformed YAML syntax test for `unmarshal YAML` error path

### `internal/planner/resolve_test.go` (new)
27 tests covering:
- Step output resolution (single, multiple, missing)
- Variable resolution (single, missing)
- Mixed step output + variable in same input
- Passthrough (no templates, empty input)
- Single template as entire input
- Nil maps, empty maps
- Extra unused outputs (succeed without error)
- Malformed patterns passthrough (empty braces, incomplete refs, no spaces, condition expressions)
- Single-pass verification (output containing `{{ }}` is not re-scanned)
- Suspicious pattern warning log verification (observed logger)
- No warning for valid templates
- Warning from substituted value containing `{{ }}`
- Multi-line input with embedded newlines
- Whitespace variations (extra spaces, tabs, mixed)
- Step ID edge cases (underscores, hyphens, single-char)
- Variable name edge case (leading underscore)
- `templateRegex` consistency with `stepIDRegex` (valid + invalid ID cross-check)

### `internal/planner/planner_test.go` (modified)
7 new tests:
- 3 fixture-based ValidateDAG tests (F-02)
- Self-dependency parse test (F-05)
- Malformed YAML parse test (F-08)

### `internal/planner/testdata/cycle_complex.yaml` (fixed)
- Changed from acyclic DAG to actual 3-node cycle (aa→bb→cc→aa) with additional node dd

## Test Results

\\\
go test ./internal/planner/... -v -cover
PASS
coverage: 98.8% of statements
62/62 tests passed
\\\

## PR Checklist

- [x] `go test ./internal/planner/... -v -cover` passes (62/62, 98.8%)
- [x] Coverage ≥ 80% (achieved: 98.8%)
- [x] `stepIDPattern` reused from PR 3a (no duplication)
- [x] `go vet ./internal/planner/...` clean
- [x] `go build ./cmd/orchestrator` succeeds
- [x] All internal tests pass (state 98.4%, registry 100%, planner 98.8%)
- [x] Total PR: 500 lines (at limit)
- [x] Branch: `feature/v01-planner-resolve`
- [x] Squash-merge ready

## Related

- RFC: [0001-core-orchestration-pipeline.md](docs/rfcs/0001-core-orchestration-pipeline.md)
- PR Plan: [0001-pr-plan.md](docs/rfcs/0001-pr-plan.md)
- PR 3: #8 (YAMLPlanner Parse+DAG+Plan)
- Next: PR 5 (`feature/v01-orchestrator-wiring` — Wire into main.go)