### PR TITLE
test: observability improvements — concurrent race tests, log assertions, zaptest logger

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -174,6 +174,7 @@ v0.1 Complete ─ end-to-end execution working
 | [#25](https://github.com/mkhomutov/Orchestr8/pull/25) | feat(scheduler): WorkflowScheduler core with polling, parallel stages, dedup | 0003 (5/7) | 2026-04-10 |
 | [#26](https://github.com/mkhomutov/Orchestr8/pull/26) | test(scheduler): step execution, template resolution, error path coverage | 0003 (6/7) | 2026-04-10 |
 | [#27](https://github.com/mkhomutov/Orchestr8/pull/27) | feat(orchestrator): wire scheduler + executor into main.go | 0003 (7/7) | 2026-04-10 |
+| [#31](https://github.com/mkhomutov/Orchestr8/pull/31) | fix(executor): additive dial options, cancellation & concurrent retry tests | 0003 follow-up (1/4) | 2026-04-10 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -444,11 +444,11 @@ All 7 implementation PRs are merged. The following PRs address "Should Fix" post
 
 #### PR checklist
 
-- [ ] `go test ./internal/state/... -v -race -cover` passes
-- [ ] `go test ./internal/scheduler/... -v -race -cover` passes
-- [ ] `go test ./tests/integration/... -v -race` passes
-- [ ] `TestListRunsErrorPath` asserts error log emission
-- [ ] Integration test surfaces diagnostic output on failure
+- [x] `go test ./internal/state/... -v -race -cover` passes
+- [x] `go test ./internal/scheduler/... -v -race -cover` passes
+- [x] `go test ./tests/integration/... -v -race` passes
+- [x] `TestListRunsErrorPath` asserts error log emission
+- [x] Integration test surfaces diagnostic output on failure
 
 ---
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1050,7 +1050,10 @@ func TestListRunsErrorPath(t *testing.T) {
 		return nil, nil
 	}}
 
-	core, logs := observer.New(zap.ErrorLevel)
+	// N-36: Use DebugLevel observer so the entry.Level assertion below
+	// actually validates that production code logs at Error (not Warn/Info).
+	// With ErrorLevel filter the level check would be tautologically true.
+	core, logs := observer.New(zap.DebugLevel)
 	observedLogger := zap.New(core)
 
 	sched := NewWorkflowScheduler(ms, nil, planner.NewYAMLPlanner(zap.NewNop()), exec, observedLogger, dir, WithPollInterval(50*time.Millisecond))

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/orchestr8/orchestr8/internal/executor"
 	"github.com/orchestr8/orchestr8/internal/planner"
@@ -803,6 +804,12 @@ workflow:
 	run := waitForRunStatus(t, store, "missing-step-run", state.RunFailed, 5*time.Second)
 	assert.Equal(t, state.RunFailed, run.Status)
 	assert.Contains(t, run.Error, "nonexistent", "error should mention the missing step ID")
+
+	// N-35: Step-level assertions — verify step is marked failed with resolution error.
+	step, ok := run.Steps["s1"]
+	require.True(t, ok, "step s1 should exist")
+	assert.Equal(t, state.RunFailed, step.Status)
+	assert.Contains(t, step.Error, "nonexistent", "step error should mention the missing step ID")
 }
 
 func TestStepStateTransitionsSuccess(t *testing.T) {
@@ -1026,6 +1033,7 @@ func TestPlanErrorPath(t *testing.T) {
 
 func TestListRunsErrorPath(t *testing.T) {
 	// N-26: Store.ListRuns() returns error → logged, no runs dispatched.
+	// N-36: Use zap/observer to assert the error is actually logged.
 	dir := t.TempDir()
 
 	realStore := state.NewInMemoryStore(zap.NewNop())
@@ -1039,7 +1047,10 @@ func TestListRunsErrorPath(t *testing.T) {
 		return nil, nil
 	}}
 
-	sched := NewWorkflowScheduler(ms, nil, planner.NewYAMLPlanner(zap.NewNop()), exec, zap.NewNop(), dir, WithPollInterval(50*time.Millisecond))
+	core, logs := observer.New(zap.ErrorLevel)
+	observedLogger := zap.New(core)
+
+	sched := NewWorkflowScheduler(ms, nil, planner.NewYAMLPlanner(zap.NewNop()), exec, observedLogger, dir, WithPollInterval(50*time.Millisecond))
 
 	ctx := context.Background()
 	sem := make(chan struct{}, 10)
@@ -1048,4 +1059,10 @@ func TestListRunsErrorPath(t *testing.T) {
 	sched.pollAndExecute(ctx, sem)
 
 	assert.Equal(t, int64(0), exec.calls.Load(), "executor should not be called on ListRuns error")
+
+	// Verify the error was actually logged (prevents silent deletion of the log line).
+	require.Equal(t, 1, logs.Len(), "expected exactly one error log entry")
+	entry := logs.All()[0]
+	assert.Equal(t, "failed to list runs", entry.Message)
+	assert.Equal(t, zap.ErrorLevel, entry.Level)
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -872,6 +872,7 @@ func TestStepStateTransitionsFailure(t *testing.T) {
 	store := state.NewInMemoryStore(zap.NewNop())
 
 	var midRunStepStatus state.RunStatus
+	var midRunStepHasStartedAt bool
 	stepExecuting := make(chan struct{})
 	stepContinue := make(chan struct{})
 
@@ -894,14 +895,16 @@ func TestStepStateTransitionsFailure(t *testing.T) {
 	require.NoError(t, err)
 	if step, ok := run.Steps["step1"]; ok {
 		midRunStepStatus = step.Status
+		midRunStepHasStartedAt = !step.StartedAt.IsZero()
 	}
 	close(stepContinue)
 
 	// Wait for run failure.
 	run = waitForRunStatus(t, store, "fail-trans", state.RunFailed, 5*time.Second)
 
-	// Mid-execution: step was Running.
+	// Mid-execution: step was Running with StartedAt set (symmetry with success variant).
 	assert.Equal(t, state.RunRunning, midRunStepStatus, "step should be Running during execution")
+	assert.True(t, midRunStepHasStartedAt, "step StartedAt should be set during execution")
 
 	// Post-failure: step is Failed with error and both timestamps.
 	step, ok := run.Steps["step1"]
@@ -1065,4 +1068,11 @@ func TestListRunsErrorPath(t *testing.T) {
 	entry := logs.All()[0]
 	assert.Equal(t, "failed to list runs", entry.Message)
 	assert.Equal(t, zap.ErrorLevel, entry.Level)
+
+	// Verify the structured zap.Error(err) field propagates the error value.
+	// This detects regressions where the zap.Error(err) field is accidentally
+	// removed from the log call but the message string remains.
+	errVal, ok := entry.ContextMap()["error"]
+	require.True(t, ok, "log entry should contain 'error' field from zap.Error()")
+	assert.Contains(t, fmt.Sprintf("%v", errVal), "database connection lost")
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -482,6 +482,62 @@ func TestConcurrentCreateAndDelete(t *testing.T) {
 	assert.Empty(t, remaining)
 }
 
+func TestConcurrentTimestampsAndErrors(t *testing.T) {
+	// N-20: Exercise SetRunTimestamps and SetRunError under -race with concurrent goroutines.
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	const runs = 20
+	for i := 0; i < runs; i++ {
+		id := fmt.Sprintf("cte-%d", i)
+		require.NoError(t, store.CreateRun(ctx, &WorkflowRun{ID: id, WorkflowID: "wf-1"}))
+	}
+
+	var wg sync.WaitGroup
+
+	// Concurrent SetRunTimestamps writers.
+	for i := 0; i < runs; i++ {
+		wg.Add(1)
+		id := fmt.Sprintf("cte-%d", i)
+		go func(runID string) {
+			defer wg.Done()
+			now := time.Now()
+			_ = store.SetRunTimestamps(ctx, runID, &now, nil)
+		}(id)
+	}
+
+	// Concurrent SetRunError writers.
+	for i := 0; i < runs; i++ {
+		wg.Add(1)
+		id := fmt.Sprintf("cte-%d", i)
+		go func(runID string) {
+			defer wg.Done()
+			_ = store.SetRunError(ctx, runID, "concurrent error for "+runID)
+		}(id)
+	}
+
+	// Concurrent readers interleaved with writers.
+	for i := 0; i < runs; i++ {
+		wg.Add(1)
+		id := fmt.Sprintf("cte-%d", i)
+		go func(runID string) {
+			defer wg.Done()
+			_, _ = store.GetRun(ctx, runID)
+		}(id)
+	}
+
+	wg.Wait()
+
+	// Verify all runs have timestamps and errors set.
+	for i := 0; i < runs; i++ {
+		id := fmt.Sprintf("cte-%d", i)
+		got, err := store.GetRun(ctx, id)
+		require.NoError(t, err)
+		assert.False(t, got.StartedAt.IsZero(), "run %s should have StartedAt set", id)
+		assert.Equal(t, "concurrent error for "+id, got.Error, "run %s should have error set", id)
+	}
+}
+
 func TestCRUDFullLifecycle(t *testing.T) {
 	ctx := context.Background()
 	store := newTestStore(t)

--- a/tests/integration/scheduler_executor_test.go
+++ b/tests/integration/scheduler_executor_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -45,7 +45,8 @@ func TestSchedulerExecutorIntegration(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	logger := zap.NewNop()
+	// N-48: Use zaptest.NewLogger to surface diagnostic output on test failure.
+	logger := zaptest.NewLogger(t)
 
 	// --- Infrastructure ---
 	store := state.NewInMemoryStore(logger)


### PR DESCRIPTION
## RFC 0003 — Follow-up PR 7: Test Observability & Coverage Gaps

**RFC**: [0003-scheduler-executor.md](docs/rfcs/0003-scheduler-executor.md)
**Branch**: `feature/v01-test-observability`
**Depends on**: PR 5 (#27) merged

### Changes

Addresses 4 "Should Fix" post-merge findings from RFC 0003 reviews, improving test observability and coverage across 3 packages.

| Finding | File | Change |
|---------|------|--------|
| N-20 | `internal/state/state_test.go` | Add `TestConcurrentTimestampsAndErrors` — 20 concurrent goroutines exercise `SetRunTimestamps` and `SetRunError` under `-race`, matching existing concurrent test patterns |
| N-35 | `internal/scheduler/scheduler_test.go` | Add step-level assertions to `TestResolutionFailureMissingStepOutput` (`step.Status == RunFailed`, `step.Error` contains expected text), matching sibling test `TestResolutionFailureMissingVariable` |
| N-36 | `internal/scheduler/scheduler_test.go` | Replace `zap.NewNop()` with `zap/observer` in `TestListRunsErrorPath` — assert error-level log entry `"failed to list runs"` is emitted (prevents silent deletion of the log line) |
| N-48 | `tests/integration/scheduler_executor_test.go` | Replace `zap.NewNop()` with `zaptest.NewLogger(t)` — surfaces diagnostic output on integration test failure |

### Verification

- [x] `go test ./internal/state/... -v -race -cover` passes (98.9% coverage)
- [x] `go test ./internal/scheduler/... -v -race -cover` passes (87.3% coverage)
- [x] `go test ./tests/integration/... -v -race` passes
- [x] `go test ./internal/... -race -cover` — full suite green
- [x] `go vet ./internal/... ./tests/... ./cmd/...` clean
- [x] All pre-commit checks pass (6/6)
