### PR TITLE
chore(release): bump version to 0.2.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@ All notable changes to this project will be documented in this file.
 - Ongoing manual test campaign and fixes (WIP) (#101)
 - Move repository to BUSL 1.1 (#63)
 
+[0.2.0]: https://github.com/mkhomutov/Persatrix/compare/v0.1.0...v0.2.0
+
 ## [0.1.0] - 2026-04-11
 
 ### 🚀 Features
@@ -238,5 +240,7 @@ All notable changes to this project will be documented in this file.
 ### 📦 Miscellaneous
 
 - Update FILEMAP.md
+
+[0.1.0]: https://github.com/mkhomutov/Persatrix/releases/tag/v0.1.0
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,66 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.2.1] - 2026-04-21
 
-- No notable changes yet.
+> **Codename:** Talk to Your Agents
+
+### Highlights
+
+- Human-agent chat is now part of the core surface. Open a terminal and run
+  `persatrix chat <agent_id>` to start an interactive conversation with any persona agent.
+- A new `Participant` protocol and `UserParticipant` implementation give the system a
+  first-class model for human participants, with relationship-memory tracking per user-agent pair.
+- The `POST /api/v1/agents/{id}/chat` REST endpoint and the `SendChatMessage` gRPC RPC
+  are both live and tested (see MT-CHAT-001 through MT-CHAT-004 in the manual-test suite).
+- Binary renamed from `orch` to `persatrix` — the CLI is now a single, coherent tool.
+
+### Upgrade Notes
+
+- **New gRPC RPC:** `SendChatMessage` added to `AgentService` (proto/task.proto). Regenerate
+  gRPC stubs if you maintain a custom client.
+- **New REST endpoint:** `POST /api/v1/agents/{id}/chat` — accepts `{message, user_id, session_id}`
+  and returns `{reply, session_id, agent_display_name, reply_status}`.
+- **Binary rename:** the CLI binary is now `persatrix` (previously `orch`). Update any scripts
+  or CI steps that reference the old name.
+- **RelationshipMemory generalised:** `RelationshipMemory` now models arbitrary participant pairs
+  (agent↔agent or user↔agent). Existing agent-agent relationship data is unaffected.
+
+### 🚀 Features
+
+- *(agents)* Participant Protocol + UserParticipant + UserStore (RFC 0016 PR 1/7) (#119)
+- *(agents)* Generalize RelationshipMemory to participant pairs (RFC 0016 PR 2/7) (#120)
+- *(agents)* SendChatMessage gRPC servicer + EventDispatcher flag (RFC 0016 PR 3/7) (#121)
+- *(server)* Add REST chat endpoint and gRPC chat executor (RFC 0016 PR 4) (#123)
+- *(cli)* Add `persatrix chat` command and rename binary (RFC 0016 PR 5/7) (#125)
+
+### 🐛 Bug Fixes
+
+- *(agents,cli)* Address PR 1–5 review follow-ups (RFC 0016 PR 6/7) (#127)
+- *(persona-runtime)* Apply PR #131 deep-review follow-ups (#133)
+
+### 🔧 Refactoring
+
+- *(executor)* Split executor.go into executor.go + dispatch.go (#124)
+
+### 📚 Documentation
+
+- *(rfcs)* Correct author attribution across all RFCs (#115)
+- *(rfc)* RFC 0015 — Process Automation & Pattern Extraction (#114)
+- *(rfc)* RFC 0016 — Human Participant & Chat Interface (#116)
+- *(rfc)* Accept RFC 0016 and add PR implementation plan (#118)
+- *(rfc)* Close RFC 0016 — Human Participant & Chat Interface (PR 7/7) (#128)
+- *(diagrams)* Architecture diagram refresh for v0.2.1 chat surface (#132)
+- *(guide)* Add chat walkthrough to persona-agents guide (#135)
+- *(readme)* Refresh README for v0.2.1 chat surface (#136)
+- *(release)* Add v0.2.1 release checklist (#137)
+
+### 🧪 Testing
+
+- Author manual tests — chat & participant surface (MT-CHAT-001..004) (#130)
+- Execute manual test suite, record results (#131)
+
+[0.2.1]: https://github.com/mkhomutov/Persatrix/compare/v0.2.0...v0.2.1
 
 ## [0.2.0] - 2026-04-18
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -580,14 +580,25 @@ v0.5.0 complete
 | [#104](https://github.com/mkhomutov/Persatrix/pull/104) | docs(diagrams): system, component, workflow, persona, memory architecture diagrams | v0.2 release prep (B-3) | 2026-04-18 |
 | [#105](https://github.com/mkhomutov/Persatrix/pull/105) | docs(changelog): generate v0.2.0 changelog + preserve unreleased section | v0.2 release prep (B-4) | 2026-04-18 |
 | [#106](https://github.com/mkhomutov/Persatrix/pull/106) | docs: v0.2.0 release checklist and pre-tag verification procedure | v0.2 release prep (D-1) | 2026-04-18 |
+| [#114](https://github.com/mkhomutov/Persatrix/pull/114) | docs(rfc): RFC 0015 — Process Automation & Pattern Extraction | 0015 (RFC) | 2026-04-19 |
 | [#115](https://github.com/mkhomutov/Persatrix/pull/115) | docs(rfcs): correct author attribution across all RFCs and add RFC 0015 | 0015 (RFC) + attribution | 2026-04-19 |
+| [#116](https://github.com/mkhomutov/Persatrix/pull/116) | docs(rfc): RFC 0016 — Human Participant & Chat Interface | 0016 (RFC) | 2026-04-19 |
+| [#118](https://github.com/mkhomutov/Persatrix/pull/118) | docs(rfc): accept RFC 0016 and add PR implementation plan | 0016 accept | 2026-04-19 |
 | [#119](https://github.com/mkhomutov/Persatrix/pull/119) | feat(agents): Participant Protocol + UserParticipant + UserStore | 0016 (1/7) | 2026-04-20 |
 | [#120](https://github.com/mkhomutov/Persatrix/pull/120) | feat(agents): generalize RelationshipMemory to participant pairs | 0016 (2/7) | 2026-04-20 |
 | [#121](https://github.com/mkhomutov/Persatrix/pull/121) | feat(agents): SendChatMessage gRPC servicer + EventDispatcher flag | 0016 (3/7) | 2026-04-20 |
 | [#123](https://github.com/mkhomutov/Persatrix/pull/123) | feat(server): add REST chat endpoint and gRPC chat executor | 0016 (4/7) | 2026-04-20 |
+| [#124](https://github.com/mkhomutov/Persatrix/pull/124) | refactor(executor): split executor.go into executor.go + dispatch.go | 0016 refactor | 2026-04-20 |
 | [#125](https://github.com/mkhomutov/Persatrix/pull/125) | feat(cli): add `persatrix chat` command and rename binary | 0016 (5/7) | 2026-04-20 |
 | [#127](https://github.com/mkhomutov/Persatrix/pull/127) | fix(agents,cli): address PR 1–5 review follow-ups | 0016 (6/7) | 2026-04-20 |
 | [#128](https://github.com/mkhomutov/Persatrix/pull/128) | docs(rfc): close RFC 0016 — Human Participant & Chat Interface (PR 7/7) | 0016 (7/7) | 2026-04-20 |
+| [#130](https://github.com/mkhomutov/Persatrix/pull/130) | docs(manual-tests): author chat surface tests (MT-CHAT-001..004) | v0.2.1 release prep | 2026-04-20 |
+| [#131](https://github.com/mkhomutov/Persatrix/pull/131) | docs(manual-tests): execute v0.2.1 manual test suite, record results | v0.2.1 release prep | 2026-04-21 |
+| [#132](https://github.com/mkhomutov/Persatrix/pull/132) | docs(diagrams): architecture diagram refresh for v0.2.1 chat surface | v0.2.1 release prep | 2026-04-21 |
+| [#133](https://github.com/mkhomutov/Persatrix/pull/133) | fix(persona-runtime): apply PR #131 deep-review follow-ups | 0016 follow-up | 2026-04-21 |
+| [#135](https://github.com/mkhomutov/Persatrix/pull/135) | docs(guide): add chat walkthrough to persona-agents guide | v0.2.1 release prep | 2026-04-21 |
+| [#136](https://github.com/mkhomutov/Persatrix/pull/136) | docs(readme): refresh README for v0.2.1 chat surface | v0.2.1 release prep | 2026-04-21 |
+| [#137](https://github.com/mkhomutov/Persatrix/pull/137) | docs(release): add v0.2.1 release checklist | v0.2.1 release prep | 2026-04-21 |
 
 ---
 

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.1.0"
+version = "0.2.1"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -879,7 +879,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/docs/v0.2.1-release-prep-plan.md
+++ b/docs/v0.2.1-release-prep-plan.md
@@ -28,7 +28,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 4 | B | Author manual tests — chat & participant surface | `feature/v021-release-prep-mt-chat` | ✅ Merged | #130 | 2026-04-20 |
 | 5 | B | Execute manual test suite, record results | `feature/v021-release-prep-mt-exec` | ✅ Merged | #131 | 2026-04-21 |
 | 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ⬜ Not started | — | — |
-| 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | ⬜ Not started | — | — |
+| 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | 🔀 PR open | #138 | — |
 | 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged

--- a/docs/v0.2.1-release-prep-plan.md
+++ b/docs/v0.2.1-release-prep-plan.md
@@ -27,7 +27,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 3 | A | README update for v0.2.1 | `feature/v021-release-prep-readme` | ✅ Merged | #136 | 2026-04-21 |
 | 4 | B | Author manual tests — chat & participant surface | `feature/v021-release-prep-mt-chat` | ✅ Merged | #130 | 2026-04-20 |
 | 5 | B | Execute manual test suite, record results | `feature/v021-release-prep-mt-exec` | ✅ Merged | #131 | 2026-04-21 |
-| 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ⬜ Not started | — | — |
+| 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ✅ Merged | #137 | 2026-04-21 |
 | 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | 🔀 PR open | #138 | — |
 | 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | ⬜ Not started | — | — |
 


### PR DESCRIPTION
## Summary

PR 7 of 8 in the [v0.2.1 release preparation plan](docs/v0.2.1-release-prep-plan.md).

Bumps both shipped components from `0.1.0` → `0.2.1` and adds the curated `[0.2.1]` changelog section covering all RFC 0016 work.

## Changes

| File | Change |
|------|--------|
| `agents/pyproject.toml` | `version = "0.1.0"` → `"0.2.1"` |
| `cli/Cargo.toml` | `version = "0.1.0"` → `"0.2.1"` |
| `cli/Cargo.lock` | Regenerated — only the `persatrix` package version entry changed |
| `CHANGELOG.md` | `[Unreleased]` placeholder replaced with curated `[0.2.1]` section |

## Changelog section highlights

- **Highlights** block: human-agent chat, Participant protocol, binary rename
- **Upgrade Notes**: new `SendChatMessage` RPC, new REST endpoint, binary rename, RelationshipMemory generalisation
- Features, bug fixes, refactoring, docs, and testing entries drawn from git-cliff output for PRs #119–#137
- Existing `[0.2.0]` section is fully preserved

## Verification

- `persatrix --version` → `persatrix 0.2.1` ✓
- `make build-cli` → compiles cleanly at v0.2.1 ✓
- `cli/Cargo.lock` diff is limited to the persatrix package version line ✓
- All pre-commit checks passed (filemap, go fmt, ruff, cargo fmt, doc links, doc status) ✓

## Depends on

PR #137 (release checklist) — merged ✓

## Checklist

- [x] `agents/pyproject.toml` updated to `0.2.1`
- [x] `cli/Cargo.toml` updated to `0.2.1`
- [x] `cli/Cargo.lock` regenerated and committed
- [x] `make build-cli` builds successfully
- [x] `CHANGELOG.md` contains a curated `[0.2.1]` section
- [x] Existing `[0.2.0]` section is preserved
- [ ] `make test` passes (run in CI)
- [ ] `make lint` clean (run in CI)