### PR TITLE
test(executor): isTransient table-driven tests, retry edge cases, concurrent dispatch

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ This document tracks development progress across all phases. Update it when merg
 |-----|-------|--------|-----|--------|
 | [0001](docs/rfcs/0001-core-orchestration-pipeline.md) | Core Orchestration Pipeline (Planner + State + Registry) | ✅ Implemented | 6 | 6/6 |
 | [0002](docs/rfcs/0002-rest-api-server.md) | REST API Server (HTTP Layer + Workflow Submission) | ✅ Implemented | 4 | 4/4 |
-| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 1/7 |
+| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 3/7 |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server (AgentService Implementation) | 📋 Proposed | 7 | 0/7 |
 
 ### Dependency Chain
@@ -56,7 +56,7 @@ v0.1 Complete ─ end-to-end execution working
 | `internal/planner/` | YAML parsing, DAG validation, topological sort | ✅ Complete (100% coverage) |
 | `internal/server/` | REST API (11 endpoints, middleware, graceful shutdown) | ✅ Complete (86.5% coverage) |
 | `internal/scheduler/` | Workflow scheduling (pick up pending runs, drive stages) | 🔲 TODO stub (RFC 0003) |
-| `internal/executor/` | gRPC task dispatch to agents | � In Progress (RFC 0003) |
+| `internal/executor/` | gRPC task dispatch to agents | ✅ Complete (96.1% coverage) |
 | `internal/generated/` | Protobuf/gRPC generated code | ✅ Complete (generated stubs) |
 | `internal/resilience/` | Circuit breaker, dead letter queue | 🔲 TODO stub (post-v0.1) |
 | `internal/security/` | Permission gates, rate limiting, audit logging | 🔲 TODO stub (v0.2+) |
