### PR TITLE
feat(state): StepExecutionMetadata + observability (RFC 0006 PR 4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(orchestrator)* Per-step execution metadata: `StepExecutionMetadata` captures `tokens_used`,
+  `llm_call_count`, `retry_count`, `cache_hit`, `wall_time_ms`, and `estimated_cost_usd` for
+  every completed step. Exposed in `GET /api/v1/workflows/{id}/status` response and logged at
+  INFO level on step completion (RFC 0006 PR 4a)
+- *(server)* Workflow status API now populates per-step data (status, output, error, timestamps,
+  metadata) — previously returned an empty steps map (RFC 0006 PR 4a)
 - *(cost)* `CostReporter` aggregates per-workflow and global cost summaries from `TokenCounter`
   data — provides `WorkflowCostSummary` (per-step breakdown, estimated USD) and
   `GlobalCostSummary` (daily totals, top agents by spend) (RFC 0006 PR 3b)

--- a/docs/rfcs/0006-pr-plan.md
+++ b/docs/rfcs/0006-pr-plan.md
@@ -473,13 +473,34 @@ PR 6 (RFC close)
 
 #### PR checklist
 
-- [ ] `go test ./internal/state/ -v -race` passes
-- [ ] `go test ./internal/executor/ -v -race` passes
-- [ ] `go test ./internal/server/ -v -race` passes
-- [ ] `StepExecutionMetadata` struct defined with all 6 fields
-- [ ] Executor populates metadata after each step
-- [ ] Status API includes per-step metadata
-- [ ] Metadata logged at INFO level
+- [x] `go test ./internal/state/ -v -race` passes
+- [x] `go test ./internal/executor/ -v -race` passes
+- [x] `go test ./internal/server/ -v -race` passes
+- [x] `StepExecutionMetadata` struct defined with all 6 fields
+- [x] Executor populates metadata after each step
+- [x] Status API includes per-step metadata
+- [x] Metadata logged at INFO level
+
+#### Review Findings (PR #87)
+
+**Should Fix (quality improvement):**
+
+1. **M-01 (Medium) — Cost estimation inconsistency between `recordStepUsage` and `buildStepMetadata`** — When an agent only reports `tokens_used` (no `input_tokens`/`output_tokens`), `recordStepUsage` maps it to `outputTokens` and computes a pessimistic cost. But `buildStepMetadata` passes `input_tokens=0, output_tokens=0` to `EstimateCost`, resulting in `$0` cost in the metadata — despite non-zero `TokensUsed` in the same struct. Fix: use resolved `tokensUsed` as `outputTokens` fallback in `buildStepMetadata`, or extract a shared token resolution function for both callers. *(Location: `internal/scheduler/scheduler.go` → `buildStepMetadata()` lines 670–685)*
+2. **M-02 (Low) — No deep copy of Metadata pointer on write in `UpdateStepState`** — Stores caller's pointer directly. Asymmetric with `CreateRun` which deep-copies. A future caller reusing a metadata pointer would silently corrupt store state. Fix: add `if step.Metadata != nil { metaCopy := *step.Metadata; step.Metadata = &metaCopy }` before `run.Steps[step.StepID] = step`. *(Location: `internal/state/state.go` → `UpdateStepState()` L201)*
+3. **M-03 (Low) — Empty step ID in `buildStepMetadata` warning logs** — `parseMetadataInt64` calls inside `buildStepMetadata` pass `""` as step ID, making warning logs undiagnosable ("failed to parse metadata value as int64, stepID="). Fix: add `stepID string` parameter to `buildStepMetadata` and pass `step.ID` from the call site. *(Location: `internal/scheduler/scheduler.go` → `buildStepMetadata()` L650)*
+4. **M-04 (Low) — Missing write-isolation test for metadata** — `TestGetRunDeepCopy_MetadataIsolation` tests read isolation only. No test verifies that mutating input metadata after `UpdateStepState` doesn't affect the store. Fix: add `TestUpdateStepState_WriteIsolation`. *(Location: `internal/state/state_test.go`)*
+
+**Nice to Have (follow-up):**
+
+5. **N-01 — Extract shared `resolveStepTokenData` helper** — Merge duplicated metadata parsing in `recordStepUsage` and `buildStepMetadata` into a single function returning a struct with `TokensUsed`, `InputTokens`, `OutputTokens`, `LLMCallCount`, `Model`, `EstimatedCostUSD`. Eliminates divergence risk. *(Location: `internal/scheduler/scheduler.go`)*
+6. **N-02 — Add `WallTimeMs` accuracy test** — Inject a mock agent with a fixed delay and assert `result.WallTimeMs >= delay`. Validates the measurement mechanism rather than just checking non-zero. *(Location: `internal/executor/executor_test.go`)*
+
+**Info (no action required):**
+
+7. **`int64` → `int` narrowing in `buildStepMetadata`** — `tokensUsed = int(parseMetadataInt64(...))` narrows int64 to int. On 64-bit platforms this is a no-op. Low risk given server deployment targets.
+8. **Redundant nil check in `buildStepMetadata`** — `result.Metadata != nil` rechecked inside an outer condition that already guarantees non-nil. Harmless but redundant.
+9. **`WallTimeMs` set only on success** — Failed steps have no wall time metadata. Acceptable for v0.2 since metadata is observability-only.
+10. **`CacheHit` hardcoded to `false`** — Correct forward-declaration for PR 4b. The constant `false` with a comment is better than omitting the field.
 
 ---
 
@@ -577,6 +598,12 @@ Review findings accumulated during PRs 1a–4b. Findings will be recorded per-PR
 | PR 3b (#86) | N-01 | Atomic snapshot for multi-scope `CheckBudget` (pre-existing C4) | Low |
 | PR 3b (#86) | N-02 | Config validation for budget thresholds (pre-existing C7) | Low |
 | PR 3b (#86) | N-03 | Structured `BudgetError` type for budget rejection (enables 429 responses) | Low |
+| PR 4a (#87) | M-01 | Cost estimation inconsistency: `buildStepMetadata` returns $0 when agent only reports `tokens_used` | Medium |
+| PR 4a (#87) | M-02 | No deep copy of Metadata pointer on write in `UpdateStepState` (asymmetric with `CreateRun`) | Low |
+| PR 4a (#87) | M-03 | Empty step ID in `buildStepMetadata` warning logs makes them undiagnosable | Low |
+| PR 4a (#87) | M-04 | Missing write-isolation test for metadata in `state_test.go` | Low |
+| PR 4a (#87) | N-01 | Extract shared `resolveStepTokenData` helper to eliminate duplicated metadata parsing | Low |
+| PR 4a (#87) | N-02 | Add `WallTimeMs` accuracy test with injected delay | Low |
 
 #### PR checklist
 
@@ -622,8 +649,8 @@ Review findings accumulated during PRs 1a–4b. Findings will be recorded per-PR
 | 1c | 1 | ~130–200 lines | ~220–340 lines | ✅ Merged (PR #83) |
 | 2 | 2 | ~200–300 lines | ~340–510 lines | ✅ Merged (PR #84) |
 | 3a | 3 | ~200–300 lines | ~340–510 lines | ✅ Merged (PR #85) |
-| 3b | 3 | ~180–260 lines | ~310–440 lines | 🟡 In review (PR #86) |
-| 4a | 4 | ~180–260 lines | ~310–440 lines | Not started |
+| 3b | 3 | ~180–260 lines | ~310–440 lines | ✅ Merged (PR #86) |
+| 4a | 4 | ~180–260 lines | ~310–440 lines | 🟡 In review (PR #87) |
 | 4b | 4 | ~200–300 lines | ~340–510 lines | Not started |
 | 5 | Follow-up | TBD | TBD | Not started |
 | 6 | Close | ~50–100 lines | ~50–100 lines | Not started |

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -61,9 +61,11 @@ type ExecuteRequest struct {
 
 // ExecuteResult contains the outcome of a task dispatch.
 type ExecuteResult struct {
-	TaskID   string
-	Output   string
-	Metadata map[string]string
+	TaskID     string
+	Output     string
+	Metadata   map[string]string
+	RetryCount int
+	WallTimeMs int64
 }
 
 // Executor defines the interface for dispatching tasks to agents.
@@ -276,6 +278,15 @@ func (e *GRPCExecutor) ExecuteTask(ctx context.Context, req ExecuteRequest) (*Ex
 
 		result, err := e.dispatch(ctx, agent.Address, grpcReq, dispatchTimeout)
 		if err == nil {
+			wallTimeMs := time.Since(start).Milliseconds()
+			result.RetryCount = attempt
+			result.WallTimeMs = wallTimeMs
+			e.logger.Info("step dispatched",
+				zap.String("agentID", req.AgentID),
+				zap.String("taskID", taskID),
+				zap.Int("retryCount", attempt),
+				zap.Int64("wallTimeMs", wallTimeMs),
+			)
 			return result, nil
 		}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -1429,3 +1429,74 @@ func TestWithTokenParser_Nil(t *testing.T) {
 	result := exec.tokenParser(errors.New("test error"))
 	assert.Equal(t, int64(0), result, "default parser should return 0")
 }
+
+// --- StepExecutionMetadata tests (RFC 0006 PR 4a) ---
+
+func TestExecuteTask_MetadataWallTime(t *testing.T) {
+	env := setupTestEnv(t, func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+		return &taskpb.TaskResponse{
+			TaskId: req.TaskId,
+			Status: taskpb.TaskStatus_COMPLETED,
+			Result: "ok",
+		}, nil
+	})
+
+	registerHealthyAgent(t, env.reg, "test-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		TaskID:  "task-wall",
+		AgentID: "test-agent",
+	})
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, result.WallTimeMs, int64(0))
+	assert.Equal(t, 0, result.RetryCount)
+}
+
+func TestExecuteTask_MetadataRetryCount(t *testing.T) {
+	var calls atomic.Int32
+	env := setupTestEnv(t, func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+		n := calls.Add(1)
+		if n <= 2 {
+			return nil, status.Errorf(codes.Unavailable, "transient error %d", n)
+		}
+		return &taskpb.TaskResponse{
+			TaskId: req.TaskId,
+			Status: taskpb.TaskStatus_COMPLETED,
+			Result: "ok after retries",
+		}, nil
+	}, WithMaxRetries(3), WithTimeout(5*time.Second))
+
+	registerHealthyAgent(t, env.reg, "retry-agent")
+
+	result, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		TaskID:  "task-retry",
+		AgentID: "retry-agent",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok after retries", result.Output)
+	assert.Equal(t, 2, result.RetryCount)
+	assert.Greater(t, result.WallTimeMs, int64(0))
+}
+
+func TestExecuteTask_MetadataFailure_NoMetadata(t *testing.T) {
+	env := setupTestEnv(t, func(_ context.Context, req *taskpb.TaskRequest) (*taskpb.TaskResponse, error) {
+		return &taskpb.TaskResponse{
+			TaskId:       req.TaskId,
+			Status:       taskpb.TaskStatus_FAILED,
+			ErrorMessage: "something broke",
+		}, nil
+	})
+
+	registerHealthyAgent(t, env.reg, "fail-agent")
+
+	_, err := env.executor.ExecuteTask(context.Background(), ExecuteRequest{
+		TaskID:  "task-fail",
+		AgentID: "fail-agent",
+	})
+
+	// Failure should not return metadata — only successful dispatches get metadata.
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrTaskFailed))
+}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -432,6 +432,18 @@ func (s *WorkflowScheduler) executeStep(
 	// Post-dispatch: record token usage and step cost (RFC 0006 PR 3b).
 	s.recordStepUsage(workflowID, step, result, registryModel)
 
+	// Build execution metadata for observability (RFC 0006 PR 4a).
+	metadata := s.buildStepMetadata(result, registryModel)
+
+	s.logger.Info("step completed",
+		zap.String("runID", runID),
+		zap.String("stepID", step.ID),
+		zap.Int("tokensUsed", metadata.TokensUsed),
+		zap.Int("retryCount", metadata.RetryCount),
+		zap.Int64("wallTimeMs", metadata.WallTimeMs),
+		zap.Float64("estimatedCostUSD", metadata.EstimatedCostUSD),
+	)
+
 	// Mark step as completed.
 	if err := s.store.UpdateStepState(ctx, runID, state.StepState{
 		StepID:     step.ID,
@@ -439,6 +451,7 @@ func (s *WorkflowScheduler) executeStep(
 		Output:     result.Output,
 		StartedAt:  startedAt,
 		FinishedAt: time.Now(),
+		Metadata:   metadata,
 	}); err != nil {
 		s.logger.Error("failed to update step state to completed",
 			zap.String("runID", runID),
@@ -629,6 +642,53 @@ func (s *WorkflowScheduler) recordStepUsage(workflowID string, step planner.Step
 			OutputTokens: outputTokens,
 			EstimatedUSD: estimatedCost,
 		})
+	}
+}
+
+// buildStepMetadata constructs a StepExecutionMetadata from the executor result
+// and cost data. Missing metadata fields degrade gracefully to zero values.
+func (s *WorkflowScheduler) buildStepMetadata(result *executor.ExecuteResult, registryModel string) *state.StepExecutionMetadata {
+	if result == nil {
+		return nil
+	}
+
+	var tokensUsed int
+	var llmCallCount int
+	if result.Metadata != nil {
+		tokensUsed = int(parseMetadataInt64(result.Metadata, "tokens_used", s.logger, ""))
+		llmCallCount = int(parseMetadataInt64(result.Metadata, "llm_call_count", s.logger, ""))
+		// If per-direction tokens are available, sum them for total.
+		if tokensUsed == 0 {
+			input := parseMetadataInt64(result.Metadata, "input_tokens", s.logger, "")
+			output := parseMetadataInt64(result.Metadata, "output_tokens", s.logger, "")
+			if input > 0 || output > 0 {
+				tokensUsed = int(input + output)
+			}
+		}
+	}
+
+	// Compute estimated cost from the pricing table if available.
+	var estimatedCostUSD float64
+	if s.tokenCounter != nil && result.Metadata != nil {
+		inputTokens := parseMetadataInt64(result.Metadata, "input_tokens", s.logger, "")
+		outputTokens := parseMetadataInt64(result.Metadata, "output_tokens", s.logger, "")
+		model := ""
+		if result.Metadata != nil {
+			model = result.Metadata["model"]
+		}
+		if model == "" {
+			model = registryModel
+		}
+		estimatedCostUSD = s.tokenCounter.Config().EstimateCost(model, inputTokens, outputTokens)
+	}
+
+	return &state.StepExecutionMetadata{
+		TokensUsed:       tokensUsed,
+		LLMCallCount:     llmCallCount,
+		RetryCount:       result.RetryCount,
+		CacheHit:         false, // Always false until PR 4b implements response cache.
+		WallTimeMs:       result.WallTimeMs,
+		EstimatedCostUSD: estimatedCostUSD,
 	}
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1942,3 +1942,156 @@ func TestTokensUsedFallback_LogMessage(t *testing.T) {
 	}
 	assert.True(t, found, "expected Info log for tokens_used fallback")
 }
+
+// --- StepExecutionMetadata tests (RFC 0006 PR 4a) ---
+
+func TestStepMetadata_PopulatedOnCompletion(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		return &executor.ExecuteResult{
+			TaskID:     "t1",
+			Output:     "done",
+			RetryCount: 2,
+			WallTimeMs: 1500,
+			Metadata: map[string]string{
+				"tokens_used":    "800",
+				"llm_call_count": "3",
+			},
+		}, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir,
+		WithPollInterval(50*time.Millisecond),
+	)
+	createPendingRun(t, store, "meta-run", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sched.Run(ctx) }()
+
+	run := waitForRunStatus(t, store, "meta-run", state.RunCompleted, 5*time.Second)
+
+	step := run.Steps["step1"]
+	require.NotNil(t, step.Metadata, "step should have execution metadata")
+	assert.Equal(t, 800, step.Metadata.TokensUsed)
+	assert.Equal(t, 3, step.Metadata.LLMCallCount)
+	assert.Equal(t, 2, step.Metadata.RetryCount)
+	assert.False(t, step.Metadata.CacheHit)
+	assert.Equal(t, int64(1500), step.Metadata.WallTimeMs)
+}
+
+func TestStepMetadata_GracefulDegradation(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		// No metadata fields — simulates an agent that doesn't report observability data.
+		return &executor.ExecuteResult{
+			TaskID:     "t1",
+			Output:     "done",
+			WallTimeMs: 200,
+		}, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir,
+		WithPollInterval(50*time.Millisecond),
+	)
+	createPendingRun(t, store, "meta-empty", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sched.Run(ctx) }()
+
+	run := waitForRunStatus(t, store, "meta-empty", state.RunCompleted, 5*time.Second)
+
+	step := run.Steps["step1"]
+	require.NotNil(t, step.Metadata, "step should have metadata even with no agent-reported fields")
+	assert.Equal(t, 0, step.Metadata.TokensUsed)
+	assert.Equal(t, 0, step.Metadata.LLMCallCount)
+	assert.Equal(t, 0, step.Metadata.RetryCount)
+	assert.False(t, step.Metadata.CacheHit)
+	assert.Equal(t, int64(200), step.Metadata.WallTimeMs)
+}
+
+func TestStepMetadata_PerDirectionTokens(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		return &executor.ExecuteResult{
+			TaskID:     "t1",
+			Output:     "done",
+			WallTimeMs: 500,
+			Metadata: map[string]string{
+				"input_tokens":  "300",
+				"output_tokens": "200",
+			},
+		}, nil
+	}}
+
+	sched := newTestScheduler(t, store, exec, dir,
+		WithPollInterval(50*time.Millisecond),
+	)
+	createPendingRun(t, store, "meta-dir", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sched.Run(ctx) }()
+
+	run := waitForRunStatus(t, store, "meta-dir", state.RunCompleted, 5*time.Second)
+
+	step := run.Steps["step1"]
+	require.NotNil(t, step.Metadata)
+	assert.Equal(t, 500, step.Metadata.TokensUsed, "should sum input + output tokens")
+}
+
+func TestStepMetadata_InfoLogOnCompletion(t *testing.T) {
+	dir := t.TempDir()
+	writeWorkflow(t, dir, "test-wf", singleStepYAML)
+
+	store := state.NewInMemoryStore(zap.NewNop())
+	exec := &mockExecutor{handler: func(_ context.Context, req executor.ExecuteRequest) (*executor.ExecuteResult, error) {
+		return &executor.ExecuteResult{
+			TaskID:     "t1",
+			Output:     "done",
+			RetryCount: 1,
+			WallTimeMs: 750,
+			Metadata: map[string]string{
+				"tokens_used": "500",
+			},
+		}, nil
+	}}
+
+	// Use observed logger to capture log output.
+	core, logs := observer.New(zap.InfoLevel)
+	logger := zap.New(core)
+	plan := planner.NewYAMLPlanner(logger)
+	sched := NewWorkflowScheduler(store, nil, plan, exec, logger, dir,
+		WithPollInterval(50*time.Millisecond),
+	)
+	createPendingRun(t, store, "meta-log", "test-wf", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = sched.Run(ctx) }()
+
+	waitForRunStatus(t, store, "meta-log", state.RunCompleted, 5*time.Second)
+
+	var found bool
+	for _, entry := range logs.All() {
+		if entry.Message == "step completed" {
+			found = true
+			assert.Equal(t, "step1", entry.ContextMap()["stepID"])
+			assert.Equal(t, int64(500), entry.ContextMap()["tokensUsed"])
+			assert.Equal(t, int64(1), entry.ContextMap()["retryCount"])
+			assert.Equal(t, int64(750), entry.ContextMap()["wallTimeMs"])
+			break
+		}
+	}
+	assert.True(t, found, "expected 'step completed' Info log with metadata fields")
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1717,3 +1717,96 @@ func TestRegisterAgentNameMaxLength(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	assert.Equal(t, maxName, resp.Name)
 }
+
+// --- StepExecutionMetadata in API response (RFC 0006 PR 4a) ---
+
+func TestGetWorkflowStatus_StepMetadata(t *testing.T) {
+	srv, dir := testServer(t)
+	writeWorkflowFixture(t, dir, "test-wf")
+
+	// Submit a run.
+	body, _ := json.Marshal(submitWorkflowRunRequest{WorkflowID: "test-wf"})
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/workflows/run", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var createResp submitWorkflowRunResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
+
+	// Manually update step state with metadata via the store.
+	meta := &state.StepExecutionMetadata{
+		TokensUsed:       1200,
+		LLMCallCount:     2,
+		RetryCount:       1,
+		CacheHit:         false,
+		WallTimeMs:       3500,
+		EstimatedCostUSD: 0.012,
+	}
+	err := srv.store.UpdateStepState(context.Background(), createResp.RunID, state.StepState{
+		StepID:   "design",
+		Status:   state.RunCompleted,
+		Output:   "design output",
+		Metadata: meta,
+	})
+	require.NoError(t, err)
+
+	// Get status and verify metadata appears in response.
+	rec = doRequest(srv.Handler(), http.MethodGet, "/api/v1/workflows/"+createResp.RunID+"/status", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+
+	var steps map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["steps"], &steps))
+
+	var stepData map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(steps["design"], &stepData))
+
+	// Verify step fields.
+	assert.JSONEq(t, `"completed"`, string(stepData["status"]))
+	assert.JSONEq(t, `"design output"`, string(stepData["output"]))
+
+	// Verify metadata.
+	var gotMeta state.StepExecutionMetadata
+	require.NoError(t, json.Unmarshal(stepData["metadata"], &gotMeta))
+	assert.Equal(t, 1200, gotMeta.TokensUsed)
+	assert.Equal(t, 2, gotMeta.LLMCallCount)
+	assert.Equal(t, 1, gotMeta.RetryCount)
+	assert.False(t, gotMeta.CacheHit)
+	assert.Equal(t, int64(3500), gotMeta.WallTimeMs)
+	assert.InDelta(t, 0.012, gotMeta.EstimatedCostUSD, 1e-9)
+}
+
+func TestGetWorkflowStatus_StepWithoutMetadata(t *testing.T) {
+	srv, dir := testServer(t)
+	writeWorkflowFixture(t, dir, "test-wf")
+
+	body, _ := json.Marshal(submitWorkflowRunRequest{WorkflowID: "test-wf"})
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/workflows/run", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var createResp submitWorkflowRunResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &createResp))
+
+	// Step without metadata (pre-PR 4a behavior).
+	err := srv.store.UpdateStepState(context.Background(), createResp.RunID, state.StepState{
+		StepID: "design",
+		Status: state.RunRunning,
+	})
+	require.NoError(t, err)
+
+	rec = doRequest(srv.Handler(), http.MethodGet, "/api/v1/workflows/"+createResp.RunID+"/status", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &raw))
+
+	var steps map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw["steps"], &steps))
+
+	var stepData map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(steps["design"], &stepData))
+
+	assert.JSONEq(t, `"running"`, string(stepData["status"]))
+	// Metadata should not be present when nil.
+	_, hasMetadata := stepData["metadata"]
+	assert.False(t, hasMetadata, "metadata should not appear in response when nil")
+}

--- a/internal/server/workflow_handlers.go
+++ b/internal/server/workflow_handlers.go
@@ -210,10 +210,30 @@ func runToResponse(run *state.WorkflowRun) workflowRunResponse {
 		WorkflowID: run.WorkflowID,
 		Status:     runStatusString(run.Status),
 		Error:      run.Error,
-		// TODO(v0.2): populate from run.Steps — step state data is now written by
-		// the Scheduler (RFC 0003), but the wire format for per-step status/output
-		// needs to be defined before exposing it.
-		Steps: make(map[string]any),
+		Steps:      make(map[string]any),
+	}
+
+	// Populate per-step data including execution metadata (RFC 0006 PR 4a).
+	for stepID, step := range run.Steps {
+		stepData := map[string]any{
+			"status": runStatusString(step.Status),
+		}
+		if step.Output != "" {
+			stepData["output"] = step.Output
+		}
+		if step.Error != "" {
+			stepData["error"] = step.Error
+		}
+		if !step.StartedAt.IsZero() {
+			stepData["started_at"] = step.StartedAt.UTC()
+		}
+		if !step.FinishedAt.IsZero() {
+			stepData["finished_at"] = step.FinishedAt.UTC()
+		}
+		if step.Metadata != nil {
+			stepData["metadata"] = step.Metadata
+		}
+		resp.Steps[stepID] = stepData
 	}
 
 	if !run.StartedAt.IsZero() {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -44,6 +44,18 @@ type WorkflowRun struct {
 	Inputs     map[string]string
 }
 
+// StepExecutionMetadata captures observability data for a completed step.
+// This is a Go struct (not a proto message per RFC 0006 Section A) — stored
+// in StepState and serialized to JSON in API responses.
+type StepExecutionMetadata struct {
+	TokensUsed       int     `json:"tokens_used"`
+	LLMCallCount     int     `json:"llm_call_count"`
+	RetryCount       int     `json:"retry_count"`
+	CacheHit         bool    `json:"cache_hit"`
+	WallTimeMs       int64   `json:"wall_time_ms"`
+	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+}
+
 // StepState tracks the state of a single step within a workflow run.
 type StepState struct {
 	StepID     string
@@ -52,6 +64,7 @@ type StepState struct {
 	Error      string
 	StartedAt  time.Time
 	FinishedAt time.Time
+	Metadata   *StepExecutionMetadata
 }
 
 // Store defines the interface for workflow run state persistence.
@@ -260,6 +273,10 @@ func deepCopyRun(run *WorkflowRun) *WorkflowRun {
 
 	cp.Steps = make(map[string]StepState, len(run.Steps))
 	for k, v := range run.Steps {
+		if v.Metadata != nil {
+			metaCopy := *v.Metadata
+			v.Metadata = &metaCopy
+		}
 		cp.Steps[k] = v
 	}
 

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -723,3 +723,88 @@ func TestRunStatusValues(t *testing.T) {
 	assert.Equal(t, RunStatus(4), RunCancelled)
 	assert.Equal(t, RunStatus(5), RunRetrying)
 }
+
+// --- StepExecutionMetadata tests (RFC 0006 PR 4a) ---
+
+func TestUpdateStepState_WithMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{
+		ID: "meta-1", WorkflowID: "wf-1",
+	}))
+
+	meta := &StepExecutionMetadata{
+		TokensUsed:       1500,
+		LLMCallCount:     3,
+		RetryCount:       1,
+		CacheHit:         false,
+		WallTimeMs:       2500,
+		EstimatedCostUSD: 0.0045,
+	}
+	err := store.UpdateStepState(ctx, "meta-1", StepState{
+		StepID:   "step-1",
+		Status:   RunCompleted,
+		Output:   "done",
+		Metadata: meta,
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "meta-1")
+	require.NoError(t, err)
+	require.NotNil(t, got.Steps["step-1"].Metadata)
+	assert.Equal(t, 1500, got.Steps["step-1"].Metadata.TokensUsed)
+	assert.Equal(t, 3, got.Steps["step-1"].Metadata.LLMCallCount)
+	assert.Equal(t, 1, got.Steps["step-1"].Metadata.RetryCount)
+	assert.False(t, got.Steps["step-1"].Metadata.CacheHit)
+	assert.Equal(t, int64(2500), got.Steps["step-1"].Metadata.WallTimeMs)
+	assert.InDelta(t, 0.0045, got.Steps["step-1"].Metadata.EstimatedCostUSD, 1e-9)
+}
+
+func TestUpdateStepState_NilMetadata(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{
+		ID: "meta-nil", WorkflowID: "wf-1",
+	}))
+
+	err := store.UpdateStepState(ctx, "meta-nil", StepState{
+		StepID: "step-1",
+		Status: RunCompleted,
+	})
+	require.NoError(t, err)
+
+	got, err := store.GetRun(ctx, "meta-nil")
+	require.NoError(t, err)
+	assert.Nil(t, got.Steps["step-1"].Metadata)
+}
+
+func TestGetRunDeepCopy_MetadataIsolation(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+
+	require.NoError(t, store.CreateRun(ctx, &WorkflowRun{
+		ID: "meta-iso", WorkflowID: "wf-1",
+	}))
+
+	meta := &StepExecutionMetadata{
+		TokensUsed: 100,
+		WallTimeMs: 500,
+	}
+	require.NoError(t, store.UpdateStepState(ctx, "meta-iso", StepState{
+		StepID:   "step-1",
+		Status:   RunCompleted,
+		Metadata: meta,
+	}))
+
+	// Get a copy and mutate its metadata.
+	got, err := store.GetRun(ctx, "meta-iso")
+	require.NoError(t, err)
+	got.Steps["step-1"].Metadata.TokensUsed = 9999
+
+	// Original in store should be unchanged.
+	got2, err := store.GetRun(ctx, "meta-iso")
+	require.NoError(t, err)
+	assert.Equal(t, 100, got2.Steps["step-1"].Metadata.TokensUsed)
+}


### PR DESCRIPTION
## Summary

Add per-step execution metadata to the orchestrator, enabling observability for token usage, LLM call counts, retries, wall time, and estimated cost for every completed step.

This is **RFC 0006 PR 4a** — StepExecutionMetadata + Observability.

## Changes

### `internal/state/state.go`
- New `StepExecutionMetadata` struct: `TokensUsed`, `LLMCallCount`, `RetryCount`, `CacheHit`, `WallTimeMs`, `EstimatedCostUSD`
- Added `Metadata *StepExecutionMetadata` field to `StepState`
- Updated `deepCopyRun()` to deep-copy metadata pointers

### `internal/executor/executor.go`
- Extended `ExecuteResult` with `RetryCount` and `WallTimeMs` fields
- Executor now measures wall time via `time.Since(start)` and tracks retry attempt count
- Added INFO-level log on successful dispatch with wall time and retry count

### `internal/scheduler/scheduler.go`
- New `buildStepMetadata()` helper: constructs `StepExecutionMetadata` from executor result, response metadata (tokens, LLM calls), and cost data
- `executeStep()` now populates `StepState.Metadata` on completion
- Added INFO-level "step completed" log with observability fields (tokens, retries, wall time, estimated cost)

### `internal/server/workflow_handlers.go`
- `runToResponse()` now populates per-step data (status, output, error, timestamps, metadata) in the `GET /api/v1/workflows/{id}/status` response — previously returned an empty steps map

### Tests
- **State**: metadata storage/retrieval, nil metadata, deep-copy isolation
- **Executor**: wall time tracking, retry count on successful retries, failure returns no metadata
- **Scheduler**: metadata populated on completion, graceful degradation (missing fields → zero), per-direction token summing, INFO log verification
- **Server**: metadata appears in status API response JSON, absent when nil

## PR Checklist
- [x] `go test ./internal/state/ -v -race` passes
- [x] `go test ./internal/executor/ -v -race` passes
- [x] `go test ./internal/server/ -v -race` passes
- [x] `go test ./internal/scheduler/ -v -race` passes
- [x] `StepExecutionMetadata` struct defined with all 6 fields
- [x] Executor populates metadata after each step
- [x] Status API includes per-step metadata
- [x] Metadata logged at INFO level
- [x] `CacheHit` always `false` until PR 4b

## Size
523 lines changed (9 files)