### PR TITLE
chore(release): final pre-tag gate — v0.2.1 complete

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-20 (RFC 0016 ✅ Implemented — all 7 PRs merged)  
-> **Current phase**: v0.2.1 (Human Participant & Chat Interface) — 🚧 In Progress  
-> **Current milestone**: v0.2.1 — RFC 0016 complete; next: release prep
+> **Last updated**: 2026-04-21 (v0.2.1 ✅ Complete — all release prep PRs merged)  
+> **Current phase**: v0.2.2 (Persona Memory Injection Token Budget) — 📋 Planned  
+> **Current milestone**: v0.2.1 released; next: RFC 0017 authoring
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -16,7 +16,7 @@ A version is ready when a developer can do something meaningful they could not d
 |---------|-------------------|--------|
 | **v0.1.0** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
 | **v0.2.0** ⭐ | Run persistent AI agents with personalities, memory, and evolving relationships from a terminal | ✅ Complete — first public release |
-| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | 🚧 In Progress |
+| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete |
 | **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | 📋 Planned |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
@@ -242,7 +242,7 @@ v0.2.0 complete
 
 ---
 
-## v0.2.1 — Talk to Your Agents
+## v0.2.1 — Talk to Your Agents ✅ Complete
 
 **What a user can do**: Open a terminal, type `persatrix chat <agent_id>`, and have a conversation with a persona agent. The agent remembers you and builds a relationship with you over time.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -124,7 +124,7 @@ Collected via `pip-licenses --from=mixed` against the `agents` extras (63 packag
 
 ## Rust dependencies
 
-Collected via `cargo license --json` inside `cli/` (198 crates).
+Collected via `cargo license --json` inside `cli/` (205 crates).
 
 | Package | Version | License | Source |
 | --- | --- | --- | --- |
@@ -137,11 +137,13 @@ Collected via `cargo license --json` inside `cli/` (198 crates).
 | `atomic-waker` | 1.1.2 | Apache-2.0 OR MIT | [link](https://github.com/smol-rs/atomic-waker) |
 | `base64` | 0.22.1 | Apache-2.0 OR MIT | [link](https://github.com/marshallpierce/rust-base64) |
 | `bitflags` | 2.11.0 | Apache-2.0 OR MIT | [link](https://github.com/bitflags/bitflags) |
+| `block2` | 0.6.2 | MIT | [link](https://github.com/madsmtm/objc2) |
 | `bumpalo` | 3.20.2 | Apache-2.0 OR MIT | [link](https://github.com/fitzgen/bumpalo) |
 | `bytecount` | 0.6.9 | Apache-2.0 OR MIT | [link](https://github.com/llogiq/bytecount) |
 | `bytes` | 1.11.1 | MIT | [link](https://github.com/tokio-rs/bytes) |
 | `cc` | 1.2.59 | Apache-2.0 OR MIT | [link](https://github.com/rust-lang/cc-rs) |
 | `cfg-if` | 1.0.4 | Apache-2.0 OR MIT | [link](https://github.com/rust-lang/cfg-if) |
+| `cfg_aliases` | 0.2.1 | MIT | [link](https://github.com/katharostech/cfg_aliases) |
 | `clap` | 4.6.0 | Apache-2.0 OR MIT | [link](https://github.com/clap-rs/clap) |
 | `clap_builder` | 4.6.0 | Apache-2.0 OR MIT | [link](https://github.com/clap-rs/clap) |
 | `clap_derive` | 4.6.0 | Apache-2.0 OR MIT | [link](https://github.com/clap-rs/clap) |
@@ -151,6 +153,8 @@ Collected via `cargo license --json` inside `cli/` (198 crates).
 | `core-foundation` | 0.9.4 | Apache-2.0 OR MIT | [link](https://github.com/servo/core-foundation-rs) |
 | `core-foundation` | 0.10.1 | Apache-2.0 OR MIT | [link](https://github.com/servo/core-foundation-rs) |
 | `core-foundation-sys` | 0.8.7 | Apache-2.0 OR MIT | [link](https://github.com/servo/core-foundation-rs) |
+| `ctrlc` | 3.5.2 | Apache-2.0 OR MIT | [link](https://github.com/Detegr/rust-ctrlc.git) |
+| `dispatch2` | 0.3.1 | Apache-2.0 OR MIT OR Zlib | [link](https://github.com/madsmtm/objc2) |
 | `displaydoc` | 0.2.5 | Apache-2.0 OR MIT | [link](https://github.com/yaahc/displaydoc) |
 | `encoding_rs` | 0.8.35 | (Apache-2.0 OR MIT) AND BSD-3-Clause | [link](https://github.com/hsivonen/encoding_rs) |
 | `equivalent` | 1.0.2 | Apache-2.0 OR MIT | [link](https://github.com/indexmap-rs/equivalent) |
@@ -208,6 +212,9 @@ Collected via `cargo license --json` inside `cli/` (198 crates).
 | `mime` | 0.3.17 | Apache-2.0 OR MIT | [link](https://github.com/hyperium/mime) |
 | `mio` | 1.2.0 | MIT | [link](https://github.com/tokio-rs/mio) |
 | `native-tls` | 0.2.18 | Apache-2.0 OR MIT | [link](https://github.com/rust-native-tls/rust-native-tls) |
+| `nix` | 0.31.2 | MIT | [link](https://github.com/nix-rust/nix) |
+| `objc2` | 0.6.4 | MIT | [link](https://github.com/madsmtm/objc2) |
+| `objc2-encode` | 4.1.0 | MIT | [link](https://github.com/madsmtm/objc2) |
 | `once_cell` | 1.21.4 | Apache-2.0 OR MIT | [link](https://github.com/matklad/once_cell) |
 | `once_cell_polyfill` | 1.70.2 | Apache-2.0 OR MIT | [link](https://github.com/polyfill-rs/once_cell_polyfill) |
 | `openssl` | 0.10.76 | Apache-2.0 | [link](https://github.com/rust-openssl/rust-openssl) |

--- a/docs/v0.2.1-release-prep-plan.md
+++ b/docs/v0.2.1-release-prep-plan.md
@@ -1,6 +1,6 @@
 # v0.2.1 Release Preparation Plan
 
-**Status**: 🚧 In flight  
+**Status**: ✅ Complete  
 **Target version**: v0.2.1 (Human Participant & Chat Interface)  
 **Created**: 2026-04-20  
 **Branch prefix**: `feature/v021-release-prep-`  
@@ -28,8 +28,8 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 4 | B | Author manual tests — chat & participant surface | `feature/v021-release-prep-mt-chat` | ✅ Merged | #130 | 2026-04-20 |
 | 5 | B | Execute manual test suite, record results | `feature/v021-release-prep-mt-exec` | ✅ Merged | #131 | 2026-04-21 |
 | 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ✅ Merged | #137 | 2026-04-21 |
-| 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | 🔀 PR open | #138 | — |
-| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | 🔀 PR open | — | — |
+| 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | ✅ Merged | #138 | 2026-04-21 |
+| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | 🔀 PR open | #140 | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 

--- a/docs/v0.2.1-release-prep-plan.md
+++ b/docs/v0.2.1-release-prep-plan.md
@@ -29,7 +29,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 5 | B | Execute manual test suite, record results | `feature/v021-release-prep-mt-exec` | ✅ Merged | #131 | 2026-04-21 |
 | 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ✅ Merged | #137 | 2026-04-21 |
 | 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | 🔀 PR open | #138 | — |
-| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | ⬜ Not started | — | — |
+| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | 🔀 PR open | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
## Summary

This is **PR 8 — the pre-tag gate** for the v0.2.1 release preparation plan. All tracks (A, B, C, D) are complete; this PR carries the final verification artifacts and marks v0.2.1 as released.

## Pre-tag verification results

| Check | Result |
|-------|--------|
| `make test` | ✅ 20/20 passed |
| `make lint` | ✅ Go golangci-lint, ruff, mypy, Rust clippy — all clean |
| `make validate` | ✅ 4 config files valid |
| Proto staleness | ✅ No substantive changes (import-style difference from grpcio-tools version pinned to relative imports) |
| `THIRD_PARTY_NOTICES.md` | ✅ Regenerated — 7 new Rust crates from `ctrlc`/`nix`/`objc2` added by the chat CLI (PR #125) |

## Changes

| File | Change |
|------|--------|
| `ROADMAP.md` | v0.2.1 status → `✅ Complete`; current phase → v0.2.2 Planned; last-updated → 2026-04-21 |
| `THIRD_PARTY_NOTICES.md` | Regenerated — 7 new crates listed (205 total, up from 198) |
| `docs/v0.2.1-release-prep-plan.md` | PR 8 row → `🔀 PR open` |

## Post-merge tagging procedure

```bash
git checkout main
git pull --ff-only origin main
git tag -a v0.2.1 -m "v0.2.1 — Talk to Your Agents"
git push origin v0.2.1
```

Then create a GitHub Release from tag `v0.2.1` using the curated `[0.2.1]` section from `CHANGELOG.md`.

## Depends on

PRs 1–7 all merged: #132, #135, #136, #130, #131, #137, #138.