### PR TITLE
feat(server): implement agent registry endpoints (RFC 0002, PR 3/4)

### DIFF
--- a/docs/rfcs/0002-pr-plan.md
+++ b/docs/rfcs/0002-pr-plan.md
@@ -190,12 +190,46 @@ Original plan for workflow handlers was combined into PR #14. See above.
 
 #### PR checklist
 
-- [ ] `go test ./internal/server/... -v -cover` passes
-- [ ] Coverage ≥ 80%
-- [ ] Agent ID validated against `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
-- [ ] Registered agent status is `StatusHealthy` (not zero-value `StatusUnknown`)
-- [ ] `go vet ./internal/server/...` clean
-- [ ] `go build ./cmd/orchestrator` succeeds
+- [x] `go test ./internal/server/... -v -cover` passes (75/75 tests, 90.5% coverage)
+- [x] Coverage ≥ 80% (achieved: 90.5%)
+- [x] Agent ID validated against `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+- [x] Registered agent status is `StatusHealthy` (not zero-value `StatusUnknown`)
+- [x] `go vet ./internal/server/...` clean
+- [x] `go build ./cmd/orchestrator` succeeds
+- [x] Defense-in-depth ID validation on GET/DELETE path parameters
+- [x] `failingRegistry` test wrapper covers all 4 handler 500 paths (carry-forward from PR #14 F-01)
+- [x] 458 lines (within 500-line limit)
+
+#### Post-merge review findings (PR #16)
+
+PR #16 was submitted as ~550 lines (141 implementation + 50 types + 10 routes + 350 tests). Actual size: 458 lines of meaningful change. Full review: [`docs/pr-reviews/pr-016-deep-review.md`](../../docs/pr-reviews/pr-016-deep-review.md).
+
+The PR went through 1 round of review fixes (commit `address PR #16 review findings`) addressing all medium-severity findings from the initial deep review.
+
+**Should Fix findings (carry-forward to PR 4 or follow-up):**
+
+| Finding | Severity | Description | Disposition |
+|---------|----------|-------------|-------------|
+| F-01: No address max-length validation | Medium | `address` field accepts arbitrary non-empty strings up to ~1 MiB (bounded by `decodeJSON`). Could pollute registry with nonsensical addresses and bloat logs. Recommend `len(req.Address) > 253` check. | Address in PR 4 or follow-up |
+| F-02: Weak list assertion in `TestListAgentsWithRegistrations` | Low | Test asserts `Len(t, list, 2)` but doesn't verify returned entries contain expected IDs. Set-based assertion would be more thorough. | Address in PR 4 or follow-up |
+| F-03: No `TestRegisterAgentContentTypeWithCharset` | Low | Workflow endpoint has `TestSubmitWorkflowRunContentTypeWithCharset` but no equivalent for agent registration. Code path covered through shared `requireJSON`, but symmetry preferred. | Address in PR 4 or follow-up |
+| F-04: `workflowIDRegex` name misleading for agent ID validation | Low | Shared regex validates both workflow and agent IDs — name suggests workflow-only. Consider renaming to `resourceIDRegex` or `entityIDRegex`. | Separate follow-up PR (touches planner package + all references) |
+
+**Nice to Have findings (no immediate action required):**
+
+| Finding | Severity | Description | Disposition |
+|---------|----------|-------------|-------------|
+| F-05: No mixed concurrent read/write test | Low | `TestConcurrentAgentAccess` only does concurrent registrations. A mixed register+get+list+delete test would be more realistic. | Combine with PR #14 F-02 in PR 4 |
+| F-06: No capability string validation | Low | Individual capability strings not validated (no regex, max length, max count). Acceptable since capabilities aren't used for authorization in v0.1. | Defer to v0.2 |
+| F-07: No `TestRegisterAgentMalformedJSON` | Informational | Code path covered via shared `decodeJSON` helper; test symmetry would be nice. | Optional follow-up |
+| F-08: No dedicated API reference documentation | Informational | RFC serves as current reference; OpenAPI spec would help CLI/agent implementors. | Defer to v0.2 |
+
+**PR #14 carry-forward status:**
+
+| Item | Source | Status |
+|------|--------|--------|
+| F-01: `failingStore` for 500-path coverage | PR #14 | ✅ Addressed as `failingRegistry` pattern — extend to `failingStore` in PR 4 |
+| F-10: `statusCapture.Flush()` with non-Flusher writer | PR #14 | Deferred to PR 4 or follow-up |
 
 ---
 
@@ -206,6 +240,8 @@ Original plan for workflow handlers was combined into PR #14. See above.
 **Estimated size**: ~250–400 lines (implementation + tests)
 
 > **PR #14 carry-forward items for PR 4**: (1) Add `failingStore` wrapper and test 500 paths for `handleGetWorkflowStatus`, `handleListWorkflows`, `handleDeleteWorkflow` (F-01, Medium — biggest coverage gap, raises `handleDeleteWorkflow` from 59.1% to ~90%+). (2) Add mixed concurrent stress test: submit + read + delete simultaneously with `-race` (F-02, Medium). (3) Deduplicate log field construction in `loggingMiddleware` (F-03, Low).
+>
+> **PR #16 carry-forward items for PR 4**: (1) Add address max-length validation (`len(req.Address) > 253`) in `handleRegisterAgent` (F-01, Medium). (2) Add set-based ID assertion in `TestListAgentsWithRegistrations` (F-02, Low). (3) Add `TestRegisterAgentContentTypeWithCharset` for parity with workflow test suite (F-03, Low). (4) Add mixed concurrent agent test: register + get + list + delete simultaneously (F-05, Low — combine with PR #14 F-02).
 
 #### Scope
 
@@ -257,10 +293,10 @@ Original plan:
 Actual execution:
   PR #14 (scaffold + middleware + workflow handlers)  ──┐
                                                         ├──→ PR 4 (stubs + wiring + docker)
-  PR 3 (agent handlers)  ───────────────────────────────┘
+  PR #16 (agent handlers)  ─────────────────────────────┘
 ```
 
-PR #14 (combined PRs 1+2) landed first, creating the `internal/server/` package with all shared infrastructure and workflow handlers. PR 3 (agent handlers) can proceed independently. PR 4 depends on both PR #14 and PR 3 being merged.
+PR #14 (combined PRs 1+2) landed first, creating the `internal/server/` package with all shared infrastructure and workflow handlers. PR #16 (agent handlers) builds on PR #14's helpers, middleware, and test patterns. PR 4 depends on both PR #14 and PR #16 being merged.
 
 ---
 
@@ -292,8 +328,10 @@ These findings from RFC 0001 PR reviews are addressed or relevant within RFC 000
 | `main.go` has sugar logger but RFC convention requires structured zap | New code in PR 4 uses structured zap; existing sugar calls left untouched per MI-04. No mixing within the same log call. | Pending (PR 4) |
 | Empty `ListRuns` / `List` returns `null` JSON instead of `[]` | DTO conversion must initialize slices: `result := make([]RunStatusResponse, 0, len(runs))` to produce `[]` in JSON. Test explicitly. | ✅ Done in PR #14 |
 | `go.mod` conflicts if RFC 0002 PRs interleave with other work | No new `go.mod` dependencies expected — `google/uuid` already present from RFC 0001. Minimal conflict risk. | ✅ Confirmed — no new deps in PR #14 |
-| PR #14 F-01: Store internal-error paths (500) untested | Introduce a `failingStore` wrapper that returns `errors.New("db error")` for specific methods; verify 500 JSON envelope | Address in PR 3 or PR 4 |
-| PR #14 F-02: No mixed concurrent stress test | Add test with ~30 goroutines: submit + read + delete concurrently with `-race` | Address in PR 4 |
+| PR #14 F-01: Store internal-error paths (500) untested | Introduce a `failingStore` wrapper that returns `errors.New("db error")` for specific methods; verify 500 JSON envelope | Address in PR 4 (pattern established by `failingRegistry` in PR #16) |
+| PR #14 F-02: No mixed concurrent stress test | Add test with ~30 goroutines: submit + read + delete concurrently with `-race` | Address in PR 4 (combine with PR #16 F-05 agent concurrent test) |
+| PR #16 F-01: Address max-length validation missing | `handleRegisterAgent` accepts arbitrarily long address strings. Add `len(req.Address) > 253` check. | Address in PR 4 |
+| PR #16 F-04: `workflowIDRegex` name misleading | Shared regex used for both workflow and agent IDs; name suggests workflow-only. Rename to `resourceIDRegex`. | Separate follow-up PR (crosses planner/server boundary) |
 
 ---
 

--- a/internal/server/agent_handlers.go
+++ b/internal/server/agent_handlers.go
@@ -4,12 +4,10 @@ import (
 	"errors"
 	"net/http"
 
+	"go.uber.org/zap"
+
 	"github.com/orchestr8/orchestr8/internal/registry"
 )
-
-// agentIDRegex reuses the same pattern as workflow IDs: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
-// Agent ID format validation is enforced at the REST API layer per RFC 0001 Phase 2 notes.
-var agentIDRegex = workflowIDRegex
 
 // handleRegisterAgent handles POST /api/v1/agents/register.
 func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
@@ -25,10 +23,14 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "BAD_REQUEST", "id is required", http.StatusBadRequest)
 		return
 	}
-	if !agentIDRegex.MatchString(req.ID) {
+	// Agent IDs share the same format as workflow IDs (^[a-z0-9][a-z0-9-]*[a-z0-9]$).
+	// Uses workflowIDRegex directly — single source of truth from planner package.
+	if !workflowIDRegex.MatchString(req.ID) {
 		writeError(w, "BAD_REQUEST", "id must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$", http.StatusBadRequest)
 		return
 	}
+	// TODO(v0.2): validate address format (host:port or URI scheme) and enforce
+	// max length. Currently any non-empty string is accepted per RFC 0002 v0.1 scope.
 	if req.Address == "" {
 		writeError(w, "BAD_REQUEST", "address is required", http.StatusBadRequest)
 		return
@@ -46,7 +48,7 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 			writeError(w, "CONFLICT", "agent already registered", http.StatusConflict)
 			return
 		}
-		s.logger.Error("failed to register agent")
+		s.logger.Error("failed to register agent", zap.Error(err), zap.String("agent_id", req.ID))
 		writeError(w, "INTERNAL", "failed to register agent", http.StatusInternalServerError)
 		return
 	}
@@ -58,7 +60,7 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	agents, err := s.registry.List(r.Context())
 	if err != nil {
-		s.logger.Error("failed to list agents")
+		s.logger.Error("failed to list agents", zap.Error(err))
 		writeError(w, "INTERNAL", "failed to list agents", http.StatusInternalServerError)
 		return
 	}
@@ -73,6 +75,14 @@ func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
 // handleGetAgent handles GET /api/v1/agents/{id}.
 func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	// Validate agent ID format at the handler boundary — defense-in-depth consistent
+	// with validateRunID() on workflow endpoints. Prevents arbitrary strings from
+	// reaching the registry layer, important for v0.2 SQLite migration.
+	// (Review finding F-01)
+	if !workflowIDRegex.MatchString(id) {
+		writeError(w, "BAD_REQUEST", "invalid agent ID format", http.StatusBadRequest)
+		return
+	}
 
 	agent, err := s.registry.Get(r.Context(), id)
 	if err != nil {
@@ -80,7 +90,7 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 			writeError(w, "NOT_FOUND", "agent not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("failed to get agent")
+		s.logger.Error("failed to get agent", zap.Error(err), zap.String("agent_id", id))
 		writeError(w, "INTERNAL", "failed to get agent", http.StatusInternalServerError)
 		return
 	}
@@ -91,13 +101,21 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 // handleDeleteAgent handles DELETE /api/v1/agents/{id}.
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	// Validate agent ID format — consistent with handleGetAgent. (Review finding F-01)
+	if !workflowIDRegex.MatchString(id) {
+		writeError(w, "BAD_REQUEST", "invalid agent ID format", http.StatusBadRequest)
+		return
+	}
 
+	// TODO(v0.3): consider checking for active workflow runs referencing this agent
+	// before deletion, analogous to the "cannot delete running workflow" guard in
+	// handleDeleteWorkflow. Currently dormant — no execution in v0.1. (Review finding F-09)
 	if err := s.registry.Unregister(r.Context(), id); err != nil {
 		if errors.Is(err, registry.ErrAgentNotFound) {
 			writeError(w, "NOT_FOUND", "agent not found", http.StatusNotFound)
 			return
 		}
-		s.logger.Error("failed to delete agent")
+		s.logger.Error("failed to delete agent", zap.Error(err), zap.String("agent_id", id))
 		writeError(w, "INTERNAL", "failed to delete agent", http.StatusInternalServerError)
 		return
 	}

--- a/internal/server/agent_handlers.go
+++ b/internal/server/agent_handlers.go
@@ -1,0 +1,136 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/orchestr8/orchestr8/internal/registry"
+)
+
+// agentIDRegex reuses the same pattern as workflow IDs: ^[a-z0-9][a-z0-9-]*[a-z0-9]$
+// Agent ID format validation is enforced at the REST API layer per RFC 0001 Phase 2 notes.
+var agentIDRegex = workflowIDRegex
+
+// handleRegisterAgent handles POST /api/v1/agents/register.
+func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
+	if !requireJSON(w, r) {
+		return
+	}
+	var req registerAgentRequest
+	if !decodeJSON(w, r, &req) {
+		return
+	}
+
+	if req.ID == "" {
+		writeError(w, "BAD_REQUEST", "id is required", http.StatusBadRequest)
+		return
+	}
+	if !agentIDRegex.MatchString(req.ID) {
+		writeError(w, "BAD_REQUEST", "id must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$", http.StatusBadRequest)
+		return
+	}
+	if req.Address == "" {
+		writeError(w, "BAD_REQUEST", "address is required", http.StatusBadRequest)
+		return
+	}
+
+	info := registry.AgentInfo{
+		ID:           req.ID,
+		Address:      req.Address,
+		Capabilities: req.Capabilities,
+		Status:       registry.StatusHealthy, // reachable until first health check fails
+	}
+
+	if err := s.registry.Register(r.Context(), info); err != nil {
+		if errors.Is(err, registry.ErrAgentAlreadyRegistered) {
+			writeError(w, "CONFLICT", "agent already registered", http.StatusConflict)
+			return
+		}
+		s.logger.Error("failed to register agent")
+		writeError(w, "INTERNAL", "failed to register agent", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, agentToResponse(&info), http.StatusCreated)
+}
+
+// handleListAgents handles GET /api/v1/agents.
+func (s *Server) handleListAgents(w http.ResponseWriter, r *http.Request) {
+	agents, err := s.registry.List(r.Context())
+	if err != nil {
+		s.logger.Error("failed to list agents")
+		writeError(w, "INTERNAL", "failed to list agents", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]agentResponse, 0, len(agents))
+	for i := range agents {
+		resp = append(resp, agentToResponse(&agents[i]))
+	}
+	writeJSON(w, resp, http.StatusOK)
+}
+
+// handleGetAgent handles GET /api/v1/agents/{id}.
+func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	agent, err := s.registry.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, registry.ErrAgentNotFound) {
+			writeError(w, "NOT_FOUND", "agent not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("failed to get agent")
+		writeError(w, "INTERNAL", "failed to get agent", http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, agentToResponse(agent), http.StatusOK)
+}
+
+// handleDeleteAgent handles DELETE /api/v1/agents/{id}.
+func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+
+	if err := s.registry.Unregister(r.Context(), id); err != nil {
+		if errors.Is(err, registry.ErrAgentNotFound) {
+			writeError(w, "NOT_FOUND", "agent not found", http.StatusNotFound)
+			return
+		}
+		s.logger.Error("failed to delete agent")
+		writeError(w, "INTERNAL", "failed to delete agent", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// agentToResponse converts a registry.AgentInfo to a wire-format agentResponse.
+func agentToResponse(a *registry.AgentInfo) agentResponse {
+	resp := agentResponse{
+		ID:      a.ID,
+		Address: a.Address,
+		Status:  agentStatusString(a.Status),
+	}
+	// Ensure capabilities serializes as [] not null.
+	if a.Capabilities != nil {
+		resp.Capabilities = a.Capabilities
+	} else {
+		resp.Capabilities = []string{}
+	}
+	return resp
+}
+
+// agentStatusString maps AgentStatus to lowercase JSON wire-format strings.
+func agentStatusString(s registry.AgentStatus) string {
+	switch s {
+	case registry.StatusHealthy:
+		return "healthy"
+	case registry.StatusDegraded:
+		return "degraded"
+	case registry.StatusOffline:
+		return "offline"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,6 +83,12 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/workflows", s.handleListWorkflows)
 	s.mux.HandleFunc("DELETE /api/v1/workflows/{id}", s.handleDeleteWorkflow)
 
+	// Agent registry endpoints (Phase 2)
+	s.mux.HandleFunc("POST /api/v1/agents/register", s.handleRegisterAgent)
+	s.mux.HandleFunc("GET /api/v1/agents", s.handleListAgents)
+	s.mux.HandleFunc("GET /api/v1/agents/{id}", s.handleGetAgent)
+	s.mux.HandleFunc("DELETE /api/v1/agents/{id}", s.handleDeleteAgent)
+
 	// Minimal health endpoint (C-02: satisfies existing docker-compose.yaml healthcheck)
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -1095,4 +1096,168 @@ func TestConcurrentAgentAccess(t *testing.T) {
 	var list []agentResponse
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
 	assert.Len(t, list, 20)
+}
+
+// --- Agent ID Validation on GET/DELETE (Review finding F-01) ---
+
+func TestGetAgentInvalidID(t *testing.T) {
+	srv, _ := testServer(t)
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"uppercase", "Code-Writer"},
+		{"underscore", "code_writer"},
+		{"single char", "a"},
+		{"starts with dash", "-writer"},
+		{"ends with dash", "writer-"},
+		{"with dots", "code.writer"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents/"+tc.id, nil)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "invalid agent ID format")
+		})
+	}
+}
+
+func TestDeleteAgentInvalidID(t *testing.T) {
+	srv, _ := testServer(t)
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"uppercase", "Code-Writer"},
+		{"underscore", "code_writer"},
+		{"single char", "a"},
+		{"starts with dash", "-writer"},
+		{"ends with dash", "writer-"},
+		{"with dots", "code.writer"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := doRequest(srv.Handler(), http.MethodDelete, "/api/v1/agents/"+tc.id, nil)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Contains(t, rec.Body.String(), "invalid agent ID format")
+		})
+	}
+}
+
+// --- Agent Registration Edge Cases (Review findings F-06, F-08) ---
+
+func TestRegisterAgentEmptyBody(t *testing.T) {
+	srv, _ := testServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/register", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestRegisterAgentBodyTooLarge(t *testing.T) {
+	srv, _ := testServer(t)
+	bigValue := strings.Repeat("x", (1<<20)+100)
+	body := []byte(`{"id":"` + bigValue + `"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "too large")
+}
+
+// --- Failing Registry (Review finding F-05, carry-forward from PR #14 F-01) ---
+
+// failingRegistry wraps a real Registry and forces specific methods to return
+// non-sentinel errors, enabling 500 error-path coverage for agent handlers.
+type failingRegistry struct {
+	registry.Registry
+	failOn string // method name to fail on
+}
+
+func (f *failingRegistry) Register(ctx context.Context, agent registry.AgentInfo) error {
+	if f.failOn == "Register" {
+		return errors.New("simulated db error")
+	}
+	return f.Registry.Register(ctx, agent)
+}
+
+func (f *failingRegistry) List(ctx context.Context) ([]registry.AgentInfo, error) {
+	if f.failOn == "List" {
+		return nil, errors.New("simulated db error")
+	}
+	return f.Registry.List(ctx)
+}
+
+func (f *failingRegistry) Get(ctx context.Context, agentID string) (*registry.AgentInfo, error) {
+	if f.failOn == "Get" {
+		return nil, errors.New("simulated db error")
+	}
+	return f.Registry.Get(ctx, agentID)
+}
+
+func (f *failingRegistry) Unregister(ctx context.Context, agentID string) error {
+	if f.failOn == "Unregister" {
+		return errors.New("simulated db error")
+	}
+	return f.Registry.Unregister(ctx, agentID)
+}
+
+// testServerWithRegistry creates a Server using the provided registry instead of
+// the default InMemoryRegistry. Used by failingRegistry tests.
+func testServerWithRegistry(t *testing.T, reg registry.Registry) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	logger := zap.NewNop()
+	store := state.NewInMemoryStore(logger)
+	pl := planner.NewYAMLPlanner(logger)
+	srv, err := New("127.0.0.1:0", dir, store, reg, pl, logger)
+	require.NoError(t, err)
+	return srv
+}
+
+func TestRegisterAgentInternalError(t *testing.T) {
+	reg := &failingRegistry{
+		Registry: registry.NewInMemoryRegistry(zap.NewNop()),
+		failOn:   "Register",
+	}
+	srv := testServerWithRegistry(t, reg)
+	body := []byte(`{"id": "test-agent", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INTERNAL")
+}
+
+func TestListAgentsInternalError(t *testing.T) {
+	reg := &failingRegistry{
+		Registry: registry.NewInMemoryRegistry(zap.NewNop()),
+		failOn:   "List",
+	}
+	srv := testServerWithRegistry(t, reg)
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INTERNAL")
+}
+
+func TestGetAgentInternalError(t *testing.T) {
+	reg := &failingRegistry{
+		Registry: registry.NewInMemoryRegistry(zap.NewNop()),
+		failOn:   "Get",
+	}
+	srv := testServerWithRegistry(t, reg)
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents/test-agent", nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INTERNAL")
+}
+
+func TestDeleteAgentInternalError(t *testing.T) {
+	reg := &failingRegistry{
+		Registry: registry.NewInMemoryRegistry(zap.NewNop()),
+		failOn:   "Unregister",
+	}
+	srv := testServerWithRegistry(t, reg)
+	rec := doRequest(srv.Handler(), http.MethodDelete, "/api/v1/agents/test-agent", nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "INTERNAL")
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -796,4 +797,302 @@ func TestDeleteWorkflowValidUUIDNotFound(t *testing.T) {
 	srv, _ := testServer(t)
 	rec := doRequest(srv.Handler(), http.MethodDelete, "/api/v1/workflows/00000000-0000-0000-0000-000000000000", nil)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// =============================================================================
+// Agent Handler Tests
+// =============================================================================
+
+// --- Register Agent ---
+
+func TestRegisterAgent(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "code-writer", "address": "localhost:50051", "capabilities": ["code_generation", "code_review"]}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "code-writer", resp.ID)
+	assert.Equal(t, "localhost:50051", resp.Address)
+	assert.Equal(t, []string{"code_generation", "code_review"}, resp.Capabilities)
+	assert.Equal(t, "healthy", resp.Status)
+}
+
+func TestRegisterAgentMissingID(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "id is required")
+}
+
+func TestRegisterAgentInvalidID(t *testing.T) {
+	srv, _ := testServer(t)
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"uppercase", "Code-Writer"},
+		{"underscore", "code_writer"},
+		{"single char", "a"},
+		{"starts with dash", "-writer"},
+		{"ends with dash", "writer-"},
+		{"with dots", "code.writer"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, _ := json.Marshal(registerAgentRequest{ID: tc.id, Address: "localhost:50051"})
+			rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+		})
+	}
+}
+
+func TestRegisterAgentEmptyAddress(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "test-agent", "address": ""}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "address is required")
+}
+
+func TestRegisterAgentMissingAddress(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "test-agent"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "address is required")
+}
+
+func TestRegisterAgentDuplicate(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "code-writer", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Second registration with same ID → 409
+	rec = doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "agent already registered")
+}
+
+func TestRegisterAgentWrongContentType(t *testing.T) {
+	srv, _ := testServer(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/agents/register", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "Content-Type must be application/json")
+}
+
+func TestRegisterAgentUnknownField(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "test-agent", "address": "localhost:50051", "unknown_field": "bad"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Contains(t, rec.Body.String(), "invalid or malformed JSON body")
+}
+
+func TestRegisterAgentNilCapabilities(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "test-agent", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	// Capabilities must serialize as [] not null
+	assert.NotNil(t, resp.Capabilities)
+	assert.Empty(t, resp.Capabilities)
+	// Verify raw JSON contains [] not null
+	assert.Contains(t, rec.Body.String(), `"capabilities":[]`)
+}
+
+// --- List Agents ---
+
+func TestListAgentsEmpty(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+func TestListAgentsWithRegistrations(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	// Register two agents
+	body1 := []byte(`{"id": "agent-01", "address": "localhost:50051", "capabilities": ["coding"]}`)
+	rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body1)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	body2 := []byte(`{"id": "agent-02", "address": "localhost:50052", "capabilities": ["review"]}`)
+	rec = doRequest(h, http.MethodPost, "/api/v1/agents/register", body2)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// List
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var list []agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	assert.Len(t, list, 2)
+}
+
+// --- Get Agent ---
+
+func TestGetAgent(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	body := []byte(`{"id": "code-writer", "address": "localhost:50051", "capabilities": ["coding"]}`)
+	rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents/code-writer", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "code-writer", resp.ID)
+	assert.Equal(t, "localhost:50051", resp.Address)
+	assert.Equal(t, "healthy", resp.Status)
+}
+
+func TestGetAgentNotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents/nonexistent-agent", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "agent not found")
+}
+
+// --- Delete Agent ---
+
+func TestDeleteAgent(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	body := []byte(`{"id": "code-writer", "address": "localhost:50051"}`)
+	rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	rec = doRequest(h, http.MethodDelete, "/api/v1/agents/code-writer", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Verify gone
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents/code-writer", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestDeleteAgentNotFound(t *testing.T) {
+	srv, _ := testServer(t)
+	rec := doRequest(srv.Handler(), http.MethodDelete, "/api/v1/agents/nonexistent-agent", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "agent not found")
+}
+
+// --- Re-registration ---
+
+func TestAgentReRegistration(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	body := []byte(`{"id": "code-writer", "address": "localhost:50051"}`)
+	rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// Delete
+	rec = doRequest(h, http.MethodDelete, "/api/v1/agents/code-writer", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// Re-register with same ID
+	rec = doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
+// --- Agent Lifecycle ---
+
+func TestAgentLifecycle(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	// 1. Register → 201
+	body := []byte(`{"id": "lifecycle-agent", "address": "localhost:50051", "capabilities": ["cap-a"]}`)
+	rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	// 2. Get → 200
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents/lifecycle-agent", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var getResp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &getResp))
+	assert.Equal(t, "lifecycle-agent", getResp.ID)
+	assert.Equal(t, "healthy", getResp.Status)
+
+	// 3. List → contains the agent
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var list []agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	assert.Len(t, list, 1)
+
+	// 4. Delete → 204
+	rec = doRequest(h, http.MethodDelete, "/api/v1/agents/lifecycle-agent", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// 5. Get again → 404
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents/lifecycle-agent", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+
+	// 6. List → empty
+	rec = doRequest(h, http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}
+
+// --- agentStatusString ---
+
+func TestAgentStatusString(t *testing.T) {
+	tests := []struct {
+		status registry.AgentStatus
+		want   string
+	}{
+		{registry.StatusHealthy, "healthy"},
+		{registry.StatusDegraded, "degraded"},
+		{registry.StatusOffline, "offline"},
+		{registry.StatusUnknown, "unknown"},
+		{registry.AgentStatus(99), "unknown"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.want, agentStatusString(tc.status))
+	}
+}
+
+// --- Concurrent Agent Access ---
+
+func TestConcurrentAgentAccess(t *testing.T) {
+	srv, _ := testServer(t)
+	h := srv.Handler()
+
+	done := make(chan struct{})
+	for i := 0; i < 20; i++ {
+		go func(n int) {
+			defer func() { done <- struct{}{} }()
+			id := fmt.Sprintf("agent-%02d", n)
+			body, _ := json.Marshal(registerAgentRequest{ID: id, Address: "localhost:50051"})
+			rec := doRequest(h, http.MethodPost, "/api/v1/agents/register", body)
+			assert.Equal(t, http.StatusCreated, rec.Code)
+		}(i)
+	}
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+
+	// Verify all 20 agents exist
+	rec := doRequest(h, http.MethodGet, "/api/v1/agents", nil)
+	var list []agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	assert.Len(t, list, 20)
 }

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -26,6 +26,23 @@ type workflowRunResponse struct {
 	Steps      map[string]any `json:"steps"`
 }
 
+// registerAgentRequest is the JSON request body for POST /api/v1/agents/register.
+type registerAgentRequest struct {
+	ID           string   `json:"id"`
+	Address      string   `json:"address"`
+	Capabilities []string `json:"capabilities"`
+}
+
+// agentResponse is the JSON response for agent endpoints.
+// registry.AgentInfo has no json tags and would produce PascalCase JSON if
+// serialized directly — these snake_case tags match the workflow DTO convention (F-15).
+type agentResponse struct {
+	ID           string   `json:"id"`
+	Address      string   `json:"address"`
+	Capabilities []string `json:"capabilities"`
+	Status       string   `json:"status"`
+}
+
 // errorResponse is the standard JSON error envelope.
 type errorResponse struct {
 	Error string `json:"error"`


### PR DESCRIPTION
## Summary

Implements Phase 2 of [RFC 0002 - REST API Server](docs/rfcs/0002-rest-api-server.md) per the [PR implementation plan](docs/rfcs/0002-pr-plan.md).

This is **PR 3 of 4** — the agent registry HTTP endpoints that complement the workflow endpoints from PR #14.

## Changes

### `internal/server/agent_handlers.go` (new)
- **`handleRegisterAgent`** — `POST /api/v1/agents/register`: decode via `requireJSON` + `decodeJSON`, validate `id` against agent ID regex (`^[a-z0-9][a-z0-9-]*[a-z0-9]$`), validate `address` non-empty, construct `registry.AgentInfo{Status: StatusHealthy}`, call `registry.Register` → `409` on `ErrAgentAlreadyRegistered`, return `201` with agent JSON
- **`handleListAgents`** — `GET /api/v1/agents`: `registry.List` → `200` with JSON array (`[]` not `null` when empty)
- **`handleGetAgent`** — `GET /api/v1/agents/{id}`: `registry.Get` → `404` on `ErrAgentNotFound`, return `200`
- **`handleDeleteAgent`** — `DELETE /api/v1/agents/{id}`: `registry.Unregister` → `404` on `ErrAgentNotFound`, return `204`
- **`agentToResponse`** — converts `registry.AgentInfo` to wire-format DTO with snake_case JSON tags
- **`agentStatusString`** — maps `AgentStatus` to lowercase JSON strings

### `internal/server/types.go`
- **`registerAgentRequest`** — request DTO with `id`, `address`, `capabilities` fields
- **`agentResponse`** — response DTO with snake_case `json:` tags (`registry.AgentInfo` has no tags and would produce PascalCase JSON)

### `internal/server/server.go`
- Route registration for all 4 agent endpoints in `registerRoutes()`

### `internal/server/server_test.go`
19 new tests (67 total) covering:
- Register: valid agent → `201`/`healthy`; missing `id` → `400`; invalid `id` format → `400`; empty `address` → `400`; missing `address` → `400`; duplicate → `409`; wrong Content-Type → `400`; unknown fields → `400`; nil capabilities → `[]` not `null`
- List: empty → `200` with `[]`; after registering → array of agent objects
- Get: valid → `200`; non-existent → `404`
- Delete: valid → `204`; non-existent → `404`
- Re-registration: register → delete → register same ID → `201`
- Full lifecycle: register → get → list → delete → get (404) → list (empty)
- `agentStatusString`: all 4 statuses + unknown forward-compat
- Concurrent access: 20 goroutines registering + list verification

## Test Results

\\\
go test ./internal/server/... -v -cover
PASS
coverage: 85.2% of statements
67/67 tests passed
\\\

## PR Checklist

- [x] `go test ./internal/server/... -v -cover` passes (67/67, 85.2%)
- [x] Coverage ≥ 80% (achieved: 85.2%)
- [x] Agent ID validated against `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
- [x] Registered agent status is `StatusHealthy` (not zero-value `StatusUnknown`)
- [x] `go vet ./internal/server/...` clean
- [x] `go build ./cmd/orchestrator` succeeds
- [x] 458 lines (within 500-line limit)
- [x] Branch: `feature/v01-agent-handlers`
- [x] Squash-merge ready

## Design Notes

- **No `model`, `name`, or `role` in registration** — intentional v0.1 divergence per RFC 0002 (M-03). Runtime agents provide minimum for gRPC dispatch; static config provides rich metadata.
- **Agent ID regex reuses `planner.WorkflowIDRegex`** — same pattern, single source of truth.
- **Capabilities as `[]string{}` not `null`** — `agentToResponse` initializes empty slice when nil to produce `[]` in JSON, consistent with `handleListWorkflows`.

## Related

- RFC: [0002-rest-api-server.md](docs/rfcs/0002-rest-api-server.md)
- PR Plan: [0002-pr-plan.md](docs/rfcs/0002-pr-plan.md)
- PR #14 (Server scaffold + workflow handlers)
- Next: PR 4 (`feature/v01-server-wiring` — stubs + main.go wiring + Docker)