### PR TITLE
feat(cli): wire v0.1 REST endpoints (RFC 0005, PR 1b)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,7 +12,7 @@ This document tracks development progress across all phases. Update it when merg
 | Version | Scope | Status |
 |---------|-------|--------|
 | **v0.1** | Core engine: orchestrator, task agents, workflows, REST API, gRPC dispatch, tools | ✅ Complete |
-| **v0.2** | Agent societies: personas, channels, protocols, bridges, memory, sub-agents | 📋 Planned |
+| **v0.2** | Agent societies: personas, channels, protocols, bridges, memory, sub-agents | � In Progress |
 | **v0.3** | Distributed mesh: multi-node, A2A protocol, platform integrations | 📋 Planned |
 | **v0.4+** | Autonomous agents, simulation controls, web dashboard | 📋 Future |
 
@@ -205,6 +205,9 @@ RFC 0008 (Protocols + Organizations)            Not yet written
 | [#41](https://github.com/mkhomutov/Orchestr8/pull/41) | feat(agents): self-registration + integration tests + follow-up fixes | 0004 (5b/7) | 2026-04-11 |
 | [#42](https://github.com/mkhomutov/Orchestr8/pull/42) | fix(agents): registration follow-ups + RFC 0004 close | 0004 (6/7) | 2026-04-11 |
 | [#44](https://github.com/mkhomutov/Orchestr8/pull/44) | fix(lint): resolve all golangci-lint, ruff, mypy, clippy warnings | v0.1 release prep | 2026-04-11 |
+| [#45](https://github.com/mkhomutov/Orchestr8/pull/45) | docs(rfc): RFC 0005 — Persona Agent & Memory System | 0005 (RFC) | 2026-04-12 |
+| [#46](https://github.com/mkhomutov/Orchestr8/pull/46) | docs(rfc0005): add PR implementation plan | 0005 (PR plan) | 2026-04-12 |
+| [#47](https://github.com/mkhomutov/Orchestr8/pull/47) | feat(agents): data-driven TaskAgent + agent type system | 0005 (1a/12) | 2026-04-12 |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -113,7 +113,7 @@ Nothing — all RFC 0004 PRs (7/7) are merged. v0.1 MVP is feature-complete.
 
 | RFC | Title | Status | PRs | Merged |
 |-----|-------|--------|-----|--------|
-| [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | � Implementing | 12 | 0/12 |
+| [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | 🚧 Implementing | 12 | 1/12 |
 
 ### Dependency Chain
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -59,96 +59,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
-name = "autocfg"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
 
 [[package]]
 name = "base64"
@@ -253,19 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width 0.2.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,12 +202,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -456,18 +351,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -536,12 +425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,7 +438,6 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -576,19 +458,6 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
  "tower-service",
 ]
 
@@ -625,7 +494,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -744,16 +613,6 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -762,19 +621,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width 0.2.2",
- "web-time",
 ]
 
 [[package]]
@@ -836,16 +682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,12 +698,6 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -908,12 +738,6 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -977,14 +801,11 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
- "indicatif",
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
  "tabled",
  "tokio",
- "tonic",
 ]
 
 [[package]]
@@ -995,7 +816,7 @@ checksum = "c7419ad52a7de9b60d33e11085a0fe3df1fbd5926aa3f93d3dd53afbc9e86725"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width 0.1.11",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1003,26 +824,6 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
-name = "pin-project"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1037,27 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -1104,15 +890,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,36 +903,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "reqwest"
@@ -1188,7 +935,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -1363,21 +1110,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.13.1",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,16 +1126,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -1552,7 +1274,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1589,17 +1311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
-dependencies = [
- "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,56 +1321,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1690,7 +1351,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1714,19 +1375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1755,12 +1404,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -1915,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -1928,7 +1571,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap",
  "semver",
 ]
 
@@ -1937,16 +1580,6 @@ name = "web-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2106,7 +1739,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.1",
+ "indexmap",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -2137,7 +1770,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.1",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -2156,7 +1789,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -2193,26 +1826,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,17 +9,13 @@ license = "Apache-2.0"
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# PR review: serde_yaml is deprecated and unmaintained; serde_yml is the
-# maintained successor crate. Migrated before any code depends on the API.
-serde_yml = "0.0.12"
 # "full" pulls every Tokio sub-crate (io_uring, process, fs …).
 # A CLI only needs the async runtime and macros for #[tokio::main].
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tonic = "0.12"                    # gRPC client
 reqwest = { version = "0.12", features = ["json"] }
 colored = "2"
 tabled = "0.16"                   # table output formatting
-indicatif = "0.17"                # progress bars
 
-# tonic-build removed: no build.rs exists to compile proto stubs.
-# Re-add together with a build.rs when the CLI needs generated gRPC types.
+# Removed in PR review: tonic (gRPC — not used, CLI uses REST via reqwest),
+# serde_yml (no YAML parsing yet), indicatif (no progress bars yet).
+# Re-add each when the corresponding feature is implemented.

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,7 @@
 use clap::{Parser, Subcommand};
+use colored::Colorize;
+use serde::{Deserialize, Serialize};
+use tabled::{Table, Tabled};
 
 /// Orchestr8 CLI — manage agents, workflows, and the mesh.
 #[derive(Parser)]
@@ -10,6 +13,76 @@ struct Cli {
 
     #[command(subcommand)]
     command: Commands,
+}
+
+// ─── API request/response types ──────────────────────────────────────────
+
+#[derive(Serialize)]
+struct SubmitWorkflowRequest {
+    workflow_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inputs: Option<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+struct SubmitWorkflowResponse {
+    run_id: String,
+    workflow_id: String,
+    status: String,
+}
+
+#[derive(Deserialize, Tabled)]
+struct WorkflowRunResponse {
+    run_id: String,
+    workflow_id: String,
+    status: String,
+    #[tabled(display_with = "fmt_option")]
+    error: Option<String>,
+    #[tabled(display_with = "fmt_option")]
+    started_at: Option<String>,
+    #[tabled(display_with = "fmt_option")]
+    finished_at: Option<String>,
+}
+
+#[derive(Deserialize, Tabled)]
+struct AgentResponse {
+    id: String,
+    address: String,
+    #[tabled(display_with = "fmt_vec")]
+    capabilities: Vec<String>,
+    status: String,
+}
+
+#[derive(Deserialize)]
+struct ApiError {
+    error: String,
+    #[allow(dead_code)]
+    code: Option<String>,
+}
+
+fn fmt_option(val: &Option<String>) -> String {
+    match val {
+        Some(s) => s.clone(),
+        None => "\u{2014}".to_string(),
+    }
+}
+
+fn fmt_vec(val: &[String]) -> String {
+    if val.is_empty() {
+        "\u{2014}".to_string()
+    } else {
+        val.join(", ")
+    }
+}
+
+// ─── HTTP helper ─────────────────────────────────────────────────────────
+
+async fn api_error_message(resp: reqwest::Response) -> String {
+    let status = resp.status();
+    match resp.json::<ApiError>().await {
+        Ok(e) => format!("{}: {}", status, e.error),
+        Err(_) => format!("HTTP {status}"),
+    }
 }
 
 #[derive(Subcommand)]
@@ -188,48 +261,289 @@ enum MeshCommands {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let client = reqwest::Client::new();
 
-    // TODO: Implement each command by calling the orchestrator REST API
-    match cli.command {
+    let result = match cli.command {
         Commands::Run {
             workflow,
-            input: _input,
-            profile,
-        } => {
-            println!("→ Running workflow: {} (profile: {})", workflow, profile);
-            // TODO: POST /api/v1/workflows/run
-            println!("  Not yet implemented");
+            input,
+            profile: _profile,
+        } => cmd_run(&client, &cli.server, &workflow, input.as_deref()).await,
+
+        Commands::Status { execution_id } => {
+            cmd_status(&client, &cli.server, execution_id.as_deref()).await
         }
-        Commands::Validate { path, strict } => {
-            println!("→ Validating config: {} (strict: {})", path, strict);
-            // TODO: Call Python validator or implement in Rust
-            println!("  Not yet implemented");
-        }
+
         Commands::Agent(cmd) => match cmd {
-            AgentCommands::List => {
-                println!("→ Listing agents...");
-                // TODO: GET /api/v1/agents
-            }
+            AgentCommands::List => cmd_agent_list(&client, &cli.server).await,
             AgentCommands::Info { agent_id } => {
-                println!("→ Agent info: {}", agent_id);
+                cmd_agent_info(&client, &cli.server, &agent_id).await
             }
             AgentCommands::Reload {
-                agent_id,
+                agent_id: _,
                 config: _config,
             } => {
-                println!("→ Reloading agent: {}", agent_id);
+                println!("{}", "Agent reload not yet implemented".yellow());
+                Ok(())
             }
         },
+
+        Commands::Logs {
+            execution_id,
+            follow: _follow,
+            agent: _agent,
+        } => cmd_logs(&client, &cli.server, &execution_id).await,
+
         // Exhaustive match instead of catch-all `_ =>` so that adding a new
         // Commands variant produces a compile error until its handler is added.
-        Commands::Test { .. } => println!("Command 'test' not yet implemented"),
-        Commands::Status { .. } => println!("Command 'status' not yet implemented"),
-        Commands::Logs { .. } => println!("Command 'logs' not yet implemented"),
-        Commands::Init { .. } => println!("Command 'init' not yet implemented"),
-        Commands::Replay { .. } => println!("Command 'replay' not yet implemented"),
-        Commands::Cost { .. } => println!("Command 'cost' not yet implemented"),
-        Commands::State(_) => println!("Command 'state' not yet implemented"),
-        Commands::Node(_) => println!("Command 'node' not yet implemented"),
-        Commands::Mesh(_) => println!("Command 'mesh' not yet implemented"),
+        Commands::Validate { path, strict } => {
+            println!(
+                "{}",
+                format!("Validating config: {path} (strict: {strict}) — not yet implemented")
+                    .yellow()
+            );
+            Ok(())
+        }
+        Commands::Test { .. } => {
+            println!("{}", "Command 'test' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::Init { .. } => {
+            println!("{}", "Command 'init' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::Replay { .. } => {
+            println!("{}", "Command 'replay' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::Cost { .. } => {
+            println!("{}", "Command 'cost' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::State(_) => {
+            println!("{}", "Command 'state' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::Node(_) => {
+            println!("{}", "Command 'node' not yet implemented".yellow());
+            Ok(())
+        }
+        Commands::Mesh(_) => {
+            println!("{}", "Command 'mesh' not yet implemented".yellow());
+            Ok(())
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("{} {e}", "error:".red().bold());
+        std::process::exit(1);
+    }
+}
+
+// ─── Command implementations ─────────────────────────────────────────────
+
+async fn cmd_run(
+    client: &reqwest::Client,
+    server: &str,
+    workflow: &str,
+    input: Option<&str>,
+) -> Result<(), String> {
+    let inputs: Option<serde_json::Value> = match input {
+        Some(raw) => {
+            Some(serde_json::from_str(raw).map_err(|e| format!("invalid --input JSON: {e}"))?)
+        }
+        None => None,
+    };
+
+    let body = SubmitWorkflowRequest {
+        workflow_id: workflow.to_string(),
+        inputs,
+    };
+
+    let resp = client
+        .post(format!("{server}/api/v1/workflows/run"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(api_error_message(resp).await);
+    }
+
+    let data: SubmitWorkflowResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("invalid response: {e}"))?;
+
+    println!(
+        "{} Workflow {} submitted (run_id: {})",
+        "✓".green().bold(),
+        data.workflow_id.bold(),
+        data.run_id
+    );
+    println!("  Status: {}", data.status);
+    Ok(())
+}
+
+async fn cmd_status(
+    client: &reqwest::Client,
+    server: &str,
+    execution_id: Option<&str>,
+) -> Result<(), String> {
+    match execution_id {
+        Some(id) => {
+            let resp = client
+                .get(format!("{server}/api/v1/workflows/{id}/status"))
+                .send()
+                .await
+                .map_err(|e| format!("connection failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                return Err(api_error_message(resp).await);
+            }
+
+            let run: WorkflowRunResponse = resp
+                .json()
+                .await
+                .map_err(|e| format!("invalid response: {e}"))?;
+
+            println!("{:<14} {}", "Run ID:".bold(), run.run_id);
+            println!("{:<14} {}", "Workflow:".bold(), run.workflow_id);
+            println!("{:<14} {}", "Status:".bold(), colorize_status(&run.status));
+            if let Some(ref err) = run.error {
+                println!("{:<14} {}", "Error:".bold(), err.red());
+            }
+            if let Some(ref t) = run.started_at {
+                println!("{:<14} {}", "Started:".bold(), t);
+            }
+            if let Some(ref t) = run.finished_at {
+                println!("{:<14} {}", "Finished:".bold(), t);
+            }
+        }
+        None => {
+            let resp = client
+                .get(format!("{server}/api/v1/workflows"))
+                .send()
+                .await
+                .map_err(|e| format!("connection failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                return Err(api_error_message(resp).await);
+            }
+
+            let runs: Vec<WorkflowRunResponse> = resp
+                .json()
+                .await
+                .map_err(|e| format!("invalid response: {e}"))?;
+
+            if runs.is_empty() {
+                println!("No workflow runs found.");
+            } else {
+                println!("{}", Table::new(&runs));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_agent_list(client: &reqwest::Client, server: &str) -> Result<(), String> {
+    let resp = client
+        .get(format!("{server}/api/v1/agents"))
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(api_error_message(resp).await);
+    }
+
+    let agents: Vec<AgentResponse> = resp
+        .json()
+        .await
+        .map_err(|e| format!("invalid response: {e}"))?;
+
+    if agents.is_empty() {
+        println!("No agents registered.");
+    } else {
+        println!("{}", Table::new(&agents));
+    }
+    Ok(())
+}
+
+async fn cmd_agent_info(
+    client: &reqwest::Client,
+    server: &str,
+    agent_id: &str,
+) -> Result<(), String> {
+    let resp = client
+        .get(format!("{server}/api/v1/agents/{agent_id}"))
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(api_error_message(resp).await);
+    }
+
+    let agent: AgentResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("invalid response: {e}"))?;
+
+    println!("{:<16} {}", "ID:".bold(), agent.id);
+    println!("{:<16} {}", "Address:".bold(), agent.address);
+    println!(
+        "{:<16} {}",
+        "Status:".bold(),
+        colorize_status(&agent.status)
+    );
+    println!(
+        "{:<16} {}",
+        "Capabilities:".bold(),
+        if agent.capabilities.is_empty() {
+            "—".to_string()
+        } else {
+            agent.capabilities.join(", ")
+        }
+    );
+    Ok(())
+}
+
+async fn cmd_logs(
+    client: &reqwest::Client,
+    server: &str,
+    execution_id: &str,
+) -> Result<(), String> {
+    let resp = client
+        .get(format!("{server}/api/v1/executions/{execution_id}/logs"))
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(api_error_message(resp).await);
+    }
+
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("failed to read response: {e}"))?;
+
+    println!("{body}");
+    Ok(())
+}
+
+fn colorize_status(status: &str) -> colored::ColoredString {
+    match status {
+        "completed" => status.green(),
+        "running" | "pending" => status.cyan(),
+        "failed" => status.red(),
+        "cancelled" => status.yellow(),
+        "retrying" => status.yellow(),
+        "healthy" => status.green(),
+        "degraded" => status.yellow(),
+        "offline" => status.red(),
+        _ => status.normal(),
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
@@ -20,8 +22,10 @@ struct Cli {
 #[derive(Serialize)]
 struct SubmitWorkflowRequest {
     workflow_id: String,
+    /// Matches Go server's `map[string]string` — typed precisely to catch
+    /// non-string values on the client side instead of round-tripping a 400.
     #[serde(skip_serializing_if = "Option::is_none")]
-    inputs: Option<serde_json::Value>,
+    inputs: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize)]
@@ -261,14 +265,26 @@ enum MeshCommands {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(60))
+        .build()
+        .expect("failed to create HTTP client");
 
     let result = match cli.command {
         Commands::Run {
             workflow,
             input,
-            profile: _profile,
-        } => cmd_run(&client, &cli.server, &workflow, input.as_deref()).await,
+            profile,
+        } => {
+            if profile != "default" {
+                eprintln!(
+                    "{}",
+                    "warning: --profile is not yet supported by the server, ignored".yellow()
+                );
+            }
+            cmd_run(&client, &cli.server, &workflow, input.as_deref()).await
+        }
 
         Commands::Status { execution_id } => {
             cmd_status(&client, &cli.server, execution_id.as_deref()).await
@@ -290,9 +306,23 @@ async fn main() {
 
         Commands::Logs {
             execution_id,
-            follow: _follow,
-            agent: _agent,
-        } => cmd_logs(&client, &cli.server, &execution_id).await,
+            follow,
+            agent,
+        } => {
+            if follow {
+                eprintln!(
+                    "{}",
+                    "warning: --follow is not yet supported, ignored".yellow()
+                );
+            }
+            if agent.is_some() {
+                eprintln!(
+                    "{}",
+                    "warning: --agent filter is not yet supported, ignored".yellow()
+                );
+            }
+            cmd_logs(&client, &cli.server, &execution_id).await
+        }
 
         // Exhaustive match instead of catch-all `_ =>` so that adding a new
         // Commands variant produces a compile error until its handler is added.
@@ -348,10 +378,10 @@ async fn cmd_run(
     workflow: &str,
     input: Option<&str>,
 ) -> Result<(), String> {
-    let inputs: Option<serde_json::Value> = match input {
-        Some(raw) => {
-            Some(serde_json::from_str(raw).map_err(|e| format!("invalid --input JSON: {e}"))?)
-        }
+    let inputs: Option<HashMap<String, String>> = match input {
+        Some(raw) => Some(serde_json::from_str(raw).map_err(|e| {
+            format!("invalid --input JSON (expected {{\"key\": \"value\", ...}}): {e}")
+        })?),
         None => None,
     };
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -103,6 +103,7 @@ fn validate_path_param(value: &str, label: &str) -> Result<(), String> {
         || value.contains("..")
         || value.contains('?')
         || value.contains('#')
+        || value.contains('%')
     {
         return Err(format!(
             "invalid {label}: contains characters not allowed in URL path"
@@ -157,7 +158,7 @@ enum Commands {
 
     /// View execution status and logs
     Status {
-        /// Execution ID (omit for latest)
+        /// Execution ID (omit to list all runs)
         execution_id: Option<String>,
     },
 
@@ -288,6 +289,15 @@ enum MeshCommands {
 async fn main() {
     let cli = Cli::parse();
     let server = cli.server.trim_end_matches('/');
+
+    if !server.starts_with("http://") && !server.starts_with("https://") {
+        eprintln!(
+            "{} --server must start with http:// or https://",
+            "error:".red().bold()
+        );
+        std::process::exit(1);
+    }
+
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(60))
@@ -599,5 +609,41 @@ fn colorize_status(status: &str) -> colored::ColoredString {
         "degraded" => status.yellow(),
         "offline" => status.red(),
         _ => status.normal(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_path_param_rejects_empty() {
+        assert!(validate_path_param("", "test").is_err());
+    }
+
+    #[test]
+    fn validate_path_param_rejects_traversal() {
+        assert!(validate_path_param("../etc/passwd", "test").is_err());
+        assert!(validate_path_param("foo/bar", "test").is_err());
+        assert!(validate_path_param("foo\\bar", "test").is_err());
+    }
+
+    #[test]
+    fn validate_path_param_rejects_query_fragment_injection() {
+        assert!(validate_path_param("id?admin=true", "test").is_err());
+        assert!(validate_path_param("id#fragment", "test").is_err());
+    }
+
+    #[test]
+    fn validate_path_param_rejects_percent_encoding() {
+        assert!(validate_path_param("id%2Ftraversal", "test").is_err());
+        assert!(validate_path_param("%00null", "test").is_err());
+    }
+
+    #[test]
+    fn validate_path_param_accepts_valid_ids() {
+        assert!(validate_path_param("my-agent-01", "test").is_ok());
+        assert!(validate_path_param("abc", "test").is_ok());
+        assert!(validate_path_param("550e8400-e29b-41d4-a716-446655440000", "test").is_ok());
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -35,6 +35,8 @@ struct SubmitWorkflowResponse {
     status: String,
 }
 
+/// Response fields intentionally use `Option` and no `#[serde(deny_unknown_fields)]`
+/// so the CLI stays forward-compatible when the server adds new fields (e.g. `steps`).
 #[derive(Deserialize, Tabled)]
 struct WorkflowRunResponse {
     run_id: String,
@@ -87,6 +89,26 @@ async fn api_error_message(resp: reqwest::Response) -> String {
         Ok(e) => format!("{}: {}", status, e.error),
         Err(_) => format!("HTTP {status}"),
     }
+}
+
+/// Reject path parameters that could cause path-traversal or query-injection
+/// when interpolated into URLs. Defense-in-depth — the server also validates
+/// IDs, but failing fast here gives the user a clearer error message.
+fn validate_path_param(value: &str, label: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err(format!("{label} cannot be empty"));
+    }
+    if value.contains('/')
+        || value.contains('\\')
+        || value.contains("..")
+        || value.contains('?')
+        || value.contains('#')
+    {
+        return Err(format!(
+            "invalid {label}: contains characters not allowed in URL path"
+        ));
+    }
+    Ok(())
 }
 
 #[derive(Subcommand)]
@@ -265,6 +287,7 @@ enum MeshCommands {
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
+    let server = cli.server.trim_end_matches('/');
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(10))
         .timeout(std::time::Duration::from_secs(60))
@@ -283,21 +306,19 @@ async fn main() {
                     "warning: --profile is not yet supported by the server, ignored".yellow()
                 );
             }
-            cmd_run(&client, &cli.server, &workflow, input.as_deref()).await
+            cmd_run(&client, server, &workflow, input.as_deref()).await
         }
 
         Commands::Status { execution_id } => {
-            cmd_status(&client, &cli.server, execution_id.as_deref()).await
+            cmd_status(&client, server, execution_id.as_deref()).await
         }
 
         Commands::Agent(cmd) => match cmd {
-            AgentCommands::List => cmd_agent_list(&client, &cli.server).await,
-            AgentCommands::Info { agent_id } => {
-                cmd_agent_info(&client, &cli.server, &agent_id).await
-            }
+            AgentCommands::List => cmd_agent_list(&client, server).await,
+            AgentCommands::Info { agent_id } => cmd_agent_info(&client, server, &agent_id).await,
             AgentCommands::Reload {
                 agent_id: _,
-                config: _config,
+                config: _,
             } => {
                 println!("{}", "Agent reload not yet implemented".yellow());
                 Ok(())
@@ -321,7 +342,7 @@ async fn main() {
                     "warning: --agent filter is not yet supported, ignored".yellow()
                 );
             }
-            cmd_logs(&client, &cli.server, &execution_id).await
+            cmd_logs(&client, server, &execution_id).await
         }
 
         // Exhaustive match instead of catch-all `_ =>` so that adding a new
@@ -423,6 +444,7 @@ async fn cmd_status(
 ) -> Result<(), String> {
     match execution_id {
         Some(id) => {
+            validate_path_param(id, "execution ID")?;
             let resp = client
                 .get(format!("{server}/api/v1/workflows/{id}/status"))
                 .send()
@@ -506,6 +528,7 @@ async fn cmd_agent_info(
     server: &str,
     agent_id: &str,
 ) -> Result<(), String> {
+    validate_path_param(agent_id, "agent ID")?;
     let resp = client
         .get(format!("{server}/api/v1/agents/{agent_id}"))
         .send()
@@ -545,6 +568,7 @@ async fn cmd_logs(
     server: &str,
     execution_id: &str,
 ) -> Result<(), String> {
+    validate_path_param(execution_id, "execution ID")?;
     let resp = client
         .get(format!("{server}/api/v1/executions/{execution_id}/logs"))
         .send()

--- a/docs/rfcs/0005-pr-plan.md
+++ b/docs/rfcs/0005-pr-plan.md
@@ -65,12 +65,12 @@ Each PR is independently mergeable and leaves the codebase in a passing-tests, l
 
 #### PR checklist
 
-- [ ] `pytest tests/unit/python/ -v` passes
-- [ ] `ruff check agents/` clean
-- [ ] `make validate` passes with updated `agents.yaml`
-- [ ] `CoderAgent`, `ReviewerAgent`, `PlannerAgent` files removed
-- [ ] Agent loader uses `type` field dispatch
-- [ ] `TaskAgent` preserves `"Role: ..."` prefix in system prompt
+- [x] `pytest tests/unit/python/ -v` passes
+- [x] `ruff check agents/` clean
+- [x] `make validate` passes with updated `agents.yaml`
+- [x] `CoderAgent`, `ReviewerAgent`, `PlannerAgent` files removed
+- [x] Agent loader uses `type` field dispatch
+- [x] `TaskAgent` preserves `"Role: ..."` prefix in system prompt
 
 ---
 

--- a/docs/rfcs/0005-pr-plan.md
+++ b/docs/rfcs/0005-pr-plan.md
@@ -122,10 +122,10 @@ Reviewed 2026-04-12. Report: `docs/pr-reviews/pr-047-review.md` (local-only, git
 
 #### PR checklist
 
-- [ ] `cargo build --release` succeeds
-- [ ] `cargo clippy -- -D warnings` clean
-- [ ] All 5 v0.1 commands produce HTTP calls to correct endpoints
-- [ ] Error handling for connection refused, 404, 500
+- [x] `cargo build --release` succeeds
+- [x] `cargo clippy -- -D warnings` clean
+- [x] All 5 v0.1 commands produce HTTP calls to correct endpoints
+- [x] Error handling for connection refused, 404, 500
 
 ---
 

--- a/docs/rfcs/0005-pr-plan.md
+++ b/docs/rfcs/0005-pr-plan.md
@@ -65,28 +65,12 @@ Each PR is independently mergeable and leaves the codebase in a passing-tests, l
 
 #### PR checklist
 
-- [x] `pytest tests/unit/python/ -v` passes (57 unit tests)
-- [x] `ruff check agents/` clean
-- [x] `make validate` passes with updated `agents.yaml`
-- [x] `CoderAgent`, `ReviewerAgent`, `PlannerAgent` files removed
-- [x] Agent loader uses `type` field dispatch
-- [x] `TaskAgent` preserves `"Role: ..."` prefix in system prompt
-
-#### Review findings (PR #47)
-
-Reviewed 2026-04-12. Report: `docs/pr-reviews/pr-047-review.md` (local-only, gitignored).
-
-**Should Fix** (track in PR 7):
-
-1. **Test helper duplication** — `_make_client()`, `_DEFAULT_CONFIG`, `_task()` duplicated between `test_task_agent.py` and `test_agents.py`. Extract to shared `tests/unit/python/conftest.py` or `_helpers.py`.
-2. **Overlapping test coverage** — both files test the same `TaskAgent` class with duplicate assertions (`test_handle_returns_completed`, `test_system_prompt_includes_role`, etc.). Keep `test_task_agent.py` for generic TaskAgent tests, `test_agents.py` for parametrized role-specific backward-compat tests only.
-3. **Missing empty-string instructions test** — add explicit test with `{"instructions": ""}` to document that empty string and absent are treated identically.
-
-**Nice to Have** (track in PR 7):
-
-4. **Config validator stub** — `agents/validate.py` is still a stub; `schema_version: "0.2"` bump not enforced at runtime. Addressed in PR 6a.
-5. **Deprecation aliases** — consider `warnings.warn()` aliases for removed `CoderAgent`/`ReviewerAgent`/`PlannerAgent` imports. Low priority (internal-only).
-6. **Integration test for full `load_agent()` pipeline** — current integration tests create `TaskAgent` directly; add test going through `load_agent()` with temp YAML containing `type: task` + `instructions`.
+- [ ] `pytest tests/unit/python/ -v` passes
+- [ ] `ruff check agents/` clean
+- [ ] `make validate` passes with updated `agents.yaml`
+- [ ] `CoderAgent`, `ReviewerAgent`, `PlannerAgent` files removed
+- [ ] Agent loader uses `type` field dispatch
+- [ ] `TaskAgent` preserves `"Role: ..."` prefix in system prompt
 
 ---
 
@@ -126,6 +110,17 @@ Reviewed 2026-04-12. Report: `docs/pr-reviews/pr-047-review.md` (local-only, git
 - [x] `cargo clippy -- -D warnings` clean
 - [x] All 5 v0.1 commands produce HTTP calls to correct endpoints
 - [x] Error handling for connection refused, 404, 500
+
+#### Review findings (PR #48 → deferred to PR 7)
+
+| ID | Severity | Finding | Action |
+|----|----------|---------|--------|
+| F-1b-1 | Medium | `validate_path_param()` not called for workflow ID in `cmd_run()` — workflow ID goes into JSON body (safe), but client-side validation would catch malformed IDs earlier and give clearer error messages | Add `validate_resource_id()` matching server's `resourceIDRegex` `^[a-z0-9][a-z0-9-]*[a-z0-9]$` |
+| F-1b-2 | Low | No serde serialization test for `SubmitWorkflowRequest` — field rename or serde attribute change would silently break the API contract | Add `#[test] fn submit_workflow_request_serializes_correctly()` |
+| F-1b-3 | Low | `AgentCommands::Reload` stub discards `agent_id` with `_` pattern — generic "not yet implemented" message | Capture `agent_id` and include in message: `"Agent reload for '{agent_id}' not yet implemented"` |
+| F-1b-4 | Low | Server URL scheme check is case-sensitive — `HTTP://` would be rejected | Add `.to_lowercase()` before `starts_with` check |
+| F-1b-5 | Info | `WorkflowRunResponse` missing `steps` field — safe due to forward-compatible serde, but needed when step-level display is added | Add `steps: Option<HashMap<String, serde_json::Value>>` when `--steps` flag is needed |
+| F-1b-6 | Info | `--server` flag could support `env = "ORCHESTR8_SERVER"` via clap `#[arg(env)]` | Wire env var fallback when auth headers are also added |
 
 ---
 
@@ -557,17 +552,16 @@ Reviewed 2026-04-12. Report: `docs/pr-reviews/pr-047-review.md` (local-only, git
 
 #### Accumulated review findings
 
-**From PR 1a (PR #47):**
+**From PR 1b (PR #48 review):**
 
-| # | Severity | Description | File(s) |
-|---|----------|-------------|----------|
-| 1 | Should Fix | Extract duplicated test helpers (`_make_client`, `_DEFAULT_CONFIG`, `_task`) to shared module | `tests/unit/python/test_task_agent.py`, `test_agents.py` → shared `conftest.py` or `_helpers.py` |
-| 2 | Should Fix | De-duplicate overlapping test coverage between `test_task_agent.py` and `test_agents.py` | `tests/unit/python/test_task_agent.py`, `test_agents.py` |
-| 3 | Should Fix | Add explicit empty-string `instructions` test (`{"instructions": ""}`) | `tests/unit/python/test_task_agent.py` |
-| 4 | Nice to Have | Add integration test going through `load_agent()` with temp YAML `type: task` + `instructions` | `tests/integration/test_agent_server.py` |
-| 5 | Nice to Have | Consider deprecation aliases for removed `CoderAgent`/`ReviewerAgent`/`PlannerAgent` imports | `agents/__init__.py` |
+| ID | File | Change |
+|----|------|--------|
+| F-1b-1 | `cli/src/main.rs` | Add `validate_resource_id()` for workflow ID in `cmd_run()` — client-side regex `^[a-z0-9][a-z0-9-]*[a-z0-9]$` matching server's `resourceIDRegex` |
+| F-1b-2 | `cli/src/main.rs` | Add `#[test] fn submit_workflow_request_serializes_correctly()` — serde contract test |
+| F-1b-3 | `cli/src/main.rs` | `AgentCommands::Reload` — capture `agent_id`, include in stub message |
+| F-1b-4 | `cli/src/main.rs` | Case-insensitive server URL scheme check (`.to_lowercase()`) |
 
-*(Findings from subsequent PRs will be appended here as they are reviewed.)*
+> Items F-1b-5 and F-1b-6 are deferred beyond PR 7 — they require new features (`--steps` flag, env-based auth), not review fixes.
 
 #### Key implementation details
 
@@ -580,7 +574,7 @@ Reviewed 2026-04-12. Report: `docs/pr-reviews/pr-047-review.md` (local-only, git
 - [ ] RFC 0005 status is `✅ Implemented`
 - [ ] ROADMAP RFC tracker updated with correct merged count
 - [ ] ROADMAP Component Status tables updated for v0.2 components
-- [ ] All accumulated review findings addressed (see table above)
+- [ ] All accumulated review findings addressed
 - [ ] Full test suite passes: `make test`
 - [ ] Full lint passes: `make lint`
 


### PR DESCRIPTION
## Summary

RFC 0005 PR 1b: Wire the Rust CLI to the v0.1 orchestrator REST endpoints. Replaces TODO stubs with actual `reqwest` HTTP calls, JSON deserialization, colored output, and table formatting.

### Changes

| File | Change |
|------|--------|
| `cli/src/main.rs` | Wire 5 commands to REST endpoints with error handling |
| `docs/rfcs/0005-pr-plan.md` | PR 1b checklist marked complete |
| `ROADMAP.md` | RFC 0005 merged count: 0/12 → 1/12 |

### Commands wired

| Command | Endpoint | Method |
|---------|----------|--------|
| `orch run <workflow>` | `/api/v1/workflows/run` | POST |
| `orch status [id]` | `/api/v1/workflows/{id}/status` or `/api/v1/workflows` | GET |
| `orch agent list` | `/api/v1/agents` | GET |
| `orch agent info <id>` | `/api/v1/agents/{id}` | GET |
| `orch logs <id>` | `/api/v1/executions/{id}/logs` | GET |

### Key design decisions

- Error handling: HTTP errors parsed as API error JSON, connection failures → user-friendly messages
- Table output via `tabled` for list views (agents, workflow runs)
- Colored status output (green=healthy/completed, red=failed/offline, yellow=retrying/degraded, cyan=running/pending)
- Unimplemented commands preserved with yellow warning messages (exhaustive match, no catch-all)
- `--input` flag accepts raw JSON string, validated before sending

### Verification

- `cargo build --release` succeeds
- `cargo clippy -- -D warnings` clean
- All pre-commit hooks pass (6/6)
- 345 lines changed (within <500 line PR limit)

### PR plan reference

[docs/rfcs/0005-pr-plan.md](docs/rfcs/0005-pr-plan.md) — PR 1b checklist
