### PR TITLE
docs: README overhaul for v0.2.0 (v0.2 release prep B-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,44 @@
 # Persatrix
 
-A general-purpose **agent society engine** — a runtime for creating, connecting, and observing groups of AI agents that behave as individuals within organizational or social structures.
+[![CI](https://github.com/mkhomutov/Persatrix/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mkhomutov/Persatrix/actions/workflows/ci.yml)
+[![License: BUSL-1.1](https://img.shields.io/badge/license-BUSL--1.1-blue.svg)](LICENSE)
+[![Go 1.24+](https://img.shields.io/badge/Go-1.24%2B-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![Python 3.11+](https://img.shields.io/badge/Python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![Rust 1.80+](https://img.shields.io/badge/Rust-1.80%2B-DEA584?logo=rust&logoColor=white)](https://www.rust-lang.org/)
+
+A general-purpose **agent society engine** — a runtime for creating, connecting, and
+observing groups of AI agents that behave as individuals within organizational or
+social structures.
+
+With **v0.2.0** (Persona Core — Persatrix's first public release) you can:
+
+- Define a persona agent with a personality, a role, and explicit behaviour dimensions.
+- Launch it as a long-running gRPC service with a tick-driven autonomy loop.
+- Give it three tiers of memory — episodic, relationship, and working — that persist
+  across restarts.
+- Bound its cost and execution with per-run token budgets, LLM-call limits, and a
+  shared response cache.
+- Submit classical task workflows from v0.1 alongside personas — the orchestrator
+  handles both through the same gRPC surface.
+
+---
+
+## What's in v0.2
+
+| Capability | Where it lives | Spec |
+|------------|----------------|------|
+| **Persona agents** — tick loop, structured behaviour, event dispatch | [agents/persona_runtime/](agents/persona_runtime/), [agents/persona.py](agents/persona.py) | [RFC 0005](docs/rfcs/0005-persona-agent-memory.md) |
+| **Three-tier memory** — episodic (SQLite), relationship, working | [agents/memory/](agents/memory/) | [RFC 0005](docs/rfcs/0005-persona-agent-memory.md) |
+| **Cost tracking & budgets** — token counting, per-run enforcement, `GET /api/v1/cost/summary` | [internal/cost/](internal/cost/), [internal/server/cost_handlers.go](internal/server/cost_handlers.go) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
+| **Execution limits** — `max_llm_calls`, derived per-call deadlines, shared retry budget | [internal/executor/](internal/executor/), [internal/scheduler/](internal/scheduler/) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
+| **Response cache** — in-memory cache keyed on prompt + config | [internal/cost/cache.go](internal/cost/cache.go) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
+| **MCP bridge** — use Model Context Protocol servers as agent tools | [agents/tools/](agents/tools/) | [RFC 0004](docs/rfcs/0004-python-agent-grpc-server.md) |
+| **OTEL tracing** — spans flowing through orchestrator → agents, visible in Jaeger | [internal/](internal/) | — |
+
+> **Upgrade note from v0.1 baseline:** `max_llm_calls` default changed from `10` to
+> `5`. See [CHANGELOG.md](CHANGELOG.md).
+
+---
 
 ## Quick Start
 
@@ -24,7 +62,7 @@ cd Persatrix
 cp .env.example .env
 # Edit .env with your ANTHROPIC_API_KEY
 
-# Build everything
+# Build everything (proto + Go + Rust)
 make all
 
 # Install Python agent dependencies
@@ -39,11 +77,11 @@ make validate
 ```bash
 docker compose up -d
 
-# View Jaeger UI (traces): http://localhost:16686
-# Orchestrator API:        http://localhost:8080
+# Orchestrator API:   http://localhost:8080
+# Jaeger UI (traces): http://localhost:16686
 ```
 
-### Run a Workflow
+### Run a Workflow (v0.1 surface)
 
 ```bash
 # Via CLI
@@ -55,6 +93,40 @@ curl -X POST http://localhost:8080/api/v1/workflows/run \
   -d '{"workflow": "feature-builder", "input": "Build a REST API for user management"}'
 ```
 
+### Run a Persona Agent (v0.2)
+
+Personas are declared in [config/agents.yaml](config/agents.yaml). A worked example
+is shipped with the repo — `sarah-chen`, a semi-autonomous "VP of Engineering"
+persona with structured behaviour, quirks, and memory configuration.
+
+```bash
+# 1. Start the orchestrator (if not already running via compose)
+make run
+
+# 2. Launch the persona as a gRPC service (separate terminal)
+make run-agent AGENT=sarah-chen
+
+# 3. Ping it through the orchestrator
+orch agent test --persona sarah-chen
+
+# 4. Inspect what it's done
+orch logs --agent sarah-chen
+```
+
+The persona's tick loop fires every `autonomy.tick_interval_seconds`, reads
+episodic and relationship memory, decides on up to `max_actions_per_tick`
+actions, and writes results back. State survives process restarts.
+
+### Inspect Cost & Budget (v0.2)
+
+```bash
+# Token usage and cost for the most recent runs
+curl http://localhost:8080/api/v1/cost/summary
+```
+
+Budgets are enforced per workflow run: exceeding `max_tokens` or `max_llm_calls`
+aborts the run with a structured error before further spend accumulates.
+
 ### Run Tests
 
 ```bash
@@ -64,63 +136,99 @@ make test-python        # Python agent tests
 make test-integration   # end-to-end tests
 ```
 
+---
+
 ## Architecture
 
 ```
-CLI (Rust) → Orchestrator (Go) → Agents (Python)
-                  ↓                    ↓
-            gRPC / REST           LLM APIs
-            OTEL Traces           Tools / MCP
+CLI (Rust) ── REST ──► Orchestrator (Go) ── gRPC ──► Agents (Python)
+                            │                            │
+                            │                      LLM APIs, tools,
+                      workflow planning,           MCP servers,
+                      scheduling, state,           three-tier memory
+                      cost, OTEL spans
 ```
 
-**Go** handles orchestration: workflow planning, scheduling, state management, security, and telemetry.
+**Go orchestrator** (`internal/`) owns workflow planning, stage scheduling, agent
+registry, state, cost, telemetry, and security. It never calls an LLM directly.
 
-**Python** handles agent logic: LLM interaction, tool execution, persona behavior, and sub-agent spawning.
+**Python agents** (`agents/`) own LLM interaction, tool execution, persona
+behaviour, memory, and sub-agent spawning. Each agent is a gRPC service.
 
-**Rust** handles the CLI: fast, single-binary distribution.
+**Rust CLI** (`cli/`) is a thin REST client to the orchestrator. All business
+logic is server-side.
 
-**gRPC** connects them: type-safe, cross-language, bidirectional streaming.
+**gRPC/protobuf** (`proto/`) is the cross-language contract. Changes go through
+an RFC.
+
+For the full set of architecture diagrams — system overview, persona runtime
+loop, memory tiers, workflow execution — see [docs/diagrams/](docs/diagrams/).
 
 ## Project Structure
 
 ```
 Persatrix/
-├── cmd/orchestrator/     Go server entry point
-├── internal/             Go packages (planner, scheduler, registry, security, ...)
-├── proto/                Protobuf definitions
-├── agents/               Python agent runtime
-│   ├── base.py           BaseAgent interface
-│   ├── persona.py        PersonaAgent (v0.2+)
-│   └── tools/            Tool system (@tool decorator, MCP bridge)
-├── cli/                  Rust CLI
-├── config/               YAML configuration
-├── workflows/            Workflow definitions
-├── schemas/              JSON Schema for config validation
-├── tests/                Test suites
-└── docker-compose.yaml   Local development stack
+├── cmd/orchestrator/       Go server entry point
+├── internal/               Go packages
+│   ├── planner/            YAML → DAG, cycle detection
+│   ├── scheduler/          Stage-level run driver
+│   ├── executor/           gRPC dispatch + retry
+│   ├── registry/           Agent lookup
+│   ├── state/              Workflow run tracking
+│   ├── server/             REST API + SSE
+│   └── cost/               Token counting, budgets, response cache (v0.2)
+├── proto/                  Protobuf definitions
+├── agents/                 Python agent runtime (persatrix_agents package)
+│   ├── base.py             BaseAgent ABC
+│   ├── persona.py          Persona agent entrypoint
+│   ├── persona_runtime/    Memory context, action loop, state persistence
+│   ├── memory/             Episodic, relationship, working memory (v0.2)
+│   ├── tools/              @tool registry, built-ins, MCP bridge, sandbox
+│   └── server.py           gRPC servicer
+├── cli/                    Rust CLI
+├── config/                 YAML configuration (schema in schemas/)
+├── workflows/              Workflow definitions
+├── docs/                   Specs, RFCs, diagrams, guides, manual tests
+└── docker-compose.yaml     Local development stack
 ```
+
+---
 
 ## Roadmap
 
-| Version | Scope | Status |
-|---------|-------|--------|
-| v0.1    | Core engine: workflows, tools, MCP, security, OTEL, testing | ✅ Complete |
-| v0.2    | Agent societies: personas, channels, protocols, bridges, sub-agents | 📋 Planned |
-| v0.3    | Distributed mesh: multi-node, A2A protocol, platform integrations | 📋 Planned |
-| v0.4+   | Autonomous agents, memory, simulation controls, web dashboard | 📋 Future |
+| Version | What a user can do | Status |
+|---------|-------------------|--------|
+| **v0.1** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
+| **v0.2** | Run persistent AI agents with personas, memory, and cost-bounded execution from a terminal | 🚧 In Progress — first public release |
+| **v0.3** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
+| **v0.4** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
+| **v0.5** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
+| **v0.6** | Run agent societies across multiple nodes and networks | 📋 Planned |
 
-See [ROADMAP.md](ROADMAP.md) for detailed progress tracking, RFC status, and component completion.
+See [ROADMAP.md](ROADMAP.md) for PR-level progress, RFC status, and per-component
+completion.
+
+---
 
 ## Documentation
 
 - [Roadmap & Progress](ROADMAP.md)
-- [MVP Specification](docs/ai-agents-orchestration-spec.md)
-- [Extension Specification](docs/persatrix-extension-spec.md)
-- [Audit Report](docs/persatrix-spec-audit.md)
+- [Changelog](CHANGELOG.md)
+- [Architecture diagrams](docs/diagrams/)
+- [Manual test suite](docs/manual-tests/README.md)
+- [RFCs](docs/rfcs/README.md) — engineering design docs
+- [Development workflow](docs/development-workflow.md)
+- [Branching strategy](docs/BRANCHING.md)
+- [MVP specification](docs/ai-agents-orchestration-spec.md)
+- [Extension specification](docs/persatrix-extension-spec.md)
+- [Spec audit](docs/persatrix-spec-audit.md)
+
+---
 
 ## License
 
 Persatrix is distributed under the Business Source License 1.1 (`BUSL-1.1`).
 Production use is not granted under the default terms in this repository.
-Each version transitions to Apache License, Version 2.0 four years after its first public release.
+Each version transitions to Apache License, Version 2.0 four years after its
+first public release.
 See [LICENSE](LICENSE) for the full terms.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ With **v0.2.0** (Persona Core — Persatrix's first public release) you can:
 | **Cost tracking & budgets** — token counting, per-run enforcement, `GET /api/v1/cost/summary` | [internal/cost/](internal/cost/), [internal/server/cost_handlers.go](internal/server/cost_handlers.go) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
 | **Execution limits** — `max_llm_calls`, derived per-call deadlines, shared retry budget | [internal/executor/](internal/executor/), [internal/scheduler/](internal/scheduler/) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
 | **Response cache** — in-memory cache keyed on prompt + config | [internal/cost/cache.go](internal/cost/cache.go) | [RFC 0006](docs/rfcs/0006-efficiency-execution-limits.md) |
-| **MCP bridge** — use Model Context Protocol servers as agent tools | [agents/tools/](agents/tools/) | [RFC 0004](docs/rfcs/0004-python-agent-grpc-server.md) |
 | **OTEL tracing** — spans flowing through orchestrator → agents, visible in Jaeger | [internal/](internal/) | — |
+
+> The MCP bridge ([agents/tools/mcp_bridge.py](agents/tools/mcp_bridge.py)) is
+> scaffolded but not yet functional — tracked as a follow-up to v0.2. Agents that
+> reference MCP tools emit a startup warning and run without them.
 
 > **Upgrade note from v0.1 baseline:** `max_llm_calls` default changed from `10` to
 > `5`. See [CHANGELOG.md](CHANGELOG.md).
@@ -109,12 +112,14 @@ make run-agent AGENT=sarah-chen
 # 3. Ping it through the orchestrator
 orch agent test --persona sarah-chen
 
-# 4. Inspect what it's done
-orch logs --agent sarah-chen
+# 4. Inspect its registration and status
+orch agent info sarah-chen
 ```
 
+Live tick-loop output — decisions, memory writes, tool calls — streams in the
+terminal where `make run-agent` (or the `agent-*` compose service) is running.
 The persona's tick loop fires every `autonomy.tick_interval_seconds`, reads
-episodic and relationship memory, decides on up to `max_actions_per_tick`
+episodic and relationship memory, decides on up to `autonomy.max_actions_per_tick`
 actions, and writes results back. State survives process restarts.
 
 ### Inspect Cost & Budget (v0.2)
@@ -144,8 +149,8 @@ make test-integration   # end-to-end tests
 CLI (Rust) ── REST ──► Orchestrator (Go) ── gRPC ──► Agents (Python)
                             │                            │
                             │                      LLM APIs, tools,
-                      workflow planning,           MCP servers,
-                      scheduling, state,           three-tier memory
+                      workflow planning,           three-tier memory
+                      scheduling, state,
                       cost, OTEL spans
 ```
 
@@ -162,7 +167,9 @@ logic is server-side.
 an RFC.
 
 For the full set of architecture diagrams — system overview, persona runtime
-loop, memory tiers, workflow execution — see [docs/diagrams/](docs/diagrams/).
+loop, memory tiers, workflow execution — see [docs/diagrams/](docs/diagrams/)
+(Mermaid source embedded in `.md` files; render in-place in any Mermaid-aware
+viewer such as GitHub or VS Code).
 
 ## Project Structure
 
@@ -183,7 +190,7 @@ Persatrix/
 │   ├── persona.py          Persona agent entrypoint
 │   ├── persona_runtime/    Memory context, action loop, state persistence
 │   ├── memory/             Episodic, relationship, working memory (v0.2)
-│   ├── tools/              @tool registry, built-ins, MCP bridge, sandbox
+│   ├── tools/              @tool registry, built-ins, sandbox
 │   └── server.py           gRPC servicer
 ├── cli/                    Rust CLI
 ├── config/                 YAML configuration (schema in schemas/)

--- a/docs/v0.2-release-prep-plan.md
+++ b/docs/v0.2-release-prep-plan.md
@@ -20,8 +20,8 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 |----|-------|-------|--------|--------|-----------|--------|
 | 1 | A | Split `agents/persona_runtime.py` | `feature/v02-release-prep-split-persona-runtime` | ✅ Merged | #95 | 2026-04-17 |
 | 2 | A | Split `internal/scheduler/scheduler.go` | `feature/v02-release-prep-split-scheduler` | ✅ Merged | #96 | 2026-04-18 |
-| 3 | A | Split `agents/memory/episodic.py` + `agents/server.py` | `feature/v02-release-prep-split-memory-server` | 🔀 PR open | — | — |
-| 4 | B | README overhaul | `feature/v02-release-prep-readme` | ⬜ Not started | — | — |
+| 3 | A | Split `agents/memory/episodic.py` + `agents/server.py` | `feature/v02-release-prep-split-memory-server` | ✅ Merged | #97 | 2026-04-18 |
+| 4 | B | README overhaul | `feature/v02-release-prep-readme` | 🔀 PR open | — | — |
 | 5 | B | Persona & memory user guide | `feature/v02-release-prep-persona-guide` | ⬜ Not started | — | — |
 | 6 | B | Generate `CHANGELOG.md` | `feature/v02-release-prep-changelog` | ⬜ Not started | — | — |
 | 7 | B | Architecture diagram refresh | `feature/v02-release-prep-diagrams` | ⬜ Not started | — | — |
@@ -157,7 +157,7 @@ Splitting oversized files before docs/tests ensures docs can reference stable mo
 
 ### PR 3 — Split `agents/memory/episodic.py` and `agents/server.py`
 
-**Status**: 🔀 PR open  
+**Status**: ✅ Merged — PR #97 (2026-04-18)  
 **Branch**: `feature/v02-release-prep-split-memory-server`  
 **Depends on**: nothing  
 **Estimated delta**: ~0 net lines (refactor only)
@@ -187,7 +187,7 @@ Splitting oversized files before docs/tests ensures docs can reference stable mo
 
 ### PR 4 — README overhaul
 
-**Status**: ⬜ Not started  
+**Status**: 🔀 PR open  
 **Branch**: `feature/v02-release-prep-readme`  
 **Depends on**: PRs 1, 2, 3 (stable module layout)  
 **Estimated delta**: ~250 lines


### PR DESCRIPTION
## Summary

PR 4 from the [v0.2.0 Release Preparation Plan](docs/v0.2-release-prep-plan.md) — Track B (Documentation Refresh). Refreshes `README.md` to reflect the v0.2 surface ahead of the first public release. Depends on PRs 1–3 (all merged: #95, #96, #97).

## What changed

**`README.md`**
- **Badges** at top of file: CI status, BUSL-1.1 license, Go 1.24+ / Python 3.11+ / Rust 1.80+.
- **Opening** rewritten for a first-time visitor — what Persatrix is, and what v0.2 concretely lets you do.
- **"What's in v0.2"** feature table linking each capability (persona agents, three-tier memory, cost tracking & budgets, execution limits, response cache, MCP bridge, OTEL tracing) to its module and originating RFC. Includes upgrade-note callout for `max_llm_calls` default change.
- **Quickstart** extended with a persona-agent flow using the shipped `sarah-chen` worked example (launch via `make run-agent AGENT=sarah-chen`, ping via `orch agent test --persona sarah-chen`) and a cost-summary curl.
- **Architecture** section: textual summary of Go/Python/Rust boundaries with a link to [`docs/diagrams/`](docs/diagrams/) for the full diagram set (replaces inline ASCII box).
- **Project structure** refreshed for the v0.2 module layout: `agents/persona_runtime/` package, `agents/memory/`, `internal/cost/`, etc.
- **Roadmap table** reshaped around user-visible capabilities; v0.2 flipped from 📋 Planned to 🚧 In Progress — first public release; v0.3–v0.6 rows aligned with ROADMAP.md.
- **Documentation** section adds links to CHANGELOG, architecture diagrams, manual test index, RFC README, development workflow, branching strategy.

**`docs/v0.2-release-prep-plan.md`** — status hygiene only:
- PR 3 row → `✅ Merged — #97 (2026-04-18)` (was stale `🔀 PR open`).
- PR 4 row → `🔀 PR open` (this PR).

## Out of scope

- The persona-guide link (PR 5) and v0.2-checklist link (PR 10) mentioned in the plan's PR 4 scope are deferred: those documents don't exist yet, so adding their links now would produce broken references. PR 5 and PR 10 will add their own README entries when they land.
- ROADMAP.md merged-PR backfill for #97–#101: pre-existing drift outside this PR's scope; PR 12 (final pre-tag verification) will reconcile.

## Verification

- [x] All 23 file/directory links in the new README resolve (spot-checked with `ls`/`test -e` before commit).
- [x] Quickstart commands verified against repo state: `make all`, `make build-agents`, `make validate`, `make run`, `make run-agent AGENT=sarah-chen`, `orch agent test --persona sarah-chen`, `GET /api/v1/cost/summary`.
- [x] Roadmap table status matches `ROADMAP.md` Version Map (v0.1 Complete, v0.2 In Progress first public release).
- [x] No file exceeds 500 lines.
- [x] Pre-commit hook passed (filemap, go fmt, ruff check, cargo fmt, doc links, doc status — 6/6).

## Test plan

- [ ] CI pipeline is green.
- [ ] Reviewer clicks every link in the rendered README — all resolve.
- [ ] Reviewer runs the persona-agent quickstart on a clean checkout and confirms the flow matches what's documented.