### PR TITLE
fix(planner,agents): RFC 0006 PR 5c — Planner/Schema + Python Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,8 +48,13 @@ All notable changes to this project will be documented in this file.
   replacing inline magic numbers in `base.py` (RFC 0006 PR 1c, #83)
 - *(agents)* Raise `max_tokens` task agent default from 4096 → **8192** — covers typical
   code review and generation without truncation (RFC 0006 §B, #83)
-- *(agents)* `_run_llm_loop()` now rejects negative `max_llm_calls` / `max_tokens` values
-  from `TaskInputConfig` with `ValueError` (RFC 0006 PR 1c, #83)
+- *(schema)* Add `description` attributes to step-level execution limit properties
+  (`timeout_seconds`, `max_llm_calls`, `max_tokens`, `context_budget`) in
+  `schemas/workflow.schema.json` for VS Code YAML extension hover hints (RFC 0006 PR 5c)
+- *(agents)* `_run_llm_loop()` rejects negative `max_llm_calls` / `max_tokens` values
+  from `TaskInputConfig` with `TaskOutput(FAILED, error_type="permanent")` — aligns with
+  all other error conditions in the loop that return structured `TaskOutput` rather than
+  raising exceptions (RFC 0006 PRs 1c+5c)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-17 (RFC 0006 PR 5b merged)  
+> **Last updated**: 2026-04-17 (RFC 0006 PR 5c merged)  
 > **Current phase**: v0.2.0 (Persona Core) — 🚧 In Progress  
-> **Current milestone**: RFC 0006 (Efficiency & Execution Limits) — PR 5c + 6 remain
+> **Current milestone**: RFC 0006 (Efficiency & Execution Limits) — PR 6 remains
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -34,7 +34,7 @@ Internal RFCs are the engineering planning tool. They do not drive version numbe
 | [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor | v0.1.0 | ✅ Implemented |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server | v0.1.0 | ✅ Implemented |
 | [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | v0.2.0 | ✅ Implemented |
-| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | v0.2.0 | 🚧 Implementing (10/12) |
+| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | v0.2.0 | 🚧 Implementing (11/12) |
 | [0007](docs/rfcs/0007-conditional-looped-workflow-control-flow.md) | Conditional & Looped Workflow Control Flow | v0.3.0 | 📋 Proposed |
 | [0008](docs/rfcs/0008-agent-memory-context-optimization.md) | Agent Memory & Context Optimization | v0.3.0 | 👍 Accepted |
 | [0009](docs/rfcs/0009-security-sandboxing.md) | Agent Identity, Security & Sandboxing | v0.3.0 (Phases 1–2) + v0.4.0 (Phases 3–4) | 📋 Proposed |
@@ -164,14 +164,14 @@ v0.1.0 complete — end-to-end execution working
 | RFC | Title | Status | PRs | Merged |
 |-----|-------|--------|-----|--------|
 | [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | ✅ Implemented | 20 | 20/20 |
-| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | 🚧 Implementing | 12 | 10/12 |
+| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | 🚧 Implementing | 12 | 11/12 |
 
 ### RFC 0006 — Execution Progress
 
 ```
 RFC 0005 (PersonaAgent + Memory + TaskAgent)              ✅ Done (20/20)
     ↓
-RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (10/12)
+RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (11/12)
     PR 1a — defaults package + Step limits + schema       ✅ #79
     PR 1b — executor + scheduler limit wiring             ✅ #81
     PR 1c — Python defaults + validation                  ✅ #83
@@ -182,13 +182,13 @@ RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (10/
     PR 4b — response cache + cost endpoint                ✅ #88
     PR 5a — executor + scheduler + state follow-ups       ✅ #90
     PR 5b — cost package hardening                        ✅ #91
-    PR 5c — planner/schema + Python fixes                 ⬜
+    PR 5c — planner/schema + Python fixes                 ✅ #92
     PR 6  — RFC close                                     ⬜
     ↓
 v0.2.0 complete
 ```
 
-> PRs 5a–5b merged. PR 5c (planner/schema + Python fixes) and PR 6 (RFC close) remain.
+> PRs 5a–5c merged. PR 6 (RFC close) remains.
 
 ### Component Status
 
@@ -476,6 +476,7 @@ v0.4.0 complete
 | [#88](https://github.com/mkhomutov/Persatrix/pull/88) | feat(cost): response cache + cost summary endpoint (RFC 0006 PR 4b) | 0006 (4b/12) | 2026-04-17 |
 | [#90](https://github.com/mkhomutov/Persatrix/pull/90) | fix(executor,scheduler,state): RFC 0006 PR 5a — execution follow-up fixes | 0006 (5a/12) | 2026-04-17 |
 | [#91](https://github.com/mkhomutov/Persatrix/pull/91) | fix(cost): atomic budget snapshot, BudgetError struct, config validation (RFC 0006 PR 5b) | 0006 (5b/12) | 2026-04-17 |
+| [#92](https://github.com/mkhomutov/Persatrix/pull/92) | fix(planner,agents): RFC 0006 PR 5c — Planner/Schema + Python Fixes | 0006 (5c/12) | 2026-04-17 |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-17 (RFC 0006 PR 5a merged)  
+> **Last updated**: 2026-04-17 (RFC 0006 PR 5b merged)  
 > **Current phase**: v0.2.0 (Persona Core) — 🚧 In Progress  
-> **Current milestone**: RFC 0006 (Efficiency & Execution Limits) — PRs 5b–5c + 6 remain
+> **Current milestone**: RFC 0006 (Efficiency & Execution Limits) — PR 5c + 6 remain
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -34,7 +34,7 @@ Internal RFCs are the engineering planning tool. They do not drive version numbe
 | [0003](docs/rfcs/0003-scheduler-executor.md) | Scheduler & Executor | v0.1.0 | ✅ Implemented |
 | [0004](docs/rfcs/0004-python-agent-grpc-server.md) | Python Agent gRPC Server | v0.1.0 | ✅ Implemented |
 | [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | v0.2.0 | ✅ Implemented |
-| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | v0.2.0 | 🚧 Implementing (9/12) |
+| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | v0.2.0 | 🚧 Implementing (10/12) |
 | [0007](docs/rfcs/0007-conditional-looped-workflow-control-flow.md) | Conditional & Looped Workflow Control Flow | v0.3.0 | 📋 Proposed |
 | [0008](docs/rfcs/0008-agent-memory-context-optimization.md) | Agent Memory & Context Optimization | v0.3.0 | 👍 Accepted |
 | [0009](docs/rfcs/0009-security-sandboxing.md) | Agent Identity, Security & Sandboxing | v0.3.0 (Phases 1–2) + v0.4.0 (Phases 3–4) | 📋 Proposed |
@@ -164,14 +164,14 @@ v0.1.0 complete — end-to-end execution working
 | RFC | Title | Status | PRs | Merged |
 |-----|-------|--------|-----|--------|
 | [0005](docs/rfcs/0005-persona-agent-memory.md) | Persona Agent & Memory System | ✅ Implemented | 20 | 20/20 |
-| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | 🚧 Implementing | 12 | 9/12 |
+| [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | 🚧 Implementing | 12 | 10/12 |
 
 ### RFC 0006 — Execution Progress
 
 ```
 RFC 0005 (PersonaAgent + Memory + TaskAgent)              ✅ Done (20/20)
     ↓
-RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (9/12)
+RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (10/12)
     PR 1a — defaults package + Step limits + schema       ✅ #79
     PR 1b — executor + scheduler limit wiring             ✅ #81
     PR 1c — Python defaults + validation                  ✅ #83
@@ -181,14 +181,14 @@ RFC 0006 (Efficiency & Execution Limits)                  🚧 Implementing (9/1
     PR 4a — StepExecutionMetadata + observability         ✅ #87
     PR 4b — response cache + cost endpoint                ✅ #88
     PR 5a — executor + scheduler + state follow-ups       ✅ #90
-    PR 5b — cost package hardening                        ⬜
+    PR 5b — cost package hardening                        ✅ #91
     PR 5c — planner/schema + Python fixes                 ⬜
     PR 6  — RFC close                                     ⬜
     ↓
 v0.2.0 complete
 ```
 
-> PR 5a merged. PRs 5b–5c (review follow-ups, parallel) and PR 6 (RFC close) remain.
+> PRs 5a–5b merged. PR 5c (planner/schema + Python fixes) and PR 6 (RFC close) remain.
 
 ### Component Status
 
@@ -475,6 +475,7 @@ v0.4.0 complete
 | [#87](https://github.com/mkhomutov/Persatrix/pull/87) | feat(state): StepExecutionMetadata + observability (RFC 0006 PR 4a) | 0006 (4a/12) | 2026-04-17 |
 | [#88](https://github.com/mkhomutov/Persatrix/pull/88) | feat(cost): response cache + cost summary endpoint (RFC 0006 PR 4b) | 0006 (4b/12) | 2026-04-17 |
 | [#90](https://github.com/mkhomutov/Persatrix/pull/90) | fix(executor,scheduler,state): RFC 0006 PR 5a — execution follow-up fixes | 0006 (5a/12) | 2026-04-17 |
+| [#91](https://github.com/mkhomutov/Persatrix/pull/91) | fix(cost): atomic budget snapshot, BudgetError struct, config validation (RFC 0006 PR 5b) | 0006 (5b/12) | 2026-04-17 |
 
 ---
 

--- a/agents/base.py
+++ b/agents/base.py
@@ -248,7 +248,11 @@ class BaseAgent(ABC):
         # Reject negative limits immediately — they are not a valid sentinel
         # and indicate a misconfigured TaskConfig from the orchestrator.
         if task.config.max_llm_calls < 0 or task.config.max_tokens < 0:
-            raise ValueError("Negative execution limits are not allowed")
+            return TaskOutput(
+                status=TaskStatus.FAILED,
+                result="Negative execution limits are not allowed",
+                metadata={"error_type": "permanent"},
+            )
 
         # 0 is the sentinel for "not set" (falsy), so `or` falls through
         # to the agent-level default, then to the system default.

--- a/agents/defaults.py
+++ b/agents/defaults.py
@@ -28,4 +28,6 @@ DEFAULT_MAX_TOKENS: int = 8192
 # Agents that do not receive an explicit timeout from TaskConfig fall back
 # to this value. Orchestrator-side default is defined in
 # internal/defaults/defaults.go as DefaultTimeoutSeconds (60).
+# Used by executor deadline derivation (PR 2); Python-side timeout wiring
+# deferred to RFC 0008.
 DEFAULT_TIMEOUT_SECONDS: int = 60

--- a/docs/rfcs/0006-pr-plan.md
+++ b/docs/rfcs/0006-pr-plan.md
@@ -100,8 +100,8 @@ PR 6 (RFC close)
 
 **Should Fix (before merge):**
 
-- [ ] Add `TestParse_StepLimits_MinimumValidValues` with `timeout_seconds: 1`, `max_llm_calls: 1`, `max_tokens: 1`, `context_budget: 1`. Verifies schema `minimum: 1` boundary is correctly parsed by Go. *(Location: `internal/planner/planner_test.go`)*
-- [ ] Add `// TODO(RFC-0008): Enforce context budget during execution.` to the `ContextBudget` field comment in `Step` struct — makes deferred work searchable and consistent with project phase stub convention. *(Location: `internal/planner/planner.go`)*
+- [x] Add `TestParse_StepLimits_MinimumValidValues` with `timeout_seconds: 1`, `max_llm_calls: 1`, `max_tokens: 1`, `context_budget: 1`. Verifies schema `minimum: 1` boundary is correctly parsed by Go. *(Location: `internal/planner/planner_test.go`)* — Addressed in PR 5c
+- [x] Add `// TODO(RFC-0008): Enforce context budget during execution.` to the `ContextBudget` field comment in `Step` struct — makes deferred work searchable and consistent with project phase stub convention. *(Location: `internal/planner/planner.go`)* — Addressed in PR 5c
 
 **Deferred to PR 5:**
 
@@ -856,8 +856,8 @@ PR 6 (RFC close)
 | 3b | 3 | ~180–260 lines | ~310–440 lines | ✅ Merged (PR #86) |
 | 4a | 4 | ~180–260 lines | ~310–440 lines | ✅ Merged (PR #87) |
 | 4b | 4 | ~200–300 lines | ~340–510 lines | ✅ Merged (PR #88) |
-| 5a | Follow-up | ~150–240 lines | ~250–400 lines | Not started |
-| 5b | Follow-up | ~120–210 lines | ~200–350 lines | ⬜ In review |
+| 5a | Follow-up | ~150–240 lines | ~250–400 lines | ✅ Merged (PR #90) |
+| 5b | Follow-up | ~120–210 lines | ~200–350 lines | ✅ Merged (PR #91) |
 | 5c | Follow-up | ~70–120 lines | ~120–200 lines | Not started |
 | 6 | Close | ~50–100 lines | ~50–100 lines | Not started |
 | **Total** | | **~1,880–2,860** | **~3,160–4,770** | |

--- a/docs/rfcs/0006-pr-plan.md
+++ b/docs/rfcs/0006-pr-plan.md
@@ -809,13 +809,13 @@ PR 6 (RFC close)
 
 #### PR checklist
 
-- [ ] `pytest tests/unit/python/ -v` passes
-- [ ] `ruff check agents/` clean
-- [ ] `mypy agents/` passes
-- [ ] `go test ./internal/planner/ -v -race` passes
-- [ ] `make validate` passes
-- [ ] M1 negative-limit error reporting aligned with `_run_llm_loop()` pattern
-- [ ] All 6 addressed findings resolved
+- [x] `pytest tests/unit/python/ -v` passes
+- [x] `ruff check agents/` clean
+- [x] `mypy agents/` passes
+- [x] `go test ./internal/planner/ -v -race` passes
+- [x] `make validate` passes
+- [x] M1 negative-limit error reporting aligned with `_run_llm_loop()` pattern
+- [x] All 6 addressed findings resolved
 
 #### Review Findings (PR #92)
 
@@ -872,7 +872,7 @@ PR 6 (RFC close)
 | 4b | 4 | ~200–300 lines | ~340–510 lines | ✅ Merged (PR #88) |
 | 5a | Follow-up | ~150–240 lines | ~250–400 lines | ✅ Merged (PR #90) |
 | 5b | Follow-up | ~120–210 lines | ~200–350 lines | ✅ Merged (PR #91) |
-| 5c | Follow-up | ~70–120 lines | ~120–200 lines | Open (PR #92) |
+| 5c | Follow-up | ~70–120 lines | ~120–200 lines | ✅ Merged (PR #92) |
 | 6 | Close | ~50–100 lines | ~50–100 lines | Not started |
 | **Total** | | **~1,880–2,860** | **~3,160–4,770** | |
 

--- a/docs/rfcs/0006-pr-plan.md
+++ b/docs/rfcs/0006-pr-plan.md
@@ -817,6 +817,20 @@ PR 6 (RFC close)
 - [ ] M1 negative-limit error reporting aligned with `_run_llm_loop()` pattern
 - [ ] All 6 addressed findings resolved
 
+#### Review Findings (PR #92)
+
+**Should Fix (quality improvement):**
+
+1. **S-01 (Low) — Misleading test method names** — `test_negative_max_llm_calls_raises`, `test_negative_max_tokens_raises`, `test_negative_both_raises` no longer raise exceptions — they now return `TaskOutput(FAILED)`. Names should be `test_negative_max_llm_calls_returns_failed`, `test_negative_max_tokens_returns_failed`, `test_negative_both_returns_failed` to match actual behavior. Test names are the first thing developers read during failures; misleading names cause debugging confusion. *(Location: `tests/unit/python/test_agents.py` lines 341, 349, 357)*
+
+2. **S-02 (Low) — Unregistered "noop" tool in loop exhaustion test** — `test_loop_exhaustion_uses_default_max_llm_calls` uses `ToolCall(name="noop")` but no "noop" tool is registered. The test works because `_execute_tools` handles unknown tools gracefully (returns "Unknown tool: noop" error), but this couples the test to an implementation detail. If `_execute_tools` changes to raise on unknown tools, this test breaks unexpectedly. Fix: register an explicit `@tool(name="noop", description="No-op tool")` fixture before creating the mock responses. *(Location: `tests/unit/python/test_agents.py` line 428)*
+
+**Nice to Have (follow-up):**
+
+3. **N-01 — Distinguish which limit was negative in error metadata** — The combined `max_llm_calls < 0 or max_tokens < 0` guard reports one generic error message. Adding `metadata["invalid_fields"] = [...]` would help operators diagnose misconfigured TaskConfigs. Very low priority since the `permanent` error_type already prevents retries. *(Location: `agents/base.py` line 250)*
+
+4. **N-02 — Add explicit loop iteration assertion to `test_explicit_max_llm_calls_used_as_is`** — The test (line 393) only verifies `COMPLETED` status but does not assert that the loop ran with `max_llm_calls=3` (the configured value). Adding a TOOL_USE scenario with exactly 3 iterations would strengthen coverage. Low priority since the zero-resolution and exhaustion tests already validate the loop mechanics. *(Location: `tests/unit/python/test_agents.py` line 393)*
+
 ---
 
 ### PR 6: `feature/v02-rfc0006-close` — RFC Close
@@ -858,7 +872,7 @@ PR 6 (RFC close)
 | 4b | 4 | ~200–300 lines | ~340–510 lines | ✅ Merged (PR #88) |
 | 5a | Follow-up | ~150–240 lines | ~250–400 lines | ✅ Merged (PR #90) |
 | 5b | Follow-up | ~120–210 lines | ~200–350 lines | ✅ Merged (PR #91) |
-| 5c | Follow-up | ~70–120 lines | ~120–200 lines | Not started |
+| 5c | Follow-up | ~70–120 lines | ~120–200 lines | Open (PR #92) |
 | 6 | Close | ~50–100 lines | ~50–100 lines | Not started |
 | **Total** | | **~1,880–2,860** | **~3,160–4,770** | |
 

--- a/internal/planner/planner.go
+++ b/internal/planner/planner.go
@@ -72,7 +72,7 @@ type Step struct {
 
 	// ContextBudget is a step-level context window budget in tokens (RFC 0008).
 	// Added here alongside RFC 0006 fields to avoid a separate schema migration.
-	// No enforcement logic in this PR — that is RFC 0008's scope.
+	// TODO(RFC-0008): Enforce context budget during execution.
 	ContextBudget int `yaml:"context_budget"`
 
 	// Cacheable marks this step as eligible for response caching (RFC 0006 PR 4b).

--- a/internal/planner/planner_test.go
+++ b/internal/planner/planner_test.go
@@ -830,6 +830,67 @@ workflow:
 	assert.Equal(t, 0, wf.Steps[0].ContextBudget, "absent limit should be zero")
 }
 
+func TestParse_StepLimits_MultiStepInheritance(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Multi-step inheritance"
+  steps:
+    - id: "with-limits"
+      agent: "coder"
+      input: "implement feature"
+      max_llm_calls: 10
+      timeout_seconds: 120
+    - id: "no-limits"
+      agent: "reviewer"
+      input: "review code"
+      depends_on: ["with-limits"]
+`
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.NoError(t, err)
+	require.Len(t, wf.Steps, 2)
+
+	// Step A: explicit limits preserved.
+	assert.Equal(t, 10, wf.Steps[0].MaxLLMCalls)
+	assert.Equal(t, 120, wf.Steps[0].TimeoutSeconds)
+	assert.Equal(t, 0, wf.Steps[0].MaxTokens, "absent limit should be zero")
+	assert.Equal(t, 0, wf.Steps[0].ContextBudget, "absent limit should be zero")
+
+	// Step B: all limits zero (inherit from agent config or system defaults).
+	assert.Equal(t, 0, wf.Steps[1].MaxLLMCalls)
+	assert.Equal(t, 0, wf.Steps[1].TimeoutSeconds)
+	assert.Equal(t, 0, wf.Steps[1].MaxTokens)
+	assert.Equal(t, 0, wf.Steps[1].ContextBudget)
+}
+
+func TestParse_StepLimits_MinimumValidValues(t *testing.T) {
+	yaml := `
+schema_version: "0.1"
+workflow:
+  id: "test-wf"
+  name: "Minimum boundary"
+  steps:
+    - id: "s1"
+      agent: "planner"
+      input: "hello"
+      timeout_seconds: 1
+      max_llm_calls: 1
+      max_tokens: 1
+      context_budget: 1
+`
+	p := newTestPlanner()
+	wf, err := p.Parse(context.Background(), writeTempYAML(t, yaml))
+	require.NoError(t, err)
+	require.Len(t, wf.Steps, 1)
+
+	assert.Equal(t, 1, wf.Steps[0].TimeoutSeconds)
+	assert.Equal(t, 1, wf.Steps[0].MaxLLMCalls)
+	assert.Equal(t, 1, wf.Steps[0].MaxTokens)
+	assert.Equal(t, 1, wf.Steps[0].ContextBudget)
+}
+
 // --- Helper ---
 
 func writeTempYAML(t *testing.T, content string) string {

--- a/schemas/workflow.schema.json
+++ b/schemas/workflow.schema.json
@@ -27,10 +27,10 @@
               "condition": { "type": "string" },
               "approval_required": { "type": "boolean" },
               "approval_timeout": { "type": "integer" },
-              "timeout_seconds": { "type": "integer", "minimum": 1 },
-              "max_llm_calls": { "type": "integer", "minimum": 1 },
-              "max_tokens": { "type": "integer", "minimum": 1 },
-              "context_budget": { "type": "integer", "minimum": 1 },
+              "timeout_seconds": { "type": "integer", "minimum": 1, "description": "Per-step wall-clock timeout in seconds. Minimum 1 when specified. Omit to inherit from agent config or system defaults." },
+              "max_llm_calls": { "type": "integer", "minimum": 1, "description": "Maximum LLM calls for this step. Minimum 1 when specified. Omit to inherit from agent config or system defaults." },
+              "max_tokens": { "type": "integer", "minimum": 1, "description": "Maximum output tokens per LLM call for this step. Minimum 1 when specified. Omit to inherit from agent config or system defaults." },
+              "context_budget": { "type": "integer", "minimum": 1, "description": "Context window budget in tokens for this step (RFC 0008). Minimum 1 when specified. Omit to inherit from agent config or system defaults." },
               "cacheable": { "type": "boolean" }
             }
           }

--- a/tests/unit/python/test_agents.py
+++ b/tests/unit/python/test_agents.py
@@ -341,7 +341,7 @@ _LIMIT_CONFIG: dict = {
 class TestExecutionLimitValidation:
     """Verify RFC 0006 §B: negative limits rejected, zero resolved to defaults."""
 
-    async def test_negative_max_llm_calls_raises(self):
+    async def test_negative_max_llm_calls_returns_failed(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
         output = await agent.handle(_task_with_config(TaskInputConfig(max_llm_calls=-1)))
@@ -349,7 +349,7 @@ class TestExecutionLimitValidation:
         assert output.result == "Negative execution limits are not allowed"
         assert output.metadata["error_type"] == "permanent"
 
-    async def test_negative_max_tokens_raises(self):
+    async def test_negative_max_tokens_returns_failed(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
         output = await agent.handle(_task_with_config(TaskInputConfig(max_tokens=-1)))
@@ -357,7 +357,7 @@ class TestExecutionLimitValidation:
         assert output.result == "Negative execution limits are not allowed"
         assert output.metadata["error_type"] == "permanent"
 
-    async def test_negative_both_raises(self):
+    async def test_negative_both_returns_failed(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
         output = await agent.handle(
@@ -420,6 +420,12 @@ class TestExecutionLimitValidation:
 
     async def test_loop_exhaustion_uses_default_max_llm_calls(self):
         """With max_llm_calls=0 and LLM always returning TOOL_USE, loop runs DEFAULT_MAX_LLM_CALLS times."""
+        # Register a noop tool so the test doesn't depend on _execute_tools'
+        # graceful handling of unknown tools (which returns an error result).
+        @tool(name="noop", description="No-op tool for loop exhaustion test")
+        async def noop_tool() -> ToolResult:
+            return ToolResult(success=True, data="no-op")
+
         tool_response = LLMResponse(
             text=None,
             stop_reason=StopReason.TOOL_USE,

--- a/tests/unit/python/test_agents.py
+++ b/tests/unit/python/test_agents.py
@@ -344,20 +344,28 @@ class TestExecutionLimitValidation:
     async def test_negative_max_llm_calls_raises(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
-        with pytest.raises(ValueError, match="Negative execution limits are not allowed"):
-            await agent.handle(_task_with_config(TaskInputConfig(max_llm_calls=-1)))
+        output = await agent.handle(_task_with_config(TaskInputConfig(max_llm_calls=-1)))
+        assert output.status == TaskStatus.FAILED
+        assert output.result == "Negative execution limits are not allowed"
+        assert output.metadata["error_type"] == "permanent"
 
     async def test_negative_max_tokens_raises(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
-        with pytest.raises(ValueError, match="Negative execution limits are not allowed"):
-            await agent.handle(_task_with_config(TaskInputConfig(max_tokens=-1)))
+        output = await agent.handle(_task_with_config(TaskInputConfig(max_tokens=-1)))
+        assert output.status == TaskStatus.FAILED
+        assert output.result == "Negative execution limits are not allowed"
+        assert output.metadata["error_type"] == "permanent"
 
     async def test_negative_both_raises(self):
         client = _make_client()
         agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
-        with pytest.raises(ValueError, match="Negative execution limits are not allowed"):
-            await agent.handle(_task_with_config(TaskInputConfig(max_llm_calls=-5, max_tokens=-100)))
+        output = await agent.handle(
+            _task_with_config(TaskInputConfig(max_llm_calls=-5, max_tokens=-100))
+        )
+        assert output.status == TaskStatus.FAILED
+        assert output.result == "Negative execution limits are not allowed"
+        assert output.metadata["error_type"] == "permanent"
 
     async def test_zero_max_llm_calls_resolves_to_default(self):
         """Zero max_llm_calls falls through to DEFAULT_MAX_LLM_CALLS (5)."""
@@ -409,3 +417,20 @@ class TestExecutionLimitValidation:
         call_kwargs = client._provider.create_message.call_args[1]
         # Agent config (2048) should take priority over system default (8192).
         assert call_kwargs["max_tokens"] == 2048
+
+    async def test_loop_exhaustion_uses_default_max_llm_calls(self):
+        """With max_llm_calls=0 and LLM always returning TOOL_USE, loop runs DEFAULT_MAX_LLM_CALLS times."""
+        tool_response = LLMResponse(
+            text=None,
+            stop_reason=StopReason.TOOL_USE,
+            usage=Usage(10, 20),
+            tool_calls=[ToolCall(id="tc1", name="noop", input={})],
+        )
+        # Provide enough responses for DEFAULT_MAX_LLM_CALLS iterations.
+        responses = [tool_response] * DEFAULT_MAX_LLM_CALLS
+        client = _make_client(responses=responses)
+        agent = TaskAgent(agent_id="test-agent", config=_LIMIT_CONFIG, llm_client=client)
+        output = await agent.handle(_task_with_config(TaskInputConfig(max_llm_calls=0)))
+        assert output.status == TaskStatus.FAILED
+        assert "Max LLM call iterations exceeded" in output.result
+        assert client._provider.create_message.call_count == DEFAULT_MAX_LLM_CALLS


### PR DESCRIPTION
## Summary

RFC 0006 PR 5c — addresses 6 cross-cutting review findings from PRs 1a, 1c, and 1b across planner tests, workflow schema, and Python agent error handling.

**RFC**: [0006-efficiency-execution-limits.md](docs/rfcs/0006-efficiency-execution-limits.md)
**PR Plan**: [0006-pr-plan.md](docs/rfcs/0006-pr-plan.md) → PR 5c section
**Depends on**: All core PRs (1a–4b) + follow-ups 5a, 5b merged ✅

## Changes

### Go Planner (`internal/planner/`)
- **Multi-step limit inheritance test** (finding 3): Two-step workflow where step A has explicit `max_llm_calls: 10, timeout_seconds: 120` and step B has no limits — verifies both parse correctly with expected values
- **Minimum valid values test** (PR #79 should-fix): Boundary test with `timeout_seconds: 1, max_llm_calls: 1, max_tokens: 1, context_budget: 1` — verifies schema `minimum: 1` is correctly parsed
- **TODO(RFC-0008) comment** (PR #79 should-fix): Add searchable `TODO(RFC-0008): Enforce context budget during execution.` to `ContextBudget` field

### Workflow Schema (`schemas/workflow.schema.json`)
- **Description attributes** (findings 4, 5): Add `"description"` to `timeout_seconds`, `max_llm_calls`, `max_tokens`, `context_budget` step properties — enables VS Code YAML extension hover hints

### Python Agents (`agents/`)
- **ValueError → TaskOutput(FAILED)** (M1): Replace `raise ValueError("Negative execution limits are not allowed")` with `return TaskOutput(status=FAILED, result="...", metadata={"error_type": "permanent"})` — aligns with all other `_run_llm_loop()` error conditions that return structured `TaskOutput`
- **DEFAULT_TIMEOUT_SECONDS comment** (M2): Add forward-declaration comment explaining the constant is used by executor deadline derivation (PR 2) and Python-side wiring is deferred to RFC 0008

### Python Tests (`tests/unit/python/`)
- Update 3 negative-limit tests to expect `TaskOutput(FAILED)` instead of `ValueError`
- Add **loop-exhaustion test** (L2): Mock LLM always returns `TOOL_USE` with `max_llm_calls=0` → verifies exactly `DEFAULT_MAX_LLM_CALLS` (5) iterations

### Housekeeping
- Fix `go fmt` formatting for 14 Go files with pre-existing line-ending issues
- Update ROADMAP with PR 5b (#91) merged
- Update PR plan size table and review finding checkboxes

## Addressed Findings

| Source | ID | Finding | Severity |
|--------|----|---------|----------|
| PR 1c (#83) | M1 | `ValueError` vs `TaskOutput(FAILED)` inconsistency | Medium |
| PR 1c (#83) | M2 | `DEFAULT_TIMEOUT_SECONDS` defined but unused | Medium |
| PR 1c (#83) | L2 | No loop-exhaustion test for default (5 iterations) | Low |
| PR 1a (#79) | 3 | Multi-step limit inheritance test | Low |
| PR 1a (#79) | 4 | Schema description parity | Low |
| PR 1a (#79) | 5 | Document zero-value behavior in schema | Low |

## Test Results

- `go test ./internal/planner/ -v -race` ✅
- `pytest tests/unit/python/test_agents.py -v` ✅ (36/36)
- `make validate` ✅
- `ruff check agents/` ✅
- Pre-commit hooks: 6/6 passed ✅