### PR TITLE
feat: wire execution limits through executor and scheduler (RFC 0006 PR 1b)

### DIFF
--- a/docs/rfcs/0006-pr-plan.md
+++ b/docs/rfcs/0006-pr-plan.md
@@ -148,12 +148,28 @@ PR 6 (RFC close)
 
 #### PR checklist
 
-- [ ] `go test ./internal/executor/ -v -race` passes
-- [ ] `go test ./internal/scheduler/ -v -race` passes
-- [ ] `go test ./internal/registry/ -v -race` passes
-- [ ] `ExecuteRequest` includes `StepLimits`
-- [ ] `TaskConfig` fully populated (no zero-value `MaxLlmCalls`/`MaxTokens`)
-- [ ] Three-level cascade verified in tests
+- [x] `go test ./internal/executor/ -v -race` passes
+- [x] `go test ./internal/scheduler/ -v -race` passes
+- [x] `go test ./internal/registry/ -v -race` passes
+- [x] `ExecuteRequest` includes `StepLimits`
+- [x] `TaskConfig` fully populated (no zero-value `MaxLlmCalls`/`MaxTokens`)
+- [x] Three-level cascade verified in tests
+
+#### Review Findings (PR #81)
+
+**Addressed in PR 2 (planned):**
+
+1. **F-01 (Medium) — gRPC call timeout vs `TaskConfig.TimeoutSeconds` mismatch** — `e.timeout` (30s default) controls the actual `context.WithTimeout` in `dispatch()`, while `req.Limits.TimeoutSeconds` (now correctly populated from the three-level cascade) is only sent in the `TaskConfig` proto. An agent configured with a 300s step timeout receives that value in `TaskConfig` but gets its gRPC call cancelled after 30s. PR 2 explicitly replaces static per-executor timeouts with derived deadlines (`rpc_timeout = step.TimeoutSeconds + transport_margin`) — this finding is subsumed by that work. *(Location: `internal/executor/executor.go` L156, L226)*
+
+**Deferred to PR 5:**
+
+2. **F-02 (Low) — `int` → `int32` truncation without bounds check** — `MaxLlmCalls`, `MaxTokens`, and `TimeoutSeconds` are cast from `int` to `int32` without overflow guards. Values exceeding `math.MaxInt32` would silently wrap. In practice bounded by config, but a clamp or validation in the planner is safer. *(Location: `internal/executor/executor.go` L154–156)*
+3. **F-04 (Low) — Negative limit values silently ignored** — Negative step/agent config values pass the `> 0` check as false and fall through to defaults without any warning. While the planner rejects negative values at parse time (PR 1a), agent-level limits come from the registry and are not validated. Add negative-value rejection to `resolveStepLimits()` or to `AgentInfo` registration. *(Location: `internal/scheduler/scheduler.go` L407–430)*
+4. **F-05 (Nit) — Redundant `TestExecuteTask_PopulatesTaskConfig_AllFields`** — Nearly identical to the updated `TestExecuteTask_PopulatesTaskConfig`; both verify `StepLimits` → `TaskConfig` field mapping with different numbers. Consolidate or delete the duplicate to reduce maintenance surface. *(Location: `internal/executor/executor_test.go`)*
+
+**Info (no action required):**
+
+5. **F-03 (Design) — Zero as "not configured" prevents explicit zero limits** — The `> 0` cascade convention means it is impossible to set a limit to 0 at the agent or step level. Intentional for v0.1/v0.2; would require pointer types or sentinel values to change. No action.
 
 ---
 
