### PR TITLE
docs(release): post-release follow-up for v0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Persatrix/
 |---------|-------------------|--------|
 | **v0.1** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
 | **v0.2.0** | Run persistent AI agents with personas, memory, and cost-bounded execution from a terminal | ✅ First public release |
-| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Release-ready |
+| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Released |
 | **v0.3** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-21 (v0.2.1 ✅ Complete — all release prep PRs merged)  
+> **Last updated**: 2026-04-21 (v0.2.1 ✅ Released — tag `v0.2.1` pushed)  
 > **Current phase**: v0.2.2 (Persona Memory Injection Token Budget) — 📋 Planned  
-> **Current milestone**: v0.2.1 released; next: RFC 0017 authoring
+> **Current milestone**: RFC 0017 authoring
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,7 +16,7 @@ A version is ready when a developer can do something meaningful they could not d
 |---------|-------------------|--------|
 | **v0.1.0** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
 | **v0.2.0** ⭐ | Run persistent AI agents with personalities, memory, and evolving relationships from a terminal | ✅ Complete — first public release |
-| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete |
+| **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete — released |
 | **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | 📋 Planned |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
@@ -599,6 +599,9 @@ v0.5.0 complete
 | [#135](https://github.com/mkhomutov/Persatrix/pull/135) | docs(guide): add chat walkthrough to persona-agents guide | v0.2.1 release prep | 2026-04-21 |
 | [#136](https://github.com/mkhomutov/Persatrix/pull/136) | docs(readme): refresh README for v0.2.1 chat surface | v0.2.1 release prep | 2026-04-21 |
 | [#137](https://github.com/mkhomutov/Persatrix/pull/137) | docs(release): add v0.2.1 release checklist | v0.2.1 release prep | 2026-04-21 |
+| [#138](https://github.com/mkhomutov/Persatrix/pull/138) | chore(release): bump version to 0.2.1 and update changelog | v0.2.1 release prep | 2026-04-21 |
+| [#140](https://github.com/mkhomutov/Persatrix/pull/140) | chore(release): final pre-tag gate — v0.2.1 complete | v0.2.1 release prep | 2026-04-21 |
+| [#141](https://github.com/mkhomutov/Persatrix/pull/141) | docs(release): post-release follow-up for v0.2.1 | v0.2.1 release prep | 2026-04-21 |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -76,7 +76,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | Version | Report | Status |
 |---------|--------|--------|
 | v0.2.0 | [v0.2-execution-report.md](v0.2-execution-report.md) | ✅ Complete |
-| v0.2.1 | [v0.2.1-execution-report.md](v0.2.1-execution-report.md) | 🔄 In progress |
+| v0.2.1 | [v0.2.1-execution-report.md](v0.2.1-execution-report.md) | ✅ Complete |
 
 ---
 

--- a/docs/v0.2.1-release-checklist.md
+++ b/docs/v0.2.1-release-checklist.md
@@ -1,5 +1,7 @@
 # v0.2.1 Release Checklist
 
+> **Status**: ✅ Released — tag `v0.2.1` pushed 2026-04-21; all gates green.
+
 > v0.2.1 — "Talk to Your Agents" — delivers the Human Participant & Chat Interface: `Participant` protocol, `UserParticipant`, chat REST endpoint (`POST /api/v1/agents/{id}/chat`), `SendChatMessage` gRPC RPC, and `persatrix chat` CLI command.
 
 **Based on test report**: [`docs/manual-tests/v0.2.1-execution-report.md`](manual-tests/v0.2.1-execution-report.md)  
@@ -9,14 +11,14 @@
 
 ## 1. Pre-release Verification
 
-- [ ] `make test` is green on a clean checkout
-- [ ] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
-- [ ] `make validate` passes for all config files
-- [ ] Proto staleness check passes: `make proto` then `git diff --exit-code`
-- [ ] `make check-licenses` is clean for Go, Python, and Rust
-- [ ] `make notices` regenerated and diffed: any newly added dependency has an acceptable license (nothing GPL, AGPL, LGPL, SSPL, or unknown); commit updated [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) as part of the release-prep PR
-- [ ] Docker smoke test: `make docker-build && make docker-up` — submit a workflow and send a chat message
-- [ ] Manual test suite complete: 17 test documents (13 existing + 4 chat) plus index
+- [x] `make test` is green on a clean checkout
+- [x] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
+- [x] `make validate` passes for all config files
+- [x] Proto staleness check passes: `make proto` then `git diff --exit-code`
+- [x] `make check-licenses` is clean for Go, Python, and Rust
+- [x] `make notices` regenerated and diffed: any newly added dependency has an acceptable license (nothing GPL, AGPL, LGPL, SSPL, or unknown); commit updated [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) as part of the release-prep PR
+- [x] Docker smoke test: `make docker-build && make docker-up` — submit a workflow and send a chat message
+- [x] Manual test suite complete: 17 test documents (13 existing + 4 chat) plus index
 
 Record the command outputs or links to CI runs used as release evidence.
 
@@ -35,11 +37,11 @@ Before tagging, all shipped components must declare `0.2.1` consistently.
 
 Checklist:
 
-- [ ] `agents/pyproject.toml` updated to `0.2.1`
-- [ ] `cli/Cargo.toml` updated to `0.2.1`
-- [ ] `cli/Cargo.lock` regenerated and committed
-- [ ] `make all` builds successfully with the new versions
-- [ ] No docs or examples still describe v0.2.1 as unreleased work-in-progress
+- [x] `agents/pyproject.toml` updated to `0.2.1`
+- [x] `cli/Cargo.toml` updated to `0.2.1`
+- [x] `cli/Cargo.lock` regenerated and committed
+- [x] `make all` builds successfully with the new versions
+- [x] No docs or examples still describe v0.2.1 as unreleased work-in-progress
 
 ---
 
@@ -49,9 +51,9 @@ The release changelog must preserve the curated v0.2.0 material already in [`CHA
 
 Checklist:
 
-- [ ] `CHANGELOG.md` contains a `[0.2.1]` section
-- [ ] The existing curated `[0.2.0]` section is preserved verbatim — not overwritten
-- [ ] The `[0.2.1]` section includes:
+- [x] `CHANGELOG.md` contains a `[0.2.1]` section
+- [x] The existing curated `[0.2.0]` section is preserved verbatim — not overwritten
+- [x] The `[0.2.1]` section includes:
   - **Features**: Participant Protocol, `UserParticipant`, memory generalization (`RelationshipMemory` → participant pairs), chat REST endpoint, `SendChatMessage` gRPC, `persatrix chat` CLI command
   - **Bug fixes**: PR #127 follow-up fixes (review findings from PRs #119–#125)
   - **Documentation**: RFC 0016 close (PR #128)
@@ -114,11 +116,11 @@ The authoritative test index is [`docs/manual-tests/README.md`](manual-tests/REA
 
 Checklist:
 
-- [ ] [`docs/manual-tests/v0.2.1-execution-report.md`](manual-tests/v0.2.1-execution-report.md) exists and is marked ✅ Complete
-- [ ] Each test records date, tester, environment, and evidence
-- [ ] Every test outcome is `Pass` or `Accepted-with-known-gap` with a linked follow-up issue
-- [ ] No unresolved `Fail` remains at tag time
-- [ ] `MT-COST-002` accepted-with-known-gap is linked to a follow-up issue
+- [x] [`docs/manual-tests/v0.2.1-execution-report.md`](manual-tests/v0.2.1-execution-report.md) exists and is marked ✅ Complete
+- [x] Each test records date, tester, environment, and evidence
+- [x] Every test outcome is `Pass` or `Accepted-with-known-gap` with a linked follow-up issue
+- [x] No unresolved `Fail` remains at tag time
+- [x] `MT-COST-002` accepted-with-known-gap is linked to a follow-up issue
 
 ---
 
@@ -135,11 +137,11 @@ git push origin v0.2.1
 
 GitHub Release checklist:
 
-- [ ] Create the GitHub Release from tag `v0.2.1`
-- [ ] Use the curated v0.2.1 changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body
-- [ ] Attach binaries or container references if produced for this release
+- [x] Create the GitHub Release from tag `v0.2.1`
+- [x] Use the curated v0.2.1 changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body
+- [x] Attach binaries or container references if produced for this release
 
 ---
 
@@ -179,22 +181,22 @@ These items remain intentionally incomplete and should be described as deferred 
 Single-page go/no-go gate. All items must be checked before tagging.
 
 ```text
-[ ] make test is green on a clean checkout
-[ ] make lint is clean
-[ ] make validate passes
-[ ] make proto then git diff --exit-code shows no generated drift
-[ ] make check-licenses passes
-[ ] THIRD_PARTY_NOTICES.md regenerated via make notices
-[ ] agents/pyproject.toml updated to 0.2.1
-[ ] cli/Cargo.toml updated to 0.2.1
-[ ] cli/Cargo.lock regenerated and committed
-[ ] make all builds successfully
-[ ] CHANGELOG.md contains a curated [0.2.1] section with upgrade notes
-[ ] Existing [0.2.0] section preserved
-[ ] All 17 manual tests recorded in docs/manual-tests/v0.2.1-execution-report.md
-[ ] No unresolved Fail in manual tests
-[ ] Known gaps documented for release notes
-[ ] Docker smoke test passes (workflow + chat message)
-[ ] git tag v0.2.1 created and pushed
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps
+[x] make test is green on a clean checkout
+[x] make lint is clean
+[x] make validate passes
+[x] make proto then git diff --exit-code shows no generated drift
+[x] make check-licenses passes
+[x] THIRD_PARTY_NOTICES.md regenerated via make notices
+[x] agents/pyproject.toml updated to 0.2.1
+[x] cli/Cargo.toml updated to 0.2.1
+[x] cli/Cargo.lock regenerated and committed
+[x] make all builds successfully
+[x] CHANGELOG.md contains a curated [0.2.1] section with upgrade notes
+[x] Existing [0.2.0] section preserved
+[x] All 17 manual tests recorded in docs/manual-tests/v0.2.1-execution-report.md
+[x] No unresolved Fail in manual tests
+[x] Known gaps documented for release notes
+[x] Docker smoke test passes (workflow + chat message)
+[x] git tag v0.2.1 created and pushed
+[x] GitHub Release published with changelog, upgrade notes, and known gaps
 ```

--- a/docs/v0.2.1-release-prep-plan.md
+++ b/docs/v0.2.1-release-prep-plan.md
@@ -29,7 +29,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 5 | B | Execute manual test suite, record results | `feature/v021-release-prep-mt-exec` | ✅ Merged | #131 | 2026-04-21 |
 | 6 | C | Release checklist (`docs/v0.2.1-release-checklist.md`) | `feature/v021-release-prep-checklist` | ✅ Merged | #137 | 2026-04-21 |
 | 7 | D | Version bump + changelog generation | `feature/v021-release-prep-version-bump` | ✅ Merged | #138 | 2026-04-21 |
-| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | 🔀 PR open | #140 | — |
+| 8 | D | Final pre-tag verification & release notes | `feature/v021-release-prep-final` | ✅ Merged | #140 | 2026-04-21 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
## Summary

Small docs-only post-release follow-up for v0.2.1. The tag `v0.2.1` was pushed to `origin` on 2026-04-21; this PR closes the post-release scope explicitly defined in [`docs/v0.2.1-release-prep-plan.md`](https://github.com/mkhomutov/Persatrix/blob/main/docs/v0.2.1-release-prep-plan.md) (Track D, PR 8 → "Post-merge tagging procedure"):

> After publishing the release, open a small docs-only follow-up PR to:
> - update README/docs links to the published `v0.2.1` tag/release URL,
> - replace any temporary release-readiness wording with final "released" wording,
> - confirm no stale references remain.

## Changes

| File | Change |
|------|--------|
| [README.md](README.md) | Roadmap row for v0.2.1: `✅ Release-ready` → `✅ Released`. |
| [ROADMAP.md](ROADMAP.md) | "Last updated" line reflects the tag is published; current milestone updated to "RFC 0017 authoring". |
| [docs/manual-tests/README.md](docs/manual-tests/README.md) | v0.2.1 execution-report row: `🔄 In progress` → `✅ Complete` (the report file itself was already marked Complete in #131). |
| [docs/v0.2.1-release-prep-plan.md](docs/v0.2.1-release-prep-plan.md) | PR 8 row: `🔀 PR open` → `✅ Merged \| #140 \| 2026-04-21`. |
| [docs/v0.2.1-release-checklist.md](docs/v0.2.1-release-checklist.md) | Add `Status: ✅ Released` header; tick all gates that are verifiably done now that the tag is on `origin/main` and the GitHub Release is published. |

## Out of scope

- No code changes
- No version bumps (next-dev cycle starts with the v0.2.2 RFC 0017 PR plan)
- No CHANGELOG changes (curated `[0.2.1]` section was finalized in #138)

## Verification

- Pre-commit gates green: filemap, go fmt, ruff, cargo fmt, doc links (442/442), doc status (75/75)
- No stale references to v0.2.1 as "in progress" or "release-ready" remain in the docs tree.

## Status hygiene

Per the [Status Hygiene rules](docs/development-workflow.md#status-hygiene), this PR brings the following into a consistent post-release state:
- ROADMAP.md ↔ README.md ↔ release-prep plan ↔ release checklist ↔ manual-tests index all agree v0.2.1 is **Released**.
- RFC 0016 status (`✅ Implemented`) was already correct from #128 and is unchanged here.
