### PR TITLE
build(proto): split make proto into go/python targets + CI staleness check (RFC 0003, PR 9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,32 @@ jobs:
       - name: Run Go tests
         run: go test ./internal/... -v -race -cover
 
+  proto-staleness:
+    name: Proto staleness check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+
+      - name: Install Go protoc plugins
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+      - name: Regenerate Go stubs
+        run: make proto-go
+
+      - name: Check for drift
+        run: git diff --exit-code internal/generated/
+
   python:
     name: Python (lint + test)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,8 @@
 # failing validation. This workflow runs the core checks on every PR and push
 # to main.
 #
-# Scope: Go build+test, Python lint+test, Rust build+clippy, config validation.
-# Proto generation and Docker builds are excluded — they require external
-# tooling (protoc, Docker) that adds complexity without scaffold-stage value.
+# Scope: Go build+test, Go proto staleness check, Python lint+test,
+# Rust build+clippy, config validation. Docker builds are excluded.
 
 name: CI
 
@@ -50,12 +49,12 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
-          version: "27.x"
+          version: "27.2"  # pin to exact version to match committed stubs
 
       - name: Install Go protoc plugins
         run: |
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.1
 
       - name: Regenerate Go stubs
         run: make proto-go

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-orchestrator build-cli build-agents proto clean test lint run validate help
+.PHONY: all build build-orchestrator build-cli build-agents proto proto-go proto-python clean test lint run validate help
 
 # ─── Config ─────────────────────────────────────────────
 GO_MODULE     := github.com/orchestr8/orchestr8
@@ -18,14 +18,22 @@ help: ## Show this help
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 # ─── Protobuf ───────────────────────────────────────────
-proto: ## Generate Go + Python code from protobuf definitions
-	@echo "→ Generating protobuf stubs..."
-	@mkdir -p $(PROTO_GO_OUT) $(PROTO_PY_OUT)
+proto: proto-go proto-python ## Generate Go + Python code from protobuf definitions
+
+proto-go: ## Generate Go gRPC stubs from protobuf definitions
+	@echo "→ Generating Go protobuf stubs..."
+	@mkdir -p $(PROTO_GO_OUT)
 	protoc --go_out=. --go-grpc_out=. \
 		--go_opt=module=$(GO_MODULE) --go-grpc_opt=module=$(GO_MODULE) \
-		--python_out=$(PROTO_PY_OUT) --grpc_python_out=$(PROTO_PY_OUT) \
 		-I $(PROTO_DIR) $(PROTO_DIR)/*.proto
-	@echo "✓ Protobuf stubs generated"
+	@echo "✓ Go protobuf stubs generated"
+
+proto-python: ## Generate Python gRPC stubs from protobuf definitions
+	@echo "→ Generating Python protobuf stubs..."
+	@mkdir -p $(PROTO_PY_OUT)
+	protoc --python_out=$(PROTO_PY_OUT) --grpc_python_out=$(PROTO_PY_OUT) \
+		-I $(PROTO_DIR) $(PROTO_DIR)/*.proto
+	@echo "✓ Python protobuf stubs generated"
 
 # ─── Build ──────────────────────────────────────────────
 build: build-orchestrator build-cli ## Build all components

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Orchestr8 Roadmap
 
-> **Last updated**: 2026-04-10  
+> **Last updated**: 2026-04-11  
 > **Current phase**: v0.1 (MVP) — ~70% complete
 
 This document tracks development progress across all phases. Update it when merging PRs or completing milestones.
@@ -38,7 +38,7 @@ RFC 0001 (State, Registry, Planner)           ✅ Done
     ↓
 RFC 0002 (REST API Server)                    ✅ Done
     ↓
-RFC 0003 (Scheduler + Executor + gRPC)        🚧 In Progress (follow-up 3/4)
+RFC 0003 (Scheduler + Executor + gRPC)        🚧 In Progress (follow-up 4/4)
     ↓
 RFC 0004 (Python Agent Server + Tools)        📋 Blocked on RFC 0003
     ↓
@@ -176,6 +176,7 @@ v0.1 Complete ─ end-to-end execution working
 | [#27](https://github.com/mkhomutov/Orchestr8/pull/27) | feat(orchestrator): wire scheduler + executor into main.go | 0003 (7/7) | 2026-04-10 |
 | [#31](https://github.com/mkhomutov/Orchestr8/pull/31) | fix(executor): additive dial options, cancellation & concurrent retry tests | 0003 follow-up (1/4) | 2026-04-10 |
 | [#32](https://github.com/mkhomutov/Orchestr8/pull/32) | test: observability improvements — concurrent race tests, log assertions, zaptest logger | 0003 follow-up (2/4) | 2026-04-11 |
+| [#33](https://github.com/mkhomutov/Orchestr8/pull/33) | fix(orchestrator): graceful shutdown drain + absolute workflowsDir | 0003 follow-up (3/4) | 2026-04-11 |
 
 ---
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -518,7 +518,7 @@ PR 5 (wiring) ✅ merged
        │
        ├──► PR 6 (executor-hardening) ✅ merged (#31)
        ├──► PR 7 (test-observability) ✅ merged (#32)
-       ├──► PR 8 (graceful-shutdown)
+       ├──► PR 8 (graceful-shutdown) ✅ merged (#33)
        └──► PR 9 (proto-tooling, optional)
 ```
 

--- a/docs/rfcs/0003-pr-plan.md
+++ b/docs/rfcs/0003-pr-plan.md
@@ -504,10 +504,10 @@ All 7 implementation PRs are merged. The following PRs address "Should Fix" post
 
 #### PR checklist
 
-- [ ] `make proto-go` generates Go stubs without Python gRPC toolchain
-- [ ] `make proto-python` generates Python stubs independently
-- [ ] `make proto` calls both targets
-- [ ] CI check detects stale generated code
+- [x] `make proto-go` generates Go stubs without Python gRPC toolchain
+- [x] `make proto-python` generates Python stubs independently
+- [x] `make proto` calls both targets
+- [x] CI check detects stale generated code
 
 ---
 


### PR DESCRIPTION
## Summary

RFC 0003 follow-up PR 9 (4/4). Addresses two **Should Fix** proto build tooling findings from the PR #21 review.

### N-02: CI proto staleness check

No automated check previously verified that generated Go stubs stay in sync with `.proto` files. This PR adds a `proto-staleness` CI job that runs `make proto-go && git diff --exit-code internal/generated/` to detect when `.proto` changes are committed without regenerating stubs.

### N-03: Split `make proto` into separate targets

`make proto` previously required both Go and Python gRPC toolchains (`protoc-gen-go`, `protoc-gen-go-grpc`, `grpcio-tools`) installed simultaneously. This PR splits it into:
- `make proto-go` — generates Go stubs only (requires Go protoc plugins)
- `make proto-python` — generates Python stubs only (requires grpcio-tools)  
- `make proto` — calls both targets (unchanged behavior for full builds)

This decouples Go development from the Python gRPC toolchain.

### Housekeeping

- Added PR #33 (graceful-shutdown) to ROADMAP merged PR history
- Updated PR plan follow-up dependency graph (PR 8 marked as merged)

## Findings Addressed

| Finding | Source | Description |
|---------|--------|-------------|
| N-02 | Review pr-021, Should Fix #1 | No CI check for proto↔stub drift |
| N-03 | Review pr-021, Should Fix #2 | `make proto` requires both Go and Python gRPC toolchains |

## Changes

| File | Change |
|------|--------|
| `Makefile` | Split `proto` target into `proto-go` + `proto-python` |
| `.github/workflows/ci.yml` | New `proto-staleness` job |
| `ROADMAP.md` | Added PR #33, updated follow-up count |
| `docs/rfcs/0003-pr-plan.md` | Marked PR 8 as merged in dependency graph |