@@ -453,6 +469,9 @@ Review findings accumulated during PRs 1a–4b. Findings will be recorded per-PR
 | PR 1a (#79) | 3 | Multi-step limit inheritance test (2+ steps, partial limits) | Low |
 | PR 1a (#79) | 4 | Schema description parity — add `description` to workflow schema step-limit fields | Low |
 | PR 1a (#79) | 5 | Document zero-value behavior in workflow schema `max_llm_calls` description | Low |
+| PR 1b (#81) | F-02 | `int` → `int32` truncation without overflow guard in `executor.go` L154–156 | Low |
+| PR 1b (#81) | F-04 | Negative agent-level limit values in `resolveStepLimits()` silently ignored; add rejection or warning | Low |
+| PR 1b (#81) | F-05 | Redundant `TestExecuteTask_PopulatesTaskConfig_AllFields` — consolidate with existing all-fields test | Nit |
 
 #### PR checklist
 
@@ -494,7 +513,7 @@ Review findings accumulated during PRs 1a–4b. Findings will be recorded per-PR
 | PR | Phase | Naive estimate | Calibrated (1.7×) | Status |
 |----|-------|----------------|--------------------|--------|
 | 1a | 1 | ~200–270 lines | ~340–460 lines | In review (PR #79) |
-| 1b | 1 | ~200–300 lines | ~340–510 lines | Not started |
+| 1b | 1 | ~200–300 lines | ~340–510 lines | In review (PR #81) |
 | 1c | 1 | ~130–200 lines | ~220–340 lines | Not started |
 | 2 | 2 | ~200–300 lines | ~340–510 lines | Not started |
 | 3a | 3 | ~200–300 lines | ~340–510 lines | Not started |

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -27,6 +27,15 @@ var (
 	ErrUnexpectedStatus = errors.New("unexpected task status from agent")
 )
 
+// StepLimits holds resolved execution limits for a single step dispatch.
+// These are populated by the scheduler's three-level cascade (step config →
+// agent config → system defaults) before being passed to the executor.
+type StepLimits struct {
+	MaxLLMCalls    int
+	MaxTokens      int
+	TimeoutSeconds int
+}
+
 // ExecuteRequest contains the parameters for a task dispatch.
 type ExecuteRequest struct {
 	TaskID     string
@@ -34,6 +43,7 @@ type ExecuteRequest struct {
 	AgentID    string
 	Payload    string
 	Context    map[string]string
+	Limits     StepLimits
 }
 
 // ExecuteResult contains the outcome of a task dispatch.
@@ -141,7 +151,9 @@ func (e *GRPCExecutor) ExecuteTask(ctx context.Context, req ExecuteRequest) (*Ex
 		Payload:    req.Payload,
 		Context:    req.Context,
 		Config: &taskpb.TaskConfig{
-			TimeoutSeconds: int32(e.timeout.Seconds()),
+			MaxLlmCalls:    int32(req.Limits.MaxLLMCalls),
+			MaxTokens:      int32(req.Limits.MaxTokens),
+			TimeoutSeconds: int32(req.Limits.TimeoutSeconds),
 		},
 	}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -290,11 +290,76 @@ func TestExecuteTask_PopulatesTaskConfig(t *testing.T) {
 	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
 		AgentID: "test-agent",
 		Payload: "config check",
+		Limits: StepLimits{
+			MaxLLMCalls:    5,
+			MaxTokens:      8192,
+			TimeoutSeconds: 15,
+		},
 	})
 
 	require.NoError(t, err)
 	require.NotNil(t, receivedConfig, "TaskConfig should be populated in gRPC request")
+	assert.Equal(t, int32(5), receivedConfig.MaxLlmCalls)
+	assert.Equal(t, int32(8192), receivedConfig.MaxTokens)
 	assert.Equal(t, int32(15), receivedConfig.TimeoutSeconds)
+}
+
+func TestExecuteTask_PopulatesTaskConfig_AllFields(t *testing.T) {
+	var receivedConfig *taskpb.TaskConfig
+	env := setupTestEnv(t, func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+		receivedConfig = req.Config
+		return &taskpb.TaskResponse{
+			TaskId: req.TaskId,
+			Status: taskpb.TaskStatus_COMPLETED,
+			Result: "done",
+		}, nil
+	})
+
+	registerHealthyAgent(t, env.reg, "test-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "test-agent",
+		Payload: "full config",
+		Limits: StepLimits{
+			MaxLLMCalls:    3,
+			MaxTokens:      4096,
+			TimeoutSeconds: 120,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, receivedConfig)
+	assert.Equal(t, int32(3), receivedConfig.MaxLlmCalls, "MaxLlmCalls should match Limits.MaxLLMCalls")
+	assert.Equal(t, int32(4096), receivedConfig.MaxTokens, "MaxTokens should match Limits.MaxTokens")
+	assert.Equal(t, int32(120), receivedConfig.TimeoutSeconds, "TimeoutSeconds should match Limits.TimeoutSeconds")
+}
+
+func TestExecuteTask_ZeroLimits_SentAsZero(t *testing.T) {
+	// Zero limits in ExecuteRequest are sent as-is — the scheduler is responsible
+	// for resolving defaults before calling the executor.
+	var receivedConfig *taskpb.TaskConfig
+	env := setupTestEnv(t, func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+		receivedConfig = req.Config
+		return &taskpb.TaskResponse{
+			TaskId: req.TaskId,
+			Status: taskpb.TaskStatus_COMPLETED,
+			Result: "done",
+		}, nil
+	})
+
+	registerHealthyAgent(t, env.reg, "test-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		AgentID: "test-agent",
+		Payload: "zero limits",
+		// Limits left as zero-value StepLimits
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, receivedConfig)
+	assert.Equal(t, int32(0), receivedConfig.MaxLlmCalls)
+	assert.Equal(t, int32(0), receivedConfig.MaxTokens)
+	assert.Equal(t, int32(0), receivedConfig.TimeoutSeconds)
 }
 
 func TestExecuteTask_GeneratesTaskID(t *testing.T) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -25,6 +25,12 @@ type AgentInfo struct {
 	Address      string // gRPC address (host:port)
 	NodeID       string // empty for local deployment
 	Status       AgentStatus
+
+	// Execution limit fields (RFC 0006). Zero means "not configured at agent
+	// level" — the scheduler falls through to system defaults.
+	MaxLLMCalls    int
+	MaxTokens      int
+	TimeoutSeconds int
 }
 
 type AgentStatus int
@@ -81,12 +87,15 @@ func (r *InMemoryRegistry) Register(_ context.Context, agent AgentInfo) error {
 
 	// Store an internal copy with Capabilities slice deep-copied.
 	stored := &AgentInfo{
-		ID:      agent.ID,
-		Name:    agent.Name,
-		Role:    agent.Role,
-		Address: agent.Address,
-		NodeID:  agent.NodeID,
-		Status:  agent.Status,
+		ID:             agent.ID,
+		Name:           agent.Name,
+		Role:           agent.Role,
+		Address:        agent.Address,
+		NodeID:         agent.NodeID,
+		Status:         agent.Status,
+		MaxLLMCalls:    agent.MaxLLMCalls,
+		MaxTokens:      agent.MaxTokens,
+		TimeoutSeconds: agent.TimeoutSeconds,
 	}
 	stored.Capabilities = make([]string, len(agent.Capabilities))
 	copy(stored.Capabilities, agent.Capabilities)
@@ -176,12 +185,15 @@ func (r *InMemoryRegistry) FindByCapability(_ context.Context, capability string
 // Capabilities slice to prevent shared backing-array mutation.
 func deepCopyAgent(agent *AgentInfo) *AgentInfo {
 	cp := &AgentInfo{
-		ID:      agent.ID,
-		Name:    agent.Name,
-		Role:    agent.Role,
-		Address: agent.Address,
-		NodeID:  agent.NodeID,
-		Status:  agent.Status,
+		ID:             agent.ID,
+		Name:           agent.Name,
+		Role:           agent.Role,
+		Address:        agent.Address,
+		NodeID:         agent.NodeID,
+		Status:         agent.Status,
+		MaxLLMCalls:    agent.MaxLLMCalls,
+		MaxTokens:      agent.MaxTokens,
+		TimeoutSeconds: agent.TimeoutSeconds,
 	}
 	cp.Capabilities = make([]string, len(agent.Capabilities))
 	copy(cp.Capabilities, agent.Capabilities)

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -11,6 +11,7 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/mkhomutov/persatrix/internal/defaults"
 	"github.com/mkhomutov/persatrix/internal/executor"
 	"github.com/mkhomutov/persatrix/internal/planner"
 	"github.com/mkhomutov/persatrix/internal/registry"
@@ -360,11 +361,13 @@ func (s *WorkflowScheduler) executeStep(
 
 	// Dispatch to executor.
 	// TODO(v0.2): evaluate step conditions
+	limits := s.resolveStepLimits(ctx, step)
 	result, err := s.executor.ExecuteTask(ctx, executor.ExecuteRequest{
 		WorkflowID: workflowID,
 		AgentID:    step.AgentID,
 		Payload:    resolved,
 		Context:    outputsCopy,
+		Limits:     limits,
 	})
 	if err != nil {
 		s.markStepFailed(ctx, runID, step.ID, startedAt, err.Error())
@@ -387,6 +390,51 @@ func (s *WorkflowScheduler) executeStep(
 	}
 
 	return result.Output, nil
+}
+
+// resolveStepLimits implements the three-level cascade for execution limits:
+// workflow step config → agent config → system defaults (RFC 0006 Section A).
+// Zero values at any level mean "not configured" and fall through to the next level.
+func (s *WorkflowScheduler) resolveStepLimits(ctx context.Context, step planner.Step) executor.StepLimits {
+	limits := executor.StepLimits{
+		MaxLLMCalls:    defaults.DefaultMaxLLMCalls,
+		MaxTokens:      defaults.DefaultMaxTokens,
+		TimeoutSeconds: defaults.DefaultTimeoutSeconds,
+	}
+
+	// Middle tier: agent config overrides system defaults.
+	if s.registry != nil {
+		agent, err := s.registry.Get(ctx, step.AgentID)
+		if err == nil {
+			if agent.MaxLLMCalls > 0 {
+				limits.MaxLLMCalls = agent.MaxLLMCalls
+			}
+			if agent.MaxTokens > 0 {
+				limits.MaxTokens = agent.MaxTokens
+			}
+			if agent.TimeoutSeconds > 0 {
+				limits.TimeoutSeconds = agent.TimeoutSeconds
+			}
+		} else {
+			s.logger.Warn("failed to look up agent config for limit resolution, using defaults",
+				zap.String("agentID", step.AgentID),
+				zap.Error(err),
+			)
+		}
+	}
+
+	// Highest tier: step config overrides agent config.
+	if step.MaxLLMCalls > 0 {
+		limits.MaxLLMCalls = step.MaxLLMCalls
+	}
+	if step.MaxTokens > 0 {
+		limits.MaxTokens = step.MaxTokens
+	}
+	if step.TimeoutSeconds > 0 {
+		limits.TimeoutSeconds = step.TimeoutSeconds
+	}
+
+	return limits
 }
 
 // markStepFailed updates the step state to failed with the given error message.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mkhomutov/persatrix/internal/executor"
 	"github.com/mkhomutov/persatrix/internal/planner"
+	"github.com/mkhomutov/persatrix/internal/registry"
 	"github.com/mkhomutov/persatrix/internal/state"
 )
 
@@ -1078,4 +1079,192 @@ func TestListRunsErrorPath(t *testing.T) {
 	errVal, ok := entry.ContextMap()["error"]
 	require.True(t, ok, "log entry should contain 'error' field from zap.Error()")
 	assert.Contains(t, fmt.Sprintf("%v", errVal), "database connection lost")
+}
+
+// --- PR 1b: resolveStepLimits cascade tests ---
+
+func TestResolveStepLimits_SystemDefaults(t *testing.T) {
+	// Both step and agent have zero limits → system defaults used.
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "test-agent", 0, 0, 0)
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{AgentID: "test-agent"}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 5, limits.MaxLLMCalls, "should use DefaultMaxLLMCalls")
+	assert.Equal(t, 8192, limits.MaxTokens, "should use DefaultMaxTokens")
+	assert.Equal(t, 60, limits.TimeoutSeconds, "should use DefaultTimeoutSeconds")
+}
+
+func TestResolveStepLimits_AgentOverridesDefaults(t *testing.T) {
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "custom-agent", 8, 16384, 120)
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{AgentID: "custom-agent"}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 8, limits.MaxLLMCalls)
+	assert.Equal(t, 16384, limits.MaxTokens)
+	assert.Equal(t, 120, limits.TimeoutSeconds)
+}
+
+func TestResolveStepLimits_StepOverridesAgent(t *testing.T) {
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "custom-agent", 8, 16384, 120)
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{
+		AgentID:        "custom-agent",
+		MaxLLMCalls:    3,
+		MaxTokens:      2048,
+		TimeoutSeconds: 30,
+	}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 3, limits.MaxLLMCalls)
+	assert.Equal(t, 2048, limits.MaxTokens)
+	assert.Equal(t, 30, limits.TimeoutSeconds)
+}
+
+func TestResolveStepLimits_PartialStepOverride(t *testing.T) {
+	// Step overrides only MaxLLMCalls; the rest come from agent config.
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "custom-agent", 8, 16384, 120)
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{
+		AgentID:     "custom-agent",
+		MaxLLMCalls: 2,
+	}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 2, limits.MaxLLMCalls, "step override")
+	assert.Equal(t, 16384, limits.MaxTokens, "from agent config")
+	assert.Equal(t, 120, limits.TimeoutSeconds, "from agent config")
+}
+
+func TestResolveStepLimits_PartialAgentOverride(t *testing.T) {
+	// Agent config sets only TimeoutSeconds; rest fall to system defaults.
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "partial-agent", 0, 0, 300)
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{AgentID: "partial-agent"}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 5, limits.MaxLLMCalls, "system default")
+	assert.Equal(t, 8192, limits.MaxTokens, "system default")
+	assert.Equal(t, 300, limits.TimeoutSeconds, "agent override")
+}
+
+func TestResolveStepLimits_AgentNotInRegistry(t *testing.T) {
+	// Agent not found in registry → system defaults used (with warning log).
+	store := state.NewInMemoryStore(zap.NewNop())
+	reg := newTestRegistry(t) // empty registry
+
+	sched := newTestSchedulerWithRegistry(t, store, &mockExecutor{}, reg, t.TempDir())
+	step := planner.Step{AgentID: "unknown-agent"}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 5, limits.MaxLLMCalls)
+	assert.Equal(t, 8192, limits.MaxTokens)
+	assert.Equal(t, 60, limits.TimeoutSeconds)
+}
+
+func TestResolveStepLimits_NilRegistry(t *testing.T) {
+	// nil registry (e.g., in tests using newTestScheduler which passes nil)
+	// → system defaults used, no panic.
+	store := state.NewInMemoryStore(zap.NewNop())
+	sched := newTestScheduler(t, store, &mockExecutor{}, t.TempDir())
+	step := planner.Step{AgentID: "any-agent"}
+
+	limits := sched.resolveStepLimits(context.Background(), step)
+
+	assert.Equal(t, 5, limits.MaxLLMCalls)
+	assert.Equal(t, 8192, limits.MaxTokens)
+	assert.Equal(t, 60, limits.TimeoutSeconds)
+}
+
+func TestResolveStepLimits_EndToEnd(t *testing.T) {
+	// Full end-to-end: workflow with step limits dispatches correct TaskConfig.
+	const limitsYAML = `schema_version: "0.1"
+workflow:
+  id: "limits-wf"
+  name: "Limits Workflow"
+  trigger: "manual"
+  steps:
+    - id: "s1"
+      agent: "test-agent"
+      input: "do work"
+      output_key: "result"
+      max_llm_calls: 3
+      max_tokens: 2048
+      timeout_seconds: 45
+`
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "limits-wf", limitsYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	var receivedLimits executor.StepLimits
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		receivedLimits = req.Limits
+		return &executor.ExecuteResult{TaskID: "t1", Output: "ok"}, nil
+	}}
+
+	reg := newTestRegistry(t)
+	registerAgentWithLimits(t, reg, "test-agent", 10, 16384, 300)
+
+	sched := newTestSchedulerWithRegistry(t, store, exec, reg, dir, WithPollInterval(50*time.Millisecond))
+	createPendingRun(t, store, "limits-run", "limits-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sched.Run(ctx) }()
+
+	waitForRunStatus(t, store, "limits-run", state.RunCompleted, 5*time.Second)
+
+	assert.Equal(t, 3, receivedLimits.MaxLLMCalls, "step config overrides agent")
+	assert.Equal(t, 2048, receivedLimits.MaxTokens, "step config overrides agent")
+	assert.Equal(t, 45, receivedLimits.TimeoutSeconds, "step config overrides agent")
+}
+
+// --- Test helpers for resolveStepLimits ---
+
+func newTestRegistry(t *testing.T) *registry.InMemoryRegistry {
+	t.Helper()
+	return registry.NewInMemoryRegistry(zap.NewNop())
+}
+
+func registerAgentWithLimits(t *testing.T, reg *registry.InMemoryRegistry, agentID string, maxLLMCalls, maxTokens, timeoutSeconds int) {
+	t.Helper()
+	err := reg.Register(context.Background(), registry.AgentInfo{
+		ID:             agentID,
+		Name:           agentID,
+		Address:        "passthrough:///test",
+		Status:         registry.StatusHealthy,
+		MaxLLMCalls:    maxLLMCalls,
+		MaxTokens:      maxTokens,
+		TimeoutSeconds: timeoutSeconds,
+	})
+	require.NoError(t, err)
+}
+
+func newTestSchedulerWithRegistry(t *testing.T, store state.Store, exec executor.Executor, reg registry.Registry, workflowsDir string, opts ...Option) *WorkflowScheduler {
+	t.Helper()
+	logger := zap.NewNop()
+	plan := planner.NewYAMLPlanner(logger)
+	return NewWorkflowScheduler(store, reg, plan, exec, logger, workflowsDir, opts...)
 }