@@ -168,6 +168,7 @@ v0.1 Complete ─ end-to-end execution working
 | [#17](https://github.com/mkhomutov/Orchestr8/pull/17) | feat(server): stub endpoints + main.go wiring | 0002 (3/4) | 2026-04-09 |
 | [#18](https://github.com/mkhomutov/Orchestr8/pull/18) | fix: review findings follow-up | 0002 (4/4) | 2026-04-10 |
 | [#21](https://github.com/mkhomutov/Orchestr8/pull/21) | feat(generated): protobuf Go code generation | 0003 (1/7) | 2026-04-10 |
+| [#22](https://github.com/mkhomutov/Orchestr8/pull/22) | feat(executor): GRPCExecutor core with retry logic | 0003 (2/7) | 2026-04-10 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -153,6 +153,15 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 - [x] `StatusUnknown` explicitly tested (N-07)
 - [x] Concurrent dispatch race-tested (N-08)
 
+#### Post-merge findings
+
+- **N-12 (Context cancellation mid-dispatch)**: The existing `TestExecuteTask_ContextCancellation` (PR 2a) only covers cancellation during the backoff `select`. If `ctx` is cancelled during `dispatch()`, the gRPC layer returns `codes.Canceled` which `isTransient` classifies as permanent — the error surfaces as `"permanent failure ... Canceled"` rather than `context.Canceled`. A test that cancels mid-dispatch would document this behavior and prevent regressions if `codes.Canceled` is accidentally added to the transient set. **Should fix** in a follow-up. *(Review pr-023, Should Fix #1)*
+- **N-13 (Concurrent retry stress test)**: `TestExecuteTask_ConcurrentDispatch` uses `WithMaxRetries(0)`, so the concurrent timer/select/backoff path is untested under concurrency. A variant where multiple goroutines all encounter transient errors and retry would exercise the backoff path under `-race`. Use `sync/atomic` counter per goroutine to track per-goroutine attempt count. **Should fix** in a follow-up. *(Review pr-023, Should Fix #2)*
+- **N-14 (`isTransient(nil)` documentation test)**: `status.FromError(nil)` returns `(OK, true)`, so `isTransient(nil)` → `false`. While `nil` never reaches `isTransient` in current code, a one-line assertion documents the behavior defensively. Nice to have. *(Review pr-023, Nice to Have #1)*
+- **N-15 (Wrapped non-gRPC error coverage)**: `TestIsTransient_NonGRPCError` only tests a single non-gRPC error string. Adding a wrapped error case (`fmt.Errorf("outer: %w", plainErr)`) would validate that `status.FromError` correctly returns `ok=false` for wrapped non-gRPC chains. Nice to have. *(Review pr-023, Nice to Have #2)*
+- **N-16 (`codes.Internal` rationale comment)**: `codes.Internal` is classified as permanent, but some `Internal` errors can be transient (e.g., gRPC transport layer errors sometimes surface as `Internal`). The classification is defensible but a comment in `isTransient()` in `executor.go` would document the rationale. Nice to have — follow-up cleanup PR. *(Review pr-023, Nice to Have #3)*
+- **N-17 (Backoff timing validation)**: No test validates actual delay ranges. The jitter formula `0.75 + rand.Float64()*0.5` produces `[0.75, 1.25)` — difficult to test without mocking `rand`. Not needed for v0.1. *(Review pr-023, Nice to Have #4)*
+
 ---
 
 ### PR 3a: `feature/v01-scheduler-core` — WorkflowScheduler Core

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -146,12 +146,12 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 
 #### PR checklist
 
-- [ ] `go test ./internal/executor/... -v -cover` passes
-- [ ] Combined coverage (2a + 2b) ≥ 80%
-- [ ] `go vet ./internal/executor/...` clean
-- [ ] No real network connections in tests (bufconn only)
-- [ ] `StatusUnknown` explicitly tested (N-07)
-- [ ] Concurrent dispatch race-tested (N-08)
+- [x] `go test ./internal/executor/... -v -cover` passes
+- [x] Combined coverage (2a + 2b) ≥ 80%
+- [x] `go vet ./internal/executor/...` clean
+- [x] No real network connections in tests (bufconn only)
+- [x] `StatusUnknown` explicitly tested (N-07)
+- [x] Concurrent dispatch race-tested (N-08)
 
 ---
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -520,6 +520,36 @@ func TestExecuteTask_TransientRetrySuccess(t *testing.T) {
 	assert.Equal(t, 3, callCount, "should succeed on 3rd attempt after 2 transient failures")
 }
 
+// TestExecuteTask_TransientThenPermanent verifies that a permanent error mid-retry
+// aborts immediately without further attempts. Covers the !isTransient(err) check
+// inside the retry loop (executor.go ExecuteTask).
+func TestExecuteTask_TransientThenPermanent(t *testing.T) {
+	callCount := 0
+	env := setupTestEnv(t,
+		func(_ context.Context, _ *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.Unavailable, "temporarily unavailable")
+			}
+			// Second attempt returns permanent error — should stop immediately.
+			return nil, status.Error(codes.InvalidArgument, "bad request")
+		},
+		WithMaxRetries(3),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "mixed-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "mixed-agent",
+		Payload: "transient then permanent",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permanent failure")
+	assert.Equal(t, 2, callCount, "should stop after transient (attempt 1) + permanent (attempt 2), no 3rd attempt")
+}
+
 func TestExecuteTask_PermanentFailureNoRetry(t *testing.T) {
 	callCount := 0
 	env := setupTestEnv(t,
@@ -564,6 +594,9 @@ func TestExecuteTask_RetryExhaustion(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "retries exhausted")
 	assert.Contains(t, err.Error(), fmt.Sprintf("%d attempts", maxRetries+1))
+	// Verify the last transient error is preserved in the wrapped error chain,
+	// so callers can inspect the root cause.
+	assert.Contains(t, err.Error(), "Unavailable")
 	assert.Equal(t, maxRetries+1, callCount, "should attempt initial + maxRetries calls")
 }
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -3,7 +3,9 @@ package executor
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -433,4 +435,259 @@ func TestWithTimeout_NegativeClamped(t *testing.T) {
 	exec := NewGRPCExecutor(reg, zap.NewNop(), WithTimeout(-5*time.Second))
 
 	assert.Equal(t, time.Second, exec.timeout)
+}
+
+// --- PR 2b: isTransient table-driven tests, retry edge cases ---
+
+func TestIsTransient_TableDriven(t *testing.T) {
+	tests := []struct {
+		code     codes.Code
+		expected bool
+	}{
+		{codes.OK, false},
+		{codes.Canceled, false},
+		{codes.Unknown, false},
+		{codes.InvalidArgument, false},
+		{codes.DeadlineExceeded, false},
+		{codes.NotFound, false},
+		{codes.AlreadyExists, false},
+		{codes.PermissionDenied, false},
+		{codes.ResourceExhausted, true},
+		{codes.FailedPrecondition, false},
+		{codes.Aborted, true},
+		{codes.OutOfRange, false},
+		{codes.Unimplemented, false},
+		{codes.Internal, false},
+		{codes.Unavailable, true},
+		{codes.DataLoss, false},
+		{codes.Unauthenticated, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code.String(), func(t *testing.T) {
+			err := status.Error(tt.code, "test error")
+			assert.Equal(t, tt.expected, isTransient(err),
+				"isTransient(%s) should be %v", tt.code, tt.expected)
+		})
+	}
+}
+
+func TestIsTransient_NonGRPCError(t *testing.T) {
+	// Non-gRPC errors (DNS, connection refused) should be transient.
+	err := errors.New("dial tcp: connection refused")
+	assert.True(t, isTransient(err))
+}
+
+func TestIsTransient_TaskFailed(t *testing.T) {
+	// Application-level ErrTaskFailed should NOT be transient.
+	err := fmt.Errorf("agent error: %w", ErrTaskFailed)
+	assert.False(t, isTransient(err))
+}
+
+func TestIsTransient_UnexpectedStatus(t *testing.T) {
+	// Application-level ErrUnexpectedStatus should NOT be transient.
+	err := fmt.Errorf("bad status: %w", ErrUnexpectedStatus)
+	assert.False(t, isTransient(err))
+}
+
+func TestExecuteTask_TransientRetrySuccess(t *testing.T) {
+	callCount := 0
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			if callCount <= 2 {
+				return nil, status.Error(codes.Unavailable, "temporarily unavailable")
+			}
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "recovered",
+			}, nil
+		},
+		WithMaxRetries(3),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "flaky-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "flaky-agent",
+		Payload: "will recover",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "recovered", result.Output)
+	assert.Equal(t, 3, callCount, "should succeed on 3rd attempt after 2 transient failures")
+}
+
+func TestExecuteTask_PermanentFailureNoRetry(t *testing.T) {
+	callCount := 0
+	env := setupTestEnv(t,
+		func(_ context.Context, _ *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			return nil, status.Error(codes.InvalidArgument, "bad request")
+		},
+		WithMaxRetries(3),
+	)
+
+	registerHealthyAgent(t, env.reg, "strict-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "strict-agent",
+		Payload: "invalid",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "permanent failure")
+	assert.Equal(t, 1, callCount, "permanent failure should not be retried")
+}
+
+func TestExecuteTask_RetryExhaustion(t *testing.T) {
+	callCount := 0
+	maxRetries := 2
+	env := setupTestEnv(t,
+		func(_ context.Context, _ *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			return nil, status.Error(codes.Unavailable, "still unavailable")
+		},
+		WithMaxRetries(maxRetries),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "down-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "down-agent",
+		Payload: "keep failing",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "retries exhausted")
+	assert.Contains(t, err.Error(), fmt.Sprintf("%d attempts", maxRetries+1))
+	assert.Equal(t, maxRetries+1, callCount, "should attempt initial + maxRetries calls")
+}
+
+func TestExecuteTask_ResourceExhaustedRetry(t *testing.T) {
+	callCount := 0
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.ResourceExhausted, "rate limited")
+			}
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "ok after rate limit",
+			}, nil
+		},
+		WithMaxRetries(2),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "busy-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "busy-agent",
+		Payload: "rate limited",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok after rate limit", result.Output)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestExecuteTask_AbortedRetry(t *testing.T) {
+	callCount := 0
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, status.Error(codes.Aborted, "transaction aborted")
+			}
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "ok after abort",
+			}, nil
+		},
+		WithMaxRetries(2),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "aborting-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "aborting-agent",
+		Payload: "aborted",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok after abort", result.Output)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestExecuteTask_StatusUnknownRejected(t *testing.T) {
+	env := setupTestEnv(t, nil) // handler never called
+
+	// Register agent with zero-value status (StatusUnknown).
+	err := env.reg.Register(context.Background(), registry.AgentInfo{
+		ID:      "unknown-agent",
+		Name:    "unknown-agent",
+		Address: "passthrough:///bufconn",
+		Status:  registry.StatusUnknown,
+	})
+	require.NoError(t, err)
+
+	_, err = env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "unknown-agent",
+		Payload: "should be rejected",
+	})
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAgentNotReady))
+	assert.Contains(t, err.Error(), "Unknown")
+}
+
+func TestExecuteTask_ConcurrentDispatch(t *testing.T) {
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "concurrent-" + req.TaskId,
+			}, nil
+		},
+		WithTimeout(5*time.Second),
+		WithMaxRetries(0),
+	)
+
+	registerHealthyAgent(t, env.reg, "concurrent-agent")
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	results := make([]*ExecuteResult, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = env.executor.ExecuteTask(
+				context.Background(),
+				ExecuteRequest{
+					TaskID:  fmt.Sprintf("task-%d", idx),
+					AgentID: "concurrent-agent",
+					Payload: fmt.Sprintf("payload-%d", idx),
+				},
+			)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := range numGoroutines {
+		require.NoError(t, errs[i], "goroutine %d should not error", i)
+		assert.Equal(t, fmt.Sprintf("concurrent-task-%d", i), results[i].Output)
+	}
 }


