### PR TITLE
feat(state): add RunRetrying, SetRunTimestamps, SetRunError (RFC 0003, PR 4/7)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ This document tracks development progress across all phases. Update it when merg
 |-----|-------|--------|-----|--------|
 | [0001](docs/rfcs/0001-core-orchestration-pipeline.md) | Core Orchestration Pipeline (Planner + State + Registry) | ✅ Implemented | 6 | 6/6 |
 | [0002](docs/rfcs/0002-rest-api-server.md) | REST API Server (HTTP Layer + Workflow Submission) | ✅ Implemented | 4 | 4/4 |
-| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 3/7 |
+| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 4/7 |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server (AgentService Implementation) | 📋 Proposed | 7 | 0/7 |
 
 ### Dependency Chain
@@ -169,6 +169,7 @@ v0.1 Complete ─ end-to-end execution working
 | [#18](https://github.com/mkhomutov/Orchestr8/pull/18) | fix: review findings follow-up | 0002 (4/4) | 2026-04-10 |
 | [#21](https://github.com/mkhomutov/Orchestr8/pull/21) | feat(generated): protobuf Go code generation | 0003 (1/7) | 2026-04-10 |
 | [#22](https://github.com/mkhomutov/Orchestr8/pull/22) | feat(executor): GRPCExecutor core with retry logic | 0003 (2/7) | 2026-04-10 |
+| [#23](https://github.com/mkhomutov/Orchestr8/pull/23) | test(executor): retry logic & error classification tests | 0003 (3/7) | 2026-04-10 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -289,10 +289,10 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 
 #### PR checklist
 
-- [ ] `go test ./internal/state/... -v -cover` passes
-- [ ] Coverage ≥ 80%
-- [ ] `RunRetrying = 5` (explicit, no `iota`)
-- [ ] `go vet ./internal/state/...` clean
+- [x] `go test ./internal/state/... -v -cover` passes
+- [x] Coverage ≥ 80%
+- [x] `RunRetrying = 5` (explicit, no `iota`)
+- [x] `go vet ./internal/state/...` clean
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -294,6 +294,15 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 - [x] `RunRetrying = 5` (explicit, no `iota`)
 - [x] `go vet ./internal/state/...` clean
 
+#### Post-merge findings
+
+- **N-18 (`runStatusString()` missing `RunRetrying`)**: `runStatusString()` in `internal/server/workflow_handlers.go` (L229–243) has no `case state.RunRetrying` — the new status renders as `"unknown"` in REST API JSON responses. No v0.1 code path sets `RunRetrying` yet, but **should fix** proactively: add `case state.RunRetrying: return "retrying"` and extend `TestRunStatusString` in `server_test.go`. Can be done in PR 3a (scheduler) or a standalone fix. *(Review pr-024, F-01)*
+- **N-19 (`TestDeleteRunAnyStatus` incomplete)**: Existing `TestDeleteRunAnyStatus` (L354–365) iterates `{RunPending, RunRunning, RunCompleted, RunFailed, RunCancelled}` but not `RunRetrying`. Trivial one-line fix: add `RunRetrying` to the `statuses` slice. **Should fix** in PR 3a or standalone. *(Review pr-024, F-02)*
+- **N-20 (No concurrent test for new methods)**: `SetRunTimestamps` and `SetRunError` are not exercised under `-race` concurrently. Existing concurrent tests cover `Create/Get/UpdateStatus/UpdateStep/Delete/List` but skip the new methods. Adding a `TestConcurrentTimestampsAndErrors` (~20 lines) would provide race detector validation. **Should fix** in a follow-up. *(Review pr-024, F-03)*
+- **N-21 (Both-nil `SetRunTimestamps` untested)**: Calling `SetRunTimestamps` with both pointers `nil` is a no-op. A test documenting this behavior prevents regressions if someone adds nil validation. Nice to have. *(Review pr-024, F-04)*
+- **N-22 (Empty-string `SetRunError` untested)**: Calling `SetRunError` with `""` effectively clears the error field. Documenting this expected behavior prevents ambiguity. Nice to have. *(Review pr-024, F-05)*
+- **N-23 (`workflowRunResponse` missing `Error` field)**: `workflowRunResponse` DTO in `internal/server/types.go` has no `Error` field. With `SetRunError` now in the `Store` interface, the Scheduler (PR 3a) will persist error messages invisible to REST API consumers. Track for follow-up — likely RFC 0002 patch or PR 3a scope. *(Review pr-024, F-06)*
+
 ---
 
 ### PR 5: `feature/v01-scheduler-wiring` — Wire into main.go

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -29,6 +29,7 @@ const (
 	RunCompleted RunStatus = 2
 	RunFailed    RunStatus = 3
 	RunCancelled RunStatus = 4
+	RunRetrying  RunStatus = 5
 )
 
 // WorkflowRun tracks the state of a single workflow execution.
@@ -64,6 +65,8 @@ type Store interface {
 	UpdateRunStatus(ctx context.Context, runID string, status RunStatus) error
 	UpdateStepState(ctx context.Context, runID string, step StepState) error
 	DeleteRun(ctx context.Context, runID string) error
+	SetRunTimestamps(ctx context.Context, runID string, startedAt, finishedAt *time.Time) error
+	SetRunError(ctx context.Context, runID string, errMsg string) error
 }
 
 // InMemoryStore is a goroutine-safe in-memory implementation of Store.
@@ -202,6 +205,47 @@ func (s *InMemoryStore) DeleteRun(_ context.Context, runID string) error {
 	return nil
 }
 
+// SetRunTimestamps updates the StartedAt and/or FinishedAt timestamps on a
+// workflow run. A nil pointer means "leave unchanged". Deep-copy semantics
+// are maintained for timestamp fields.
+// Returns ErrRunNotFound if the run does not exist.
+func (s *InMemoryStore) SetRunTimestamps(_ context.Context, runID string, startedAt, finishedAt *time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	run, exists := s.runs[runID]
+	if !exists {
+		return ErrRunNotFound
+	}
+
+	if startedAt != nil {
+		run.StartedAt = *startedAt
+	}
+	if finishedAt != nil {
+		run.FinishedAt = *finishedAt
+	}
+
+	s.logger.Debug("run timestamps updated", zap.String("runID", runID))
+	return nil
+}
+
+// SetRunError sets the Error field on a workflow run. Used by the scheduler's
+// failRun helper to persist failure reasons.
+// Returns ErrRunNotFound if the run does not exist.
+func (s *InMemoryStore) SetRunError(_ context.Context, runID string, errMsg string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	run, exists := s.runs[runID]
+	if !exists {
+		return ErrRunNotFound
+	}
+
+	run.Error = errMsg
+	s.logger.Debug("run error set", zap.String("runID", runID), zap.String("error", errMsg))
+	return nil
+}
+
 // deepCopyRun creates a deep copy of a WorkflowRun, reconstructing both the
 // Steps and Inputs maps to prevent shared backing-reference mutation.
 func deepCopyRun(run *WorkflowRun) *WorkflowRun {
@@ -240,6 +284,8 @@ func (s RunStatus) String() string {
 		return "Failed"
 	case RunCancelled:
 		return "Cancelled"
+	case RunRetrying:
+		return "Retrying"
 	default:
 		return fmt.Sprintf("RunStatus(%d)", int(s))
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -369,15 +369,6 @@ func TestDeleteRunThenUpdateStepReturnsNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrRunNotFound)
 }
 
-func TestRunStatusValues(t *testing.T) {
-	// Verify explicit integer assignments match proto/task.proto alignment.
-	assert.Equal(t, RunStatus(0), RunPending)
-	assert.Equal(t, RunStatus(1), RunRunning)
-	assert.Equal(t, RunStatus(2), RunCompleted)
-	assert.Equal(t, RunStatus(3), RunFailed)
-	assert.Equal(t, RunStatus(4), RunCancelled)
-}
-
 func TestStoreInterface(t *testing.T) {
 	// Compile-time check that InMemoryStore implements Store.
 	var _ Store = (*InMemoryStore)(nil)
@@ -554,9 +545,124 @@ func TestRunStatusString(t *testing.T) {
 		{RunCompleted, "Completed"},
 		{RunFailed, "Failed"},
 		{RunCancelled, "Cancelled"},
+		{RunRetrying, "Retrying"},
 		{RunStatus(99), "RunStatus(99)"},
 	}
 	for _, tt := range tests {
 		assert.Equal(t, tt.want, tt.status.String())
 	}
+}
+
+func TestRunRetryingStatus(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	// RunRetrying = 5, explicit integer aligned with proto/task.proto RETRYING = 5.
+	assert.Equal(t, RunStatus(5), RunRetrying)
+
+	// Create a run with RunRetrying status and retrieve it.
+	run := &WorkflowRun{ID: "retry-1", WorkflowID: "wf-1", Status: RunRetrying}
+	require.NoError(t, store.CreateRun(ctx, run))
+
+	got, err := store.GetRun(ctx, "retry-1")
+	require.NoError(t, err)
+	assert.Equal(t, RunRetrying, got.Status)
+}
+
+func TestSetRunTimestampsBoth(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{ID: "ts-1", WorkflowID: "wf-1"}))
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+	finished := time.Date(2026, 4, 10, 12, 5, 0, 0, time.UTC)
+
+	err := store.SetRunTimestamps(ctx, "ts-1", &started, &finished)
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "ts-1")
+	require.NoError(t, err)
+	assert.Equal(t, started, got.StartedAt)
+	assert.Equal(t, finished, got.FinishedAt)
+}
+
+func TestSetRunTimestampsOnlyStartedAt(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{ID: "ts-2", WorkflowID: "wf-1"}))
+
+	started := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	err := store.SetRunTimestamps(ctx, "ts-2", &started, nil)
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "ts-2")
+	require.NoError(t, err)
+	assert.Equal(t, started, got.StartedAt)
+	assert.True(t, got.FinishedAt.IsZero(), "FinishedAt should remain zero")
+}
+
+func TestSetRunTimestampsOnlyFinishedAt(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	started := time.Date(2026, 4, 10, 11, 0, 0, 0, time.UTC)
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{
+		ID:         "ts-3",
+		WorkflowID: "wf-1",
+		StartedAt:  started,
+	}))
+
+	finished := time.Date(2026, 4, 10, 12, 0, 0, 0, time.UTC)
+
+	err := store.SetRunTimestamps(ctx, "ts-3", nil, &finished)
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "ts-3")
+	require.NoError(t, err)
+	assert.Equal(t, started, got.StartedAt, "StartedAt should remain unchanged")
+	assert.Equal(t, finished, got.FinishedAt)
+}
+
+func TestSetRunTimestampsNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	started := time.Now()
+	err := store.SetRunTimestamps(ctx, "nonexistent", &started, nil)
+	assert.ErrorIs(t, err, ErrRunNotFound)
+}
+
+func TestSetRunError(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{ID: "err-1", WorkflowID: "wf-1"}))
+
+	err := store.SetRunError(ctx, "err-1", "step 'plan' failed: agent timeout")
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "err-1")
+	require.NoError(t, err)
+	assert.Equal(t, "step 'plan' failed: agent timeout", got.Error)
+}
+
+func TestSetRunErrorNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	err := store.SetRunError(ctx, "nonexistent", "some error")
+	assert.ErrorIs(t, err, ErrRunNotFound)
+}
+
+func TestRunStatusValues(t *testing.T) {
+	// Verify explicit integer assignments match proto/task.proto alignment.
+	assert.Equal(t, RunStatus(0), RunPending)
+	assert.Equal(t, RunStatus(1), RunRunning)
+	assert.Equal(t, RunStatus(2), RunCompleted)
+	assert.Equal(t, RunStatus(3), RunFailed)
+	assert.Equal(t, RunStatus(4), RunCancelled)
+	assert.Equal(t, RunStatus(5), RunRetrying)
 }


