### PR TITLE
test(scheduler): step execution, template resolution, error path coverage (RFC 0003, PR 3b/7)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ This document tracks development progress across all phases. Update it when merg
 |-----|-------|--------|-----|--------|
 | [0001](docs/rfcs/0001-core-orchestration-pipeline.md) | Core Orchestration Pipeline (Planner + State + Registry) | ✅ Implemented | 6 | 6/6 |
 | [0002](docs/rfcs/0002-rest-api-server.md) | REST API Server (HTTP Layer + Workflow Submission) | ✅ Implemented | 4 | 4/4 |
-| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 4/7 |
+| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 5/7 |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server (AgentService Implementation) | 📋 Proposed | 7 | 0/7 |
 
 ### Dependency Chain
@@ -170,6 +170,8 @@ v0.1 Complete ─ end-to-end execution working
 | [#21](https://github.com/mkhomutov/Orchestr8/pull/21) | feat(generated): protobuf Go code generation | 0003 (1/7) | 2026-04-10 |
 | [#22](https://github.com/mkhomutov/Orchestr8/pull/22) | feat(executor): GRPCExecutor core with retry logic | 0003 (2/7) | 2026-04-10 |
 | [#23](https://github.com/mkhomutov/Orchestr8/pull/23) | test(executor): retry logic & error classification tests | 0003 (3/7) | 2026-04-10 |
+| [#24](https://github.com/mkhomutov/Orchestr8/pull/24) | feat(state): RunRetrying, SetRunTimestamps, SetRunError | 0003 (4/7) | 2026-04-10 |
+| [#25](https://github.com/mkhomutov/Orchestr8/pull/25) | feat(scheduler): WorkflowScheduler core with polling, parallel stages, dedup | 0003 (5/7) | 2026-04-10 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -262,12 +262,12 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 
 #### PR checklist
 
-- [ ] `go test ./internal/scheduler/... -v -cover` passes
-- [ ] Combined coverage (3a + 3b) ≥ 80%
-- [ ] `go vet ./internal/scheduler/...` clean
-- [ ] TOCTOU branch exercised (N-24)
-- [ ] `Plan()` error path tested (N-25)
-- [ ] `ListRuns` error path tested (N-26)
+- [x] `go test ./internal/scheduler/... -v -cover` passes
+- [x] Combined coverage (3a + 3b) ≥ 80% (87.3%)
+- [x] `go vet ./internal/scheduler/...` clean
+- [x] TOCTOU branch exercised (N-24)
+- [x] `Plan()` error path tested (N-25)
+- [x] `ListRuns` error path tested (N-26)
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -269,6 +269,20 @@ RFC 0003 defines ~900 LOC across 5 phases (excluding generated proto output). Th
 - [x] `Plan()` error path tested (N-25)
 - [x] `ListRuns` error path tested (N-26)
 
+#### Post-merge findings
+
+- **N-35 (`TestResolutionFailureMissingStepOutput` missing step-level assertion)**: Only asserts run-level error (`run.Error` contains `"nonexistent"`). Does **not** verify `step.Status == RunFailed` or `step.Error`, unlike the sibling test `TestResolutionFailureMissingVariable` which checks both. Template resolution failures go through `markStepFailed` — asserting step state confirms that path. **Should fix** in a follow-up. *(Review pr-026, Should Fix #1)*
+- **N-36 (`TestListRunsErrorPath` uses `zap.NewNop()`)**: The test verifies no dispatch occurs but cannot confirm the error was actually logged. Since the code path under test is `logger.Error("failed to list runs") + return`, using `zap.NewNop()` means the test passes even if the logging line is accidentally deleted. **Should fix** in a follow-up: use `zaptest.NewLogger(t)` or `zap/observer` to assert an error-level log entry containing `"failed to list runs"` was emitted. *(Review pr-026, Should Fix #2)*
+- **N-37 (`TestStepStateTransitionsFailure` missing `midRunStepHasStartedAt`)**: Does not assert `midRunStepHasStartedAt` during intermediate state (unlike the success variant `TestStepStateTransitionsSuccess`). Minor inconsistency — the success test already covers this, but symmetry would improve confidence. **Should fix** in a follow-up. *(Review pr-026, Should Fix #3)*
+- **N-38 (`mockStore` nil-panic risk)**: Embedded `state.Store` interface means nil-panic if `Store` field is not set. Future tests copying the pattern could misuse it. Nice to have: add a constructor `newMockStore(real state.Store, listErr error)` or a comment documenting the requirement. *(Review pr-026, Nice to Have #1)*
+- **N-39 (Observed-logger test for `failRun`)**: A test with `zap/observer` that verifies `failRun` emits expected structured log fields (`runID`, `error`) would provide regression coverage for error reporting quality. Nice to have. *(Review pr-026, Nice to Have #2)*
+- **N-40 (Multi-template-in-single-input test)**: A step with `input: "{{ user_request }} using {{ steps.prev.output }}"` — both `{{ variable }}` and `{{ steps.<id>.output }}` in a single input string — would exercise the single-pass multi-match path in `ResolveInputs`. Nice to have. *(Review pr-026, Nice to Have #3)*
+- **N-41 (`UpdateStepState` failure coverage)**: `UpdateStepState` failures during `executeStep` (scheduler.go L328–335, L373–382) are logged but don't abort execution. A test with a failing mock store would verify this logging-only behavior. Nice to have. *(Review pr-026, Nice to Have #4, related to N-30)*
+- **N-42 (`SetRunTimestamps` failure in success path)**: `SetRunTimestamps` failure on the success/completion path (scheduler.go L261–264) is logged but doesn't prevent run completion. A test documenting this behavior would prevent regressions. Nice to have. *(Review pr-026, Nice to Have #5, related to N-31)*
+- **N-43 (Duplicate `OutputKey` in parallel stage)**: Two steps with same `output_key` → verify last-write-wins or add warning. Nice to have. *(Review pr-026, Nice to Have #6, related to N-29)*
+- **N-44 (Concurrent template resolution >2 parallel steps)**: Only 2 parallel steps tested reading outputs. 3+ parallel steps depending on prior stage outputs would provide stronger race detector validation. Nice to have. *(Review pr-026, Nice to Have #7, related to N-33)*
+- **N-45 (`SetRunTimestamps` failure in `failRun`)**: Verify failure logging doesn't prevent error/status persistence. Not previously tracked. Nice to have. *(Review pr-026, Nice to Have #8)*
+
 ---
 
 ### PR 4: `feature/v01-state-extension` — Store Extension + RunRetrying

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -694,3 +694,358 @@ func TestSuccessPathContextCancellation(t *testing.T) {
 	assert.Equal(t, state.RunCompleted, run.Status)
 	assert.False(t, run.FinishedAt.IsZero(), "FinishedAt should be set despite cancelled context")
 }
+
+// --- PR 3b: Step Execution & Template Resolution Tests ---
+
+// mockPlanner wraps a real YAMLPlanner but allows Plan() to be overridden.
+type mockPlanner struct {
+	real    planner.Planner
+	planErr error // if non-nil, Plan() returns this error
+}
+
+func (m *mockPlanner) Parse(ctx context.Context, yamlPath string) (*planner.Workflow, error) {
+	return m.real.Parse(ctx, yamlPath)
+}
+
+func (m *mockPlanner) ValidateDAG(ctx context.Context, wf *planner.Workflow) error {
+	return m.real.ValidateDAG(ctx, wf)
+}
+
+func (m *mockPlanner) Plan(ctx context.Context, wf *planner.Workflow) (*planner.ExecutionPlan, error) {
+	if m.planErr != nil {
+		return nil, m.planErr
+	}
+	return m.real.Plan(ctx, wf)
+}
+
+// mockStore wraps InMemoryStore but allows ListRuns to be overridden.
+type mockStore struct {
+	state.Store
+	listRunsErr error // if non-nil, ListRuns() returns this error
+}
+
+func (m *mockStore) ListRuns(ctx context.Context) ([]*state.WorkflowRun, error) {
+	if m.listRunsErr != nil {
+		return nil, m.listRunsErr
+	}
+	return m.Store.ListRuns(ctx)
+}
+
+func TestResolutionFailureMissingVariable(t *testing.T) {
+	// Missing variable in {{ variable }} template → RunFailed with resolution error.
+	const missingVarYAML = `schema_version: "0.1"
+workflow:
+  id: "missing-var"
+  name: "Missing Var"
+  trigger: "manual"
+  steps:
+    - id: "s1"
+      agent: "test-agent"
+      input: "build: {{ missing_key }}"
+      output_key: "result"
+`
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "missing-var", missingVarYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		t.Fatal("executor should not be called when template resolution fails")
+		return nil, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "missing-run", "missing-var", nil) // no inputs → missing_key unresolvable
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	run := waitForRunStatus(t, store, "missing-run", state.RunFailed, 5*time.Second)
+	assert.Equal(t, state.RunFailed, run.Status)
+	assert.Contains(t, run.Error, "missing_key", "error should mention the missing variable")
+
+	// Step should be marked as failed with the resolution error.
+	step, ok := run.Steps["s1"]
+	require.True(t, ok, "step s1 should exist")
+	assert.Equal(t, state.RunFailed, step.Status)
+	assert.Contains(t, step.Error, "missing_key")
+}
+
+func TestResolutionFailureMissingStepOutput(t *testing.T) {
+	// Missing step output in {{ steps.<id>.output }} template → RunFailed.
+	const missingStepYAML = `schema_version: "0.1"
+workflow:
+  id: "missing-step"
+  name: "Missing Step Output"
+  trigger: "manual"
+  steps:
+    - id: "s1"
+      agent: "test-agent"
+      input: "use: {{ steps.nonexistent.output }}"
+      output_key: "result"
+`
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "missing-step", missingStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		t.Fatal("executor should not be called when step output is missing")
+		return nil, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "missing-step-run", "missing-step", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	run := waitForRunStatus(t, store, "missing-step-run", state.RunFailed, 5*time.Second)
+	assert.Equal(t, state.RunFailed, run.Status)
+	assert.Contains(t, run.Error, "nonexistent", "error should mention the missing step ID")
+}
+
+func TestStepStateTransitionsSuccess(t *testing.T) {
+	// Verify a successful step transitions through Running → Completed with timestamps.
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+
+	// Record intermediate step states.
+	var midRunStepStatus state.RunStatus
+	var midRunStepHasStartedAt bool
+	stepExecuting := make(chan struct{})
+	stepContinue := make(chan struct{})
+
+	exec := &mockExecutor{handler: func(ctx context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		close(stepExecuting)
+		<-stepContinue
+		return &executor.ExecuteResult{TaskID: "t1", Output: "done"}, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "trans-run", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	// Wait for executor to be called — step should be in Running state.
+	<-stepExecuting
+	run, err := store.GetRun(context.Background(), "trans-run")
+	require.NoError(t, err)
+	if step, ok := run.Steps["step1"]; ok {
+		midRunStepStatus = step.Status
+		midRunStepHasStartedAt = !step.StartedAt.IsZero()
+	}
+	close(stepContinue)
+
+	// Wait for completion.
+	run = waitForRunStatus(t, store, "trans-run", state.RunCompleted, 5*time.Second)
+
+	// Mid-execution: step was Running with StartedAt set.
+	assert.Equal(t, state.RunRunning, midRunStepStatus, "step should be Running during execution")
+	assert.True(t, midRunStepHasStartedAt, "step StartedAt should be set during execution")
+
+	// Post-completion: step is Completed with both timestamps.
+	step, ok := run.Steps["step1"]
+	require.True(t, ok)
+	assert.Equal(t, state.RunCompleted, step.Status)
+	assert.False(t, step.StartedAt.IsZero(), "step StartedAt should be set")
+	assert.False(t, step.FinishedAt.IsZero(), "step FinishedAt should be set")
+	assert.True(t, step.FinishedAt.After(step.StartedAt) || step.FinishedAt.Equal(step.StartedAt))
+}
+
+func TestStepStateTransitionsFailure(t *testing.T) {
+	// Verify a failing step transitions through Running → Failed with error and timestamps.
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+
+	var midRunStepStatus state.RunStatus
+	stepExecuting := make(chan struct{})
+	stepContinue := make(chan struct{})
+
+	exec := &mockExecutor{handler: func(ctx context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		close(stepExecuting)
+		<-stepContinue
+		return nil, fmt.Errorf("step failed intentionally")
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "fail-trans", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	// Wait for executor to be called — step should be in Running state.
+	<-stepExecuting
+	run, err := store.GetRun(context.Background(), "fail-trans")
+	require.NoError(t, err)
+	if step, ok := run.Steps["step1"]; ok {
+		midRunStepStatus = step.Status
+	}
+	close(stepContinue)
+
+	// Wait for run failure.
+	run = waitForRunStatus(t, store, "fail-trans", state.RunFailed, 5*time.Second)
+
+	// Mid-execution: step was Running.
+	assert.Equal(t, state.RunRunning, midRunStepStatus, "step should be Running during execution")
+
+	// Post-failure: step is Failed with error and both timestamps.
+	step, ok := run.Steps["step1"]
+	require.True(t, ok)
+	assert.Equal(t, state.RunFailed, step.Status)
+	assert.Contains(t, step.Error, "step failed intentionally")
+	assert.False(t, step.StartedAt.IsZero(), "step StartedAt should be preserved on failure")
+	assert.False(t, step.FinishedAt.IsZero(), "step FinishedAt should be set on failure")
+}
+
+func TestMultiStageTemplateChaining(t *testing.T) {
+	// Verify output from stage N is available as input in stage N+1 via {{ steps.<key>.output }}.
+	const chainingYAML = `schema_version: "0.1"
+workflow:
+  id: "chain-wf"
+  name: "Chain"
+  trigger: "manual"
+  steps:
+    - id: "generate"
+      agent: "gen-agent"
+      input: "generate data for {{ user_request }}"
+      output_key: "gen_out"
+    - id: "transform"
+      agent: "xform-agent"
+      input: "transform: {{ steps.gen_out.output }}"
+      output_key: "xform_out"
+      depends_on: ["generate"]
+    - id: "validate"
+      agent: "val-agent"
+      input: "validate: {{ steps.xform_out.output }}"
+      output_key: "val_out"
+      depends_on: ["transform"]
+`
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "chain-wf", chainingYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	payloads := make(map[string]string)
+	var mu sync.Mutex
+
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		mu.Lock()
+		payloads[req.AgentID] = req.Payload
+		mu.Unlock()
+		return &executor.ExecuteResult{
+			TaskID: "t1",
+			Output: fmt.Sprintf("result-from-%s", req.AgentID),
+		}, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "chain-run", "chain-wf", map[string]string{
+		"user_request": "API endpoints",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	run := waitForRunStatus(t, store, "chain-run", state.RunCompleted, 5*time.Second)
+	assert.Equal(t, state.RunCompleted, run.Status)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "generate data for API endpoints", payloads["gen-agent"],
+		"first stage should resolve {{ user_request }} from inputs")
+	assert.Equal(t, "transform: result-from-gen-agent", payloads["xform-agent"],
+		"second stage should resolve {{ steps.gen_out.output }} from first stage output")
+	assert.Equal(t, "validate: result-from-xform-agent", payloads["val-agent"],
+		"third stage should resolve {{ steps.xform_out.output }} from second stage output")
+}
+
+func TestTOCTOUBranch(t *testing.T) {
+	// N-24: Run changed to RunCancelled between poll and executeRun re-read → no execution.
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		t.Fatal("executor should not be called for a cancelled run")
+		return nil, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "toctou-run", "test-wf", nil)
+
+	// Cancel the run between poll and execution.
+	require.NoError(t, store.UpdateRunStatus(context.Background(), "toctou-run", state.RunCancelled))
+
+	// Directly call executeRun — it should see RunCancelled and skip.
+	sched.executeRun(context.Background(), "toctou-run")
+
+	// Run should still be cancelled — not failed or completed.
+	run, err := store.GetRun(context.Background(), "toctou-run")
+	require.NoError(t, err)
+	assert.Equal(t, state.RunCancelled, run.Status, "run should remain cancelled (TOCTOU guard)")
+	assert.Equal(t, int64(0), exec.calls.Load(), "executor should not have been called")
+}
+
+func TestPlanErrorPath(t *testing.T) {
+	// N-25: Planner.Plan() returns error → RunFailed with appropriate error message.
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		t.Fatal("executor should not be called when Plan() fails")
+		return nil, nil
+	}}
+
+	logger := zap.NewNop()
+	mp := &mockPlanner{
+		real:    planner.NewYAMLPlanner(logger),
+		planErr: fmt.Errorf("unsupported step type: custom-action"),
+	}
+
+	sched := NewWorkflowScheduler(store, nil, mp, exec, logger, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "plan-err-run", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go sched.Run(ctx)
+
+	run := waitForRunStatus(t, store, "plan-err-run", state.RunFailed, 5*time.Second)
+	assert.Equal(t, state.RunFailed, run.Status)
+	assert.Contains(t, run.Error, "plan workflow")
+	assert.Contains(t, run.Error, "unsupported step type")
+}
+
+func TestListRunsErrorPath(t *testing.T) {
+	// N-26: Store.ListRuns() returns error → logged, no runs dispatched.
+	dir := t.TempDir()
+
+	realStore := state.NewInMemoryStore(zap.NewNop())
+	ms := &mockStore{
+		Store:       realStore,
+		listRunsErr: fmt.Errorf("database connection lost"),
+	}
+
+	exec := &mockExecutor{handler: func(_ context.Context, _ executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		t.Fatal("executor should not be called when ListRuns fails")
+		return nil, nil
+	}}
+
+	sched := NewWorkflowScheduler(ms, nil, planner.NewYAMLPlanner(zap.NewNop()), exec, zap.NewNop(), dir, WithPollInterval(50*time.Millisecond))
+
+	ctx := context.Background()
+	sem := make(chan struct{}, 10)
+
+	// pollAndExecute should handle the error gracefully — no panic, no dispatch.
+	sched.pollAndExecute(ctx, sem)
+
+	assert.Equal(t, int64(0), exec.calls.Load(), "executor should not be called on ListRuns error")
+}


### PR DESCRIPTION
## RFC 0003 — PR 3b/7: Step Execution & Template Resolution Tests

**RFC**: [0003-scheduler-executor.md](docs/rfcs/0003-scheduler-executor.md)
**Branch**: `feature/v01-scheduler-templates`
**Depends on**: PR 3a (#25) merged

### Changes

Extends `internal/scheduler/scheduler_test.go` with 8 tests covering template resolution, step state transitions, and error paths identified in PR 3a review findings.

### Tests added

| Test | Purpose |
|------|---------|
| `TestResolutionFailureMissingVariable` | Missing `{{ variable }}` template → `RunFailed` with error naming the variable |
| `TestResolutionFailureMissingStepOutput` | Missing `{{ steps.<id>.output }}` reference → `RunFailed` |
| `TestStepStateTransitionsSuccess` | Verifies step progression: `Running` (mid-execution) → `Completed` with timestamps |
| `TestStepStateTransitionsFailure` | Verifies step progression: `Running` (mid-execution) → `Failed` with error and timestamps |
| `TestMultiStageTemplateChaining` | 3-stage workflow: vars + step outputs chain across stages |
| `TestTOCTOUBranch` | Run changed to `RunCancelled` between poll and `executeRun` → skipped (N-24) |
| `TestPlanErrorPath` | `Plan()` returns error → `RunFailed` with "plan workflow" message (N-25) |
| `TestListRunsErrorPath` | `ListRuns()` returns error → no dispatch, no panic (N-26) |

### New test infrastructure

- `mockPlanner`: wraps real `YAMLPlanner`, allows `Plan()` error injection
- `mockStore`: wraps `InMemoryStore`, allows `ListRuns()` error injection

### Verification

- [x] `go test ./internal/scheduler/... -v -race -cover` — 27 tests pass
- [x] Combined coverage (3a + 3b): **87.3%** (exceeds 80% target)
- [x] `go vet ./internal/scheduler/...` clean
- [x] No real network connections in tests
- [x] TOCTOU branch exercised (N-24)
- [x] `Plan()` error path tested (N-25)
- [x] `ListRuns` error path tested (N-26)