### PR DESCRIPTION
## RFC 0003 — PR 2b/7: Retry Logic & Error Classification Tests

**RFC**: [0003-scheduler-executor.md](docs/rfcs/0003-scheduler-executor.md)
**Branch**: \eature/v01-executor-retry\
**Depends on**: PR 2a (#22) merged

### Changes

Extends \internal/executor/executor_test.go\ with comprehensive retry and error classification tests.

### Tests added

| Test | Purpose |
|------|---------|
| \TestIsTransient_TableDriven\ | All 17 gRPC status codes → expected transient/permanent classification |
| \TestIsTransient_NonGRPCError\ | Non-gRPC errors (DNS, connection refused) → transient |
| \TestIsTransient_TaskFailed\ | Application-level \ErrTaskFailed\ → permanent (not retried) |
| \TestIsTransient_UnexpectedStatus\ | Application-level \ErrUnexpectedStatus\ → permanent (not retried) |
| \TestExecuteTask_TransientRetrySuccess\ | \Unavailable\ ×2 → success on 3rd attempt |
| \TestExecuteTask_PermanentFailureNoRetry\ | \InvalidArgument\ → 1 call only, no retry |
| \TestExecuteTask_RetryExhaustion\ | \Unavailable\ × (maxRetries+1) → retries exhausted error |
| \TestExecuteTask_ResourceExhaustedRetry\ | Rate limited → recovered on retry |
| \TestExecuteTask_AbortedRetry\ | Transaction aborted → recovered on retry |
| \TestExecuteTask_StatusUnknownRejected\ | Zero-value \StatusUnknown\ → \ErrAgentNotReady\ (N-07) |
| \TestExecuteTask_ConcurrentDispatch\ | 10 goroutines dispatch simultaneously, race detector clean (N-08) |

### Verification

- [x] \go test ./internal/executor/... -v -race -cover\ — 30 tests pass
- [x] Combined coverage: **96.1%** (exceeds 80% target)
- [x] \go vet ./internal/executor/...\ clean
- [x] No real network connections (bufconn only)
- [x] \StatusUnknown\ explicitly tested (review finding N-07)
- [x] Concurrent dispatch race-tested (review finding N-08)
- [x] All pre-commit checks pass (6/6)