### PR DESCRIPTION
## RFC 0003 - PR 4/7: Store Extension + RunRetrying

**RFC**: [0003-scheduler-executor.md](docs/rfcs/0003-scheduler-executor.md)
**Branch**: `feature/v01-state-extension`
**Depends on**: RFC 0001 (existing Store implementation) - independent of PRs 2-3

### Changes

| File | Change |
|------|--------|
| `internal/state/state.go` | Add `RunRetrying RunStatus = 5`, `SetRunTimestamps` and `SetRunError` to `Store` interface, implement in `InMemoryStore`, extend `RunStatus.String()` |
| `internal/state/state_test.go` | 8 new tests for timestamps, errors, retrying status, String() |

### Key implementation details

- `RunRetrying RunStatus = 5` - explicit integer, aligned with `proto/task.proto` `RETRYING = 5`
- `SetRunTimestamps(ctx, runID, startedAt, finishedAt *time.Time)` - nil pointer means "leave unchanged"
- `SetRunError(ctx, runID, errMsg string)` - sets `WorkflowRun.Error` field for scheduler's `failRun` helper
- Deep-copy semantics maintained for timestamp fields
- `RunStatus.String()` extended with `Retrying` case

### Tests added

| Test | Purpose |
|------|---------|
| `TestRunRetryingStatus` | RunRetrying stored and retrieved correctly, value = 5 |
| `TestSetRunTimestampsBoth` | Both timestamps set and verified |
| `TestSetRunTimestampsOnlyStartedAt` | Only StartedAt set, FinishedAt unchanged |
| `TestSetRunTimestampsOnlyFinishedAt` | Only FinishedAt set, StartedAt unchanged |
| `TestSetRunTimestampsNotFound` | Nonexistent run returns ErrRunNotFound |
| `TestSetRunError` | Error message set and retrieved |
| `TestSetRunErrorNotFound` | Nonexistent run returns ErrRunNotFound |
| `TestRunStatusValues` | All 6 status values verified (including RunRetrying) |

### Verification

- [x] `go test ./internal/state/... -v -race -cover` - 35 tests pass
- [x] Coverage: **98.9%** (exceeds 80% target)
- [x] `go vet ./internal/state/...` clean
- [x] `go build ./...` full project compiles
- [x] `RunRetrying = 5` (explicit, no iota)
- [x] All pre-commit checks pass (6/6)