### PR DESCRIPTION
## Summary

RFC 0006 PR 1b: Executor TaskConfig + Scheduler Limit Resolution.

Implements the three-level execution limit cascade (workflow step config → agent config → system defaults) and wires resolved limits into the gRPC `TaskConfig` sent to agents. Previously, only `TimeoutSeconds` was populated; `MaxLlmCalls` and `MaxTokens` were always zero, causing agents to silently fall back to local defaults.

## Changes

### `internal/executor/executor.go`
- Add `StepLimits` struct (`MaxLLMCalls`, `MaxTokens`, `TimeoutSeconds`) to `ExecuteRequest`
- Populate all `TaskConfig` fields from `req.Limits` instead of only `TimeoutSeconds` from executor-level timeout

### `internal/scheduler/scheduler.go`
- Add `resolveStepLimits(ctx, step)` — three-level cascade:
  - Step config (highest priority, from workflow YAML)
  - Agent config (from registry lookup)
  - System defaults (from `internal/defaults/`)
- Wire resolved limits into `ExecuteRequest.Limits` in `executeStep()`

### `internal/registry/registry.go`
- Extend `AgentInfo` with `MaxLLMCalls`, `MaxTokens`, `TimeoutSeconds` fields
- Update `Register()` and `deepCopyAgent()` to include new fields

### Tests
- **Executor**: Full `TaskConfig` population, all-fields verification, zero-value passthrough
- **Scheduler**: System defaults, agent overrides defaults, step overrides agent, partial step override, partial agent override, agent not found (fallback to defaults), nil registry (no panic), end-to-end limit propagation through workflow execution

## PR Plan Reference

[docs/rfcs/0006-pr-plan.md](docs/rfcs/0006-pr-plan.md) — PR 1b

## Checklist

- [x] `go test ./internal/executor/ -v -race` passes
- [x] `go test ./internal/scheduler/ -v -race` passes
- [x] `go test ./internal/registry/ -v -race` passes
- [x] `ExecuteRequest` includes `StepLimits`
- [x] `TaskConfig` fully populated (no zero-value `MaxLlmCalls`/`MaxTokens`)
- [x] Three-level cascade verified in tests
