### PR TITLE
fix(executor): additive dial options, mid-dispatch cancel & retry stress tests (RFC 0003, PR 6)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,7 +28,7 @@ This document tracks development progress across all phases. Update it when merg
 |-----|-------|--------|-----|--------|
 | [0001](docs/rfcs/0001-core-orchestration-pipeline.md) | Core Orchestration Pipeline (Planner + State + Registry) | ✅ Implemented | 6 | 6/6 |
 | [0002](docs/rfcs/0002-rest-api-server.md) | REST API Server (HTTP Layer + Workflow Submission) | ✅ Implemented | 4 | 4/4 |
-| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | 🚧 Implementing | 7 | 6/7 |
+| [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor (Parallel Stage Execution + gRPC Dispatch) | ✅ Implemented | 7+4 | 7/7 |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server (AgentService Implementation) | 📋 Proposed | 7 | 0/7 |
 
 ### Dependency Chain
@@ -173,6 +173,7 @@ v0.1 Complete ─ end-to-end execution working
 | [#24](https://github.com/mkhomutov/Orchestr8/pull/24) | feat(state): RunRetrying, SetRunTimestamps, SetRunError | 0003 (4/7) | 2026-04-10 |
 | [#25](https://github.com/mkhomutov/Orchestr8/pull/25) | feat(scheduler): WorkflowScheduler core with polling, parallel stages, dedup | 0003 (5/7) | 2026-04-10 |
 | [#26](https://github.com/mkhomutov/Orchestr8/pull/26) | test(scheduler): step execution, template resolution, error path coverage | 0003 (6/7) | 2026-04-10 |
+| [#27](https://github.com/mkhomutov/Orchestr8/pull/27) | feat(orchestrator): wire scheduler + executor into main.go | 0003 (7/7) | 2026-04-10 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -413,10 +413,10 @@ All 7 implementation PRs are merged. The following PRs address "Should Fix" post
 
 #### PR checklist
 
-- [ ] `go test ./internal/executor/... -v -race -cover` passes
-- [ ] `WithDialOptions` callers always get transport credentials
-- [ ] Cancellation mid-dispatch test documents observed behavior
-- [ ] Concurrent retry stress test exercises backoff path under `-race`
+- [x] `go test ./internal/executor/... -v -race -cover` passes (33 tests, 97.4% coverage)
+- [x] `WithDialOptions` callers always get transport credentials
+- [x] Cancellation mid-dispatch test documents observed behavior
+- [x] Concurrent retry stress test exercises backoff path under `-race`
 
 ---
 

--- a/docs/rfcs/0003-scheduler-executor.md
+++ b/docs/rfcs/0003-scheduler-executor.md
@@ -1,7 +1,7 @@
 # RFC 0003 — Scheduler & Executor (Parallel Stage Execution + gRPC Task Dispatch)
 
 **Type**: architecture
-**Status**: 🚧 Implementing
+**Status**: ✅ Implemented
 **Author**: Orchestr8 team
 **Date**: 2026-04-09
 **Target**: v0.1 (MVP)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -192,14 +192,13 @@ func (e *GRPCExecutor) ExecuteTask(ctx context.Context, req ExecuteRequest) (*Ex
 
 // dispatch performs a single gRPC ExecuteTask call to the agent at the given address.
 func (e *GRPCExecutor) dispatch(ctx context.Context, address string, req *taskpb.TaskRequest) (*ExecuteResult, error) {
-	// Build dial options.
+	// Build dial options. Transport credentials are always included as the base
+	// so callers using WithDialOptions (e.g., custom interceptors) don't need to
+	// independently remember to supply credentials. (N-06)
+	// TODO(security): enable mTLS — replace insecure credentials here.
 	opts := make([]grpc.DialOption, 0, len(e.dialOpts)+1)
-	if len(e.dialOpts) > 0 {
-		opts = append(opts, e.dialOpts...)
-	} else {
-		// TODO(security): enable mTLS
-		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	}
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts = append(opts, e.dialOpts...)
 
 	// TODO(v0.2): connection pooling — reuse connections across tasks.
 	conn, err := grpc.NewClient(address, opts...)
@@ -244,6 +243,7 @@ func (e *GRPCExecutor) dispatch(ctx context.Context, address string, req *taskpb
 // isTransient classifies whether an error is transient and eligible for retry.
 // gRPC Unavailable, ResourceExhausted, and Aborted are transient.
 // DeadlineExceeded is permanent (retrying with the same timeout won't help).
+// Canceled is permanent (retrying with a cancelled context always fails — see N-12 test).
 // Non-gRPC errors (DNS, connection refused, etc.) are treated as transient.
 // Application-level permanent errors (ErrTaskFailed, ErrUnexpectedStatus) from
 // dispatch are explicitly excluded — these indicate the agent processed the

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,7 +15,6 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
@@ -65,12 +65,12 @@ func setupTestEnv(t *testing.T, handler func(context.Context, *taskpb.TaskReques
 	reg := registry.NewInMemoryRegistry(zap.NewNop())
 	logger := zap.NewNop()
 
-	// Bufconn dialer option.
+	// Bufconn dialer option. Transport credentials are provided by the executor
+	// base (N-06 additive dial options), so only the context dialer is needed here.
 	bufDialer := WithDialOptions(
 		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
 			return lis.DialContext(ctx)
 		}),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 
 	allOpts := append([]Option{bufDialer}, opts...)
@@ -723,4 +723,137 @@ func TestExecuteTask_ConcurrentDispatch(t *testing.T) {
 		require.NoError(t, errs[i], "goroutine %d should not error", i)
 		assert.Equal(t, fmt.Sprintf("concurrent-task-%d", i), results[i].Output)
 	}
+}
+
+// --- PR 6: Executor Hardening (N-06, N-12, N-13) ---
+
+// TestExecuteTask_ContextCancellationMidDispatch verifies behavior when the context
+// is cancelled during an active gRPC dispatch (not during backoff sleep). The gRPC
+// layer returns codes.Canceled which isTransient classifies as permanent. This test
+// documents that the error surfaces as "permanent failure ... Canceled" rather than
+// a bare context.Canceled. (N-12)
+func TestExecuteTask_ContextCancellationMidDispatch(t *testing.T) {
+	var callCount int32
+	env := setupTestEnv(t,
+		func(ctx context.Context, _ *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			atomic.AddInt32(&callCount, 1)
+			// Block until the context is cancelled — simulates a slow agent.
+			<-ctx.Done()
+			return nil, status.Error(codes.Canceled, "context canceled")
+		},
+		WithMaxRetries(3),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "slow-agent")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a brief delay so the dispatch is in-flight.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := env.executor.ExecuteTask(ctx, ExecuteRequest{
+		AgentID: "slow-agent",
+		Payload: "will be cancelled mid-dispatch",
+	})
+
+	require.Error(t, err)
+	// codes.Canceled is classified as permanent by isTransient, so the error
+	// surfaces as "permanent failure" rather than context.Canceled.
+	assert.Contains(t, err.Error(), "permanent failure")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&callCount), "should not retry after codes.Canceled")
+}
+
+// TestExecuteTask_ConcurrentRetryStress exercises the backoff/retry path under the
+// race detector by having multiple goroutines all encounter transient errors before
+// eventually succeeding. This validates that the per-dispatch timer/select/backoff
+// is safe under concurrent use. (N-13)
+func TestExecuteTask_ConcurrentRetryStress(t *testing.T) {
+	var totalAttempts sync.Map // goroutine index → attempt count
+
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			// Track per-task attempts via the totalAttempts map.
+			key := req.TaskId
+			val, _ := totalAttempts.LoadOrStore(key, new(int32))
+			count := val.(*int32)
+			attempt := atomic.AddInt32(count, 1)
+
+			// First attempt always fails with transient error.
+			if attempt <= 1 {
+				return nil, status.Error(codes.Unavailable, "temporarily unavailable")
+			}
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "recovered-" + req.TaskId,
+			}, nil
+		},
+		WithMaxRetries(3),
+		WithTimeout(5*time.Second),
+	)
+
+	registerHealthyAgent(t, env.reg, "retry-agent")
+
+	const numGoroutines = 8
+	var wg sync.WaitGroup
+	results := make([]*ExecuteResult, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	for i := range numGoroutines {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = env.executor.ExecuteTask(
+				context.Background(),
+				ExecuteRequest{
+					TaskID:  fmt.Sprintf("stress-%d", idx),
+					AgentID: "retry-agent",
+					Payload: fmt.Sprintf("stress-payload-%d", idx),
+				},
+			)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := range numGoroutines {
+		require.NoError(t, errs[i], "goroutine %d should not error", i)
+		assert.Equal(t, fmt.Sprintf("recovered-stress-%d", i), results[i].Output)
+
+		// Verify each goroutine retried at least once.
+		key := fmt.Sprintf("stress-%d", i)
+		val, ok := totalAttempts.Load(key)
+		require.True(t, ok, "attempt counter should exist for %s", key)
+		assert.Equal(t, int32(2), *val.(*int32), "goroutine %d should have made exactly 2 attempts", i)
+	}
+}
+
+// TestDialOptions_Additive verifies that caller-provided dial options are additive
+// with the base transport credentials, not a replacement. (N-06)
+func TestDialOptions_Additive(t *testing.T) {
+	// This test verifies the fix works end-to-end: even when WithDialOptions is
+	// used (as in setupTestEnv for bufconn), transport credentials are still
+	// included by the executor. If they weren't, gRPC would refuse to dial.
+	env := setupTestEnv(t,
+		func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+			return &taskpb.TaskResponse{
+				TaskId: req.TaskId,
+				Status: taskpb.TaskStatus_COMPLETED,
+				Result: "additive-ok",
+			}, nil
+		},
+	)
+
+	registerHealthyAgent(t, env.reg, "additive-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "additive-agent",
+		Payload: "verify additive dial options",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "additive-ok", result.Output)
 }


### PR DESCRIPTION
## RFC 0003 — PR 6: Executor Hardening

**RFC**: [0003-scheduler-executor.md](docs/rfcs/0003-scheduler-executor.md)
**Branch**: `feature/v01-executor-hardening`
**Depends on**: PR 5 (#27) merged

### Changes

Addresses 3 post-merge review findings from executor PRs:

| Finding | Change |
|---------|--------|
| **N-06** (dial options bypass) | Make dial options additive — always append insecure credentials as base, then append caller-provided `dialOpts`. Prevents callers using `WithDialOptions` from accidentally omitting transport credentials. |
| **N-12** (context cancellation mid-dispatch) | New test: cancel `ctx` during active gRPC dispatch → documents that `codes.Canceled` surfaces as `"permanent failure"` (not bare `context.Canceled`). |
| **N-13** (concurrent retry untested) | New test: 8 goroutines all encounter transient errors and retry → validates backoff `select`/timer path under `-race` with `sync/atomic` counters. |

Also adds `TestDialOptions_Additive` to verify the N-06 fix works end-to-end.

### Status updates

- RFC 0003 status → `✅ Implemented` (all 7 implementation PRs merged)
- ROADMAP: add missing PR #27 to merged history, update RFC 0003 to 7+4 follow-ups
- PR plan: mark PR 6 checklist as complete

### Verification

- [x] `go test ./internal/executor/... -v -race -cover` — 33 tests pass, **97.4% coverage**
- [x] `go vet ./internal/executor/...` clean
- [x] `go build ./...` full project compiles
- [x] No real network connections in tests (bufconn only)
- [x] All pre-commit checks pass (6/6)
