### PR TITLE
fix: address accumulated review findings (RFC 0002, PR 5/5)

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -49,7 +49,11 @@ func main() {
 		logger, err = zap.NewProduction()
 	}
 	if err != nil {
-		panic("failed to initialise logger: " + err.Error())
+		// PR #18 F-01: use fmt+os.Exit instead of panic for consistent startup
+		// error handling — produces a clean single-line message without a
+		// goroutine stack trace, matching the --env validation pattern above.
+		fmt.Fprintln(os.Stderr, "failed to initialise logger: "+err.Error())
+		os.Exit(1)
 	}
 	defer logger.Sync() //nolint:errcheck
 	log := logger.Sugar()

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -34,7 +34,8 @@ func main() {
 	switch *env {
 	case "development", "staging", "production":
 	default:
-		panic("invalid --env value: " + *env + " (must be development|staging|production)")
+		fmt.Fprintln(os.Stderr, "invalid --env value: "+*env+" (must be development|staging|production)")
+		os.Exit(1)
 	}
 
 	// PR review: development logger (DPanic panics, verbose stacktraces) was

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
     # NOTE(review-F02): Docker 'command' replaces Dockerfile CMD entirely.
     # All required flags must be listed here, not just the override.
-    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--port", "9090", "--workflows-dir", "/app/workflows/"]
+    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--port", "9090", "--workflows-dir", "/app/workflows/", "--env", "development"]
     ports:
       - "9090:9090"   # gRPC
       - "8080:8080"   # HTTP REST + SSE

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
     restart: unless-stopped
     # NOTE(review-F02): Docker 'command' replaces Dockerfile CMD entirely.
     # All required flags must be listed here, not just the override.
-    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--workflows-dir", "/app/workflows/"]
+    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--port", "9090", "--workflows-dir", "/app/workflows/"]
     ports:
       - "9090:9090"   # gRPC
       - "8080:8080"   # HTTP REST + SSE
@@ -19,7 +19,6 @@ services:
       - ./workflows:/app/workflows:ro
       - workspace:/workspace
     environment:
-      - ENVIRONMENT=development
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
       - OTEL_SERVICE_NAME=orchestr8-server
     depends_on:

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -24,16 +24,20 @@ const stepIDPattern = `[a-z0-9](?:[a-z0-9_-]*[a-z0-9])?`
 // maxYAMLSize is the maximum allowed YAML file size (1 MB).
 const maxYAMLSize = 1 << 20
 
-// WorkflowIDRegex and agentIDRegex require minimum 2 characters and no underscores
-// (matching the agent ID convention: ^[a-z0-9][a-z0-9-]*[a-z0-9]$).
+// ResourceIDRegex validates external-facing resource identifiers (workflow IDs, agent IDs).
+// Requires minimum 2 characters, lowercase alphanumeric with hyphens, no leading/trailing hyphens.
+// Exported for reuse by the server package (review finding F-04: eliminates regex
+// duplication across security-relevant validation boundaries).
+// Renamed from WorkflowIDRegex (PR #16 F-04) since it validates both workflow and agent IDs.
+//
+// agentIDRegex is kept as a separate compiled pattern for clearer error messages in
+// planner-internal validation, even though the pattern is identical.
+//
 // stepIDRegex intentionally allows underscores and single-character IDs (e.g. "a",
 // "step_1") because step IDs are workflow-internal identifiers, not externally
-// visible names. The patterns are kept separate for clearer error messages.
-//
-// WorkflowIDRegex is exported for reuse by the server package (review finding F-04:
-// eliminates regex duplication across security-relevant validation boundaries).
+// visible names.
 var (
-	WorkflowIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+	ResourceIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 	agentIDRegex    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 	stepIDRegex     = regexp.MustCompile(`^` + stepIDPattern + `$`)
 	outputKeyRegex  = regexp.MustCompile(`^` + stepIDPattern + `$`)
@@ -151,8 +155,8 @@ func (p *YAMLPlanner) validate(wf *WorkflowFile) error {
 	if w.ID == "" {
 		return errors.New("workflow id is required")
 	}
-	if !WorkflowIDRegex.MatchString(w.ID) {
-		return fmt.Errorf("invalid workflow id %q: must match %s", w.ID, WorkflowIDRegex.String())
+	if !ResourceIDRegex.MatchString(w.ID) {
+		return fmt.Errorf("invalid workflow id %q: must match %s", w.ID, ResourceIDRegex.String())
 	}
 
 	if w.Name == "" {

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -38,7 +38,11 @@ const maxYAMLSize = 1 << 20
 // visible names.
 var (
 	ResourceIDRegex = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
-	agentIDRegex    = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+	// PR #18 F-02: share the compiled regex instance since the pattern is
+	// identical. Separate variable names are retained for clearer error
+	// messages in validation call sites; separate compilation is unnecessary
+	// and risks future divergence if one pattern is updated but not the other.
+	agentIDRegex = ResourceIDRegex
 	stepIDRegex     = regexp.MustCompile(`^` + stepIDPattern + `$`)
 	outputKeyRegex  = regexp.MustCompile(`^` + stepIDPattern + `$`)
 )

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -668,17 +668,17 @@ func TestStepIDRegex_InvalidIDs(t *testing.T) {
 	}
 }
 
-func TestWorkflowIDRegex_ValidIDs(t *testing.T) {
+func TestResourceIDRegex_ValidIDs(t *testing.T) {
 	valid := []string{"ab", "feature-builder", "v01", "a1b2"}
 	for _, id := range valid {
-		assert.True(t, WorkflowIDRegex.MatchString(id), "expected valid: %q", id)
+		assert.True(t, ResourceIDRegex.MatchString(id), "expected valid: %q", id)
 	}
 }
 
-func TestWorkflowIDRegex_InvalidIDs(t *testing.T) {
+func TestResourceIDRegex_InvalidIDs(t *testing.T) {
 	invalid := []string{"", "a", "-start", "end-", "A-B", "has space"}
 	for _, id := range invalid {
-		assert.False(t, WorkflowIDRegex.MatchString(id), "expected invalid: %q", id)
+		assert.False(t, ResourceIDRegex.MatchString(id), "expected invalid: %q", id)
 	}
 }
 

--- a/internal/server/agent_handlers.go
+++ b/internal/server/agent_handlers.go
@@ -24,8 +24,8 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Agent IDs share the same format as workflow IDs (^[a-z0-9][a-z0-9-]*[a-z0-9]$).
-	// Uses workflowIDRegex directly — single source of truth from planner package.
-	if !workflowIDRegex.MatchString(req.ID) {
+	// Uses resourceIDRegex directly — single source of truth from planner package.
+	if !resourceIDRegex.MatchString(req.ID) {
 		writeError(w, "BAD_REQUEST", "id must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$", http.StatusBadRequest)
 		return
 	}
@@ -89,7 +89,7 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 	// with validateRunID() on workflow endpoints. Prevents arbitrary strings from
 	// reaching the registry layer, important for v0.2 SQLite migration.
 	// (Review finding F-01)
-	if !workflowIDRegex.MatchString(id) {
+	if !resourceIDRegex.MatchString(id) {
 		writeError(w, "BAD_REQUEST", "invalid agent ID format", http.StatusBadRequest)
 		return
 	}
@@ -112,7 +112,7 @@ func (s *Server) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	// Validate agent ID format — consistent with handleGetAgent. (Review finding F-01)
-	if !workflowIDRegex.MatchString(id) {
+	if !resourceIDRegex.MatchString(id) {
 		writeError(w, "BAD_REQUEST", "invalid agent ID format", http.StatusBadRequest)
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1461,7 +1461,7 @@ func TestMixedConcurrentWorkflowAccess(t *testing.T) {
 	// NOTE(review-F04): goroutines assert status codes to verify correctness,
 	// not just absence of panics/deadlocks. Failures are collected via t.Errorf
 	// which is goroutine-safe.
-	done := make(chan struct{}, 30)
+	done := make(chan struct{}, 35)
 
 	// 10 goroutines submit new runs
 	for i := 0; i < 10; i++ {
@@ -1475,13 +1475,24 @@ func TestMixedConcurrentWorkflowAccess(t *testing.T) {
 		}()
 	}
 
-	// 10 goroutines read existing runs
-	for i := 0; i < 10; i++ {
+	// 5 goroutines read runs not targeted by DELETE (safe — always 200)
+	for i := 5; i < 10; i++ {
 		go func(id string) {
 			defer func() { done <- struct{}{} }()
 			rec := doRequest(h, http.MethodGet, "/api/v1/workflows/"+id+"/status", nil)
 			if rec.Code != http.StatusOK {
 				t.Errorf("concurrent get %s: got %d, want %d", id, rec.Code, http.StatusOK)
+			}
+		}(runIDs[i])
+	}
+
+	// 5 goroutines read runs that may be concurrently deleted (accept 200 or 404)
+	for i := 0; i < 5; i++ {
+		go func(id string) {
+			defer func() { done <- struct{}{} }()
+			rec := doRequest(h, http.MethodGet, "/api/v1/workflows/"+id+"/status", nil)
+			if rec.Code != http.StatusOK && rec.Code != http.StatusNotFound {
+				t.Errorf("concurrent get-or-miss %s: got %d, want 200 or 404", id, rec.Code)
 			}
 		}(runIDs[i])
 	}
@@ -1497,7 +1508,19 @@ func TestMixedConcurrentWorkflowAccess(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 30; i++ {
+	// 5 goroutines delete pre-created runs (PR #17 F-04: exercises TOCTOU delete path)
+	for i := 0; i < 5; i++ {
+		go func(id string) {
+			defer func() { done <- struct{}{} }()
+			rec := doRequest(h, http.MethodDelete, "/api/v1/workflows/"+id, nil)
+			// 204 = deleted, 404 = already deleted by another goroutine — both valid
+			if rec.Code != http.StatusNoContent && rec.Code != http.StatusNotFound {
+				t.Errorf("concurrent delete %s: got %d, want 204 or 404", id, rec.Code)
+			}
+		}(runIDs[i])
+	}
+
+	for i := 0; i < 35; i++ {
 		<-done
 	}
 }
@@ -1516,7 +1539,7 @@ func TestMixedConcurrentAgentAccess(t *testing.T) {
 
 	// NOTE(review-F04): goroutines assert status codes to verify correctness,
 	// not just absence of panics/deadlocks.
-	done := make(chan struct{}, 30)
+	done := make(chan struct{}, 35)
 
 	// 10 goroutines register new agents
 	for i := 0; i < 10; i++ {
@@ -1531,14 +1554,26 @@ func TestMixedConcurrentAgentAccess(t *testing.T) {
 		}(i)
 	}
 
-	// 10 goroutines get existing agents
-	for i := 0; i < 10; i++ {
+	// 5 goroutines get agents not targeted by DELETE (safe — always 200)
+	for i := 5; i < 10; i++ {
 		go func(n int) {
 			defer func() { done <- struct{}{} }()
 			id := fmt.Sprintf("pre-agent-%02d", n)
 			rec := doRequest(h, http.MethodGet, "/api/v1/agents/"+id, nil)
 			if rec.Code != http.StatusOK {
 				t.Errorf("concurrent get %s: got %d, want %d", id, rec.Code, http.StatusOK)
+			}
+		}(i)
+	}
+
+	// 5 goroutines get agents that may be concurrently deleted (accept 200 or 404)
+	for i := 0; i < 5; i++ {
+		go func(n int) {
+			defer func() { done <- struct{}{} }()
+			id := fmt.Sprintf("pre-agent-%02d", n)
+			rec := doRequest(h, http.MethodGet, "/api/v1/agents/"+id, nil)
+			if rec.Code != http.StatusOK && rec.Code != http.StatusNotFound {
+				t.Errorf("concurrent get-or-miss %s: got %d, want 200 or 404", id, rec.Code)
 			}
 		}(i)
 	}
@@ -1554,7 +1589,20 @@ func TestMixedConcurrentAgentAccess(t *testing.T) {
 		}()
 	}
 
-	for i := 0; i < 30; i++ {
+	// 5 goroutines delete pre-registered agents (PR #17 F-04: exercises concurrent unregister)
+	for i := 0; i < 5; i++ {
+		go func(n int) {
+			defer func() { done <- struct{}{} }()
+			id := fmt.Sprintf("pre-agent-%02d", n)
+			rec := doRequest(h, http.MethodDelete, "/api/v1/agents/"+id, nil)
+			// 204 = deleted, 404 = already deleted by another goroutine — both valid
+			if rec.Code != http.StatusNoContent && rec.Code != http.StatusNotFound {
+				t.Errorf("concurrent delete %s: got %d, want 204 or 404", id, rec.Code)
+			}
+		}(i)
+	}
+
+	for i := 0; i < 35; i++ {
 		<-done
 	}
 }

--- a/internal/server/stub_handlers.go
+++ b/internal/server/stub_handlers.go
@@ -4,6 +4,7 @@ import "net/http"
 
 // handleGetLogs handles GET /api/v1/executions/{id}/logs.
 // Deferred to RFC 0003 — the Executor will capture step-level logs.
+// TODO(v0.3): validate execution ID format before querying
 func (s *Server) handleGetLogs(w http.ResponseWriter, _ *http.Request) {
 	writeError(w, "NOT_IMPLEMENTED", "not implemented in v0.1", http.StatusNotImplemented)
 }

--- a/internal/server/workflow_handlers.go
+++ b/internal/server/workflow_handlers.go
@@ -13,10 +13,10 @@ import (
 	"github.com/orchestr8/orchestr8/internal/state"
 )
 
-// workflowIDRegex is imported from the planner package to ensure a single source
-// of truth for the workflow ID validation pattern across security boundaries.
-// (Review finding F-04: eliminates divergence risk between planner and server.)
-var workflowIDRegex = planner.WorkflowIDRegex
+// resourceIDRegex is imported from the planner package to ensure a single source
+// of truth for the resource ID validation pattern across security boundaries.
+// Used for both workflow IDs and agent IDs (renamed from workflowIDRegex per PR #16 F-04).
+var resourceIDRegex = planner.ResourceIDRegex
 
 // Sentinel errors for workflow path resolution.
 var (
@@ -39,7 +39,7 @@ func (s *Server) handleSubmitWorkflowRun(w http.ResponseWriter, r *http.Request)
 		writeError(w, "BAD_REQUEST", "workflow_id is required", http.StatusBadRequest)
 		return
 	}
-	if !workflowIDRegex.MatchString(req.WorkflowID) {
+	if !resourceIDRegex.MatchString(req.WorkflowID) {
 		writeError(w, "BAD_REQUEST", "workflow_id must match ^[a-z0-9][a-z0-9-]*[a-z0-9]$", http.StatusBadRequest)
 		return
 	}
@@ -183,7 +183,7 @@ func (s *Server) handleDeleteWorkflow(w http.ResponseWriter, r *http.Request) {
 // within the workflows directory. Returns ErrWorkflowNotFound for traversal attempts
 // or missing files (no information leakage about path structure).
 func (s *Server) resolveWorkflowPath(workflowID string) (string, error) {
-	if !workflowIDRegex.MatchString(workflowID) {
+	if !resourceIDRegex.MatchString(workflowID) {
 		return "", ErrInvalidWorkflowID
 	}
 


### PR DESCRIPTION
## Summary

Sweeps all outstanding low-severity review findings accumulated across PRs #14, #16, and #17, closing out RFC 0002 implementation.

This is **PR 5 of 5** — the final cleanup PR for [RFC 0002 - REST API Server](docs/rfcs/0002-rest-api-server.md).

## Changes

### `cmd/orchestrator/main.go`
- **`panic()` → clean exit** — Replace `panic()` with `fmt.Fprintln(os.Stderr, msg)` + `os.Exit(1)` for `--env` validation. Produces a clean single-line error instead of a full goroutine stack trace. Logger is not yet initialized at this point, so `logger.Fatal()` is not available. (PR #17 F-01)

### `internal/planner/planner.go`
- **`WorkflowIDRegex` → `ResourceIDRegex`** — The regex `^[a-z0-9][a-z0-9-]*[a-z0-9]$` validates both workflow IDs and agent IDs. The old name was misleading since PR #16 reused it for agent ID validation. Updated comment to explain the rename rationale. (PR #16 F-04)

### `internal/planner/planner_test.go`
- **`TestWorkflowIDRegex_*` → `TestResourceIDRegex_*`** — Test function names updated to match the renamed export.

### `internal/server/workflow_handlers.go`
- **`workflowIDRegex` → `resourceIDRegex`** — Package-level variable and all 3 usage sites renamed to match the planner export rename. Updated comment to note dual-purpose (workflow + agent IDs).

### `internal/server/agent_handlers.go`
- **`workflowIDRegex` → `resourceIDRegex`** — All 3 usage sites updated. Comment updated to reference `resourceIDRegex`.

### `internal/server/server_test.go`
- **DELETE goroutines in `TestMixedConcurrentWorkflowAccess`** — 5 goroutines delete pre-created runs while 10 create and 10 list concurrently. GET goroutines for runs targeted by DELETE accept `200` or `404`. Exercises TOCTOU delete path under concurrency. (PR #17 F-04)
- **DELETE goroutines in `TestMixedConcurrentAgentAccess`** — 5 goroutines unregister pre-registered agents while others register/get/list. Same `204`/`404` acceptance pattern. (PR #17 F-04)

### `docker-compose.yaml`
- **Remove `ENVIRONMENT=development`** — Env var was unused; `main.go` reads `--env` flag only. (PR #17 F-05)
- **Add explicit port flags** — `--http-port 8080` and `--port 9090` in command array so Docker deployment is self-documenting and decoupled from Go flag defaults. (PR #17 F-06)

### `internal/server/stub_handlers.go`
- **Add TODO comment** — `// TODO(v0.3): validate execution ID format before querying` on `handleGetLogs`. (PR #17 F-07)

## Findings Addressed

| Source | Finding | Severity |
|--------|---------|----------|
| PR #17 F-01 | `panic()` for `--env` validation | Medium |
| PR #17 F-04 | Mixed concurrent tests lack DELETE goroutines | Medium |
| PR #16 F-04 | `WorkflowIDRegex` name misleading for agent ID validation | Low |
| PR #17 F-05 | `ENVIRONMENT=development` env var unused | Low |
| PR #17 F-06 | Docker port flags implicit | Low |
| PR #17 F-07 | Stub handlers ignore `{id}` format | Low |
| PR #14 F-10 | `statusCapture.Flush()` non-Flusher test | Low |

> PR #14 F-10 disposition: Deferred — defense-in-depth; `httptest.NewRecorder` implements `Flusher`, and the `Flush()` fallback is a no-op safety net. Not worth a dedicated test.

## Test Results

```
go test ./internal/... -cover
state:    29/29 PASS  coverage: 98.6%
registry: 25/25 PASS  coverage: 100.0%
planner:  63/63 PASS  coverage: 98.8%
server:   90/90 PASS  coverage: 96.7%
```

## PR Checklist

- [x] `go test ./internal/... -cover` passes (207/207 tests)
- [x] `go vet ./...` clean
- [x] `go build ./cmd/orchestrator` succeeds
- [x] `--env invalid` produces clean single-line error (no stack trace)
- [x] Mixed concurrent tests include DELETE goroutines
- [x] `WorkflowIDRegex` → `ResourceIDRegex` rename compiles across all packages
- [x] `docker-compose.yaml` has explicit port flags and no unused env vars
- [x] 87 lines changed (well within 500-line limit)
- [x] Branch: `feature/v01-rfc0002-followup`
- [x] Squash-merge ready

## Related

- RFC: [0002-rest-api-server.md](docs/rfcs/0002-rest-api-server.md)
- PR Plan: [0002-pr-plan.md](docs/rfcs/0002-pr-plan.md)
- PR 1+2: #14 (Server scaffold + workflow handlers)
- PR 3: #16 (Agent handlers)
- PR 4: #17 (Stubs + wiring + Docker)
