### PR TITLE
docs(safety): add cost warning, responsible-use section, and runtime cost notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,59 @@ for an end-to-end run.
 
 ---
 
+## ⚠️ Cost Warning — Read Before Running
+
+Persatrix uses commercial LLM APIs (Anthropic by default; the model is selected
+per agent in [config/agents.yaml](config/agents.yaml)) and runs persona agents
+with autonomous tick loops that consume API tokens continuously while the
+agent process is alive.
+
+**This is experimental software (pre-1.0, BUSL-1.1). It has bugs. Some bugs
+may cost you money.**
+
+During testing of v0.2.1 the author accidentally left a persona agent running
+with a faulty empty-context idle check and lost roughly $35 USD in API costs
+before noticing. v0.2.2 ships the empty-context tick short-circuit
+([RFC 0017](docs/rfcs/0017-persona-memory-injection-budget.md)) that
+fixes that specific bug. Other bugs with similar cost implications almost
+certainly exist.
+
+**Before running Persatrix, every user must:**
+
+1. **Set hard spending limits at your LLM provider's billing page.** This is
+   the authoritative safeguard against runaway costs. Persatrix's own budget
+   controls (`max_llm_calls` per agent, `max_daily_usd` in
+   [config/optimization.yaml](config/optimization.yaml), per-workflow token
+   budgets) are best-effort and should never be your only protection.
+
+2. **Configure billing alerts at your LLM provider** so you are notified
+   immediately if spending exceeds expected thresholds.
+
+3. **Start with short test sessions.** Stop persona agents explicitly when
+   you are done — kill the `make run-agent` process or the `agent-*` Docker
+   Compose service. Do not rely on `idle_after_ticks` or the empty-context
+   short-circuit alone.
+
+4. **Review [config/agents.yaml](config/agents.yaml) and
+   [config/optimization.yaml](config/optimization.yaml) and set conservative
+   limits** appropriate to your budget — `max_llm_calls` per agent,
+   `tick_interval_seconds` (longer = cheaper), `max_actions_per_tick`,
+   `idle_after_ticks`, and the global `max_daily_usd` budget.
+
+5. **Monitor your provider's usage dashboard during initial runs.** Do not
+   assume budgets are being enforced correctly until you have verified
+   against your provider's authoritative numbers. Persatrix exposes
+   `GET /api/v1/cost/summary` for in-process accounting, but that is
+   independent from your provider's billing.
+
+Persatrix is distributed under [BUSL 1.1](LICENSE). No warranty is provided.
+The authors are not liable for API costs, lost data, or any other damages
+arising from use. Use at your own risk. See
+[SECURITY.md § Responsible Use](SECURITY.md#responsible-use) for the broader
+framing.
+
+---
+
 ## Quick Start
 
 ### Prerequisites

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,36 @@ Persatrix uses deny-by-default security for agent permissions. For details on th
 
 - [Agent Configuration](config/agents.yaml) — Agent permissions and capabilities
 - [Security Gates](internal/security/) — Go orchestrator security enforcement
+
+## Responsible Use
+
+Persatrix is experimental, pre-1.0 software distributed under
+[BUSL 1.1](LICENSE). It drives commercial LLM APIs and runs persona agents
+with autonomous tick loops, so misuse or undiscovered bugs can incur real
+monetary cost. Users running Persatrix are responsible for:
+
+- **Configuring spending limits at their LLM provider.** This is the
+  authoritative safeguard. Persatrix's internal budget controls
+  (`max_llm_calls` per agent, `max_daily_usd` in
+  [config/optimization.yaml](config/optimization.yaml), per-workflow token
+  budgets, response cache) are best-effort and have known limitations —
+  see the cost warning in [README.md](README.md#-cost-warning--read-before-running).
+- **Not running Persatrix in production environments** without significant
+  additional safeguards beyond what the project provides. The roadmap
+  through v0.3 explicitly treats current releases as experimental.
+- **Reviewing agent actions before allowing them to affect real systems.**
+  Persona behaviour is non-deterministic by design and tool permissions
+  default to deny — keep them that way unless you have audited the
+  alternative.
+- **Stopping persona agents explicitly when done.** Kill the `make run-agent`
+  process or the `agent-*` Docker Compose service. Do not rely on
+  `idle_after_ticks`, the empty-context tick short-circuit, or any other
+  automatic timeout alone.
+- **Reporting cost or security bugs responsibly** via the private
+  vulnerability reporting channel above (for security-sensitive issues) or
+  via [GitHub Issues](https://github.com/mkhomutov/Persatrix/issues) (for
+  unexpected-cost or budget-bypass bugs that are not directly exploitable).
+
+Persatrix authors and contributors are not liable for API costs, damages,
+or losses arising from use of this software, as stated in
+[LICENSE](LICENSE).

--- a/agents/server_persona.py
+++ b/agents/server_persona.py
@@ -224,3 +224,25 @@ async def initialize_persona_agents(
                 agent_id,
                 interval,
             )
+            # Cost-safety notice — emitted at the moment LLM spend can begin
+            # accruing for an autonomous persona. See README.md "Cost Warning"
+            # and SECURITY.md "Responsible Use" for the full framing.
+            max_llm_calls = agent.config.get("max_llm_calls", "unset")
+            logger.warning(
+                "COST: persona '%s' is now running an autonomous tick loop "
+                "and will consume LLM tokens continuously.",
+                agent_id,
+            )
+            logger.warning(
+                "COST: tick_interval=%ss, max_actions_per_tick=%s, "
+                "idle_after_ticks=%s, max_llm_calls=%s.",
+                interval,
+                max_actions,
+                idle_after,
+                max_llm_calls,
+            )
+            logger.warning(
+                "COST: stop this agent explicitly when done — do not rely "
+                "on idle detection alone. Confirm hard spending limits are "
+                "set at your LLM provider's billing page."
+            )

--- a/agents/server_persona.py
+++ b/agents/server_persona.py
@@ -218,18 +218,15 @@ async def initialize_persona_agents(
             )
             tick_schedulers[agent_id] = scheduler
             dispatcher.register_tick_scheduler(agent_id, scheduler)
-            scheduler.start()
-            logger.info(
-                "Started tick scheduler for %s (interval=%ds)",
-                agent_id,
-                interval,
-            )
-            # Cost-safety notice — emitted at the moment LLM spend can begin
-            # accruing for an autonomous persona. See README.md "Cost Warning"
-            # and SECURITY.md "Responsible Use" for the full framing.
+            # Cost-safety notice — emitted *before* scheduler.start() so the
+            # warning is guaranteed to reach the log before any LLM spend can
+            # begin.  Placing it after start() would invert the semantic order
+            # the PR description promised ("at the exact moment spend can begin")
+            # and mislead future maintainers.
+            # See README.md "Cost Warning" and SECURITY.md "Responsible Use".
             max_llm_calls = agent.config.get("max_llm_calls", "unset")
             logger.warning(
-                "COST: persona '%s' is now running an autonomous tick loop "
+                "COST: persona '%s' is about to start an autonomous tick loop "
                 "and will consume LLM tokens continuously.",
                 agent_id,
             )
@@ -242,7 +239,14 @@ async def initialize_persona_agents(
                 max_llm_calls,
             )
             logger.warning(
-                "COST: stop this agent explicitly when done — do not rely "
+                "COST: stop agent '%s' explicitly when done — do not rely "
                 "on idle detection alone. Confirm hard spending limits are "
-                "set at your LLM provider's billing page."
+                "set at your LLM provider's billing page.",
+                agent_id,
+            )
+            scheduler.start()
+            logger.info(
+                "Started tick scheduler for %s (interval=%ds)",
+                agent_id,
+                interval,
             )

--- a/tests/unit/python/test_event_dispatch_tick.py
+++ b/tests/unit/python/test_event_dispatch_tick.py
@@ -1233,11 +1233,16 @@ class TestInitializePersonaAgents:
         assert "iron-fox" in dispatcher._agents
         await ok_agent.close_memory()
 
-    async def test_tick_schedulers_dict_mutated_in_place(self):
+    async def test_tick_schedulers_dict_mutated_in_place(self, caplog):
         """The tick_schedulers dict passed in is mutated: autonomous agents are inserted.
 
         Validates the in-place mutation contract documented in the function's
         docstring — callers rely on the dict being populated, not on a return value.
+
+        Also asserts that the three COST: warning lines are actually emitted on the
+        autonomous path so that a silent regression (accidental deletion or wrong
+        condition guard) is caught by the test suite.
+        (PR #150 review: cost-warning log lines lacked a dedicated regression test.)
         """
         from agents.server_persona import initialize_persona_agents
 
@@ -1257,10 +1262,12 @@ class TestInitializePersonaAgents:
         dispatcher = EventDispatcher()
         schedulers: dict = {}
 
-        await initialize_persona_agents({"ember-owl": agent}, dispatcher, schedulers)
+        with caplog.at_level(logging.WARNING, logger="Persatrix.agent.server_persona"):
+            await initialize_persona_agents({"ember-owl": agent}, dispatcher, schedulers)
 
         assert "ember-owl" in schedulers
         assert schedulers["ember-owl"].is_running
+        assert any("COST:" in r.message for r in caplog.records)
 
         await schedulers["ember-owl"].stop()
         await agent.close_memory()


### PR DESCRIPTION
## Summary

Warn users prominently about possible runaway LLM costs when Persatrix is used unwisely. Adapts an external safety recommendation to this project's realities (actual config knobs, BUSL-1.1 licensing, the v0.2.1 -> v0.2.2 cost-bug anecdote, RFC 0017).

No behaviour changes to agents, orchestrator, or CLI beyond three new `logger.warning(...)` lines emitted when an autonomous persona's tick scheduler starts.

## Changes

### `README.md`
- New **"⚠️ Cost Warning — Read Before Running"** section inserted immediately after the v0.2.1 capability table and **before Quick Start**, so it cannot be missed on a first read.
- Concrete: references the actual budget surfaces — `max_llm_calls` per agent in [config/agents.yaml](config/agents.yaml), `max_daily_usd` / per-workflow / per-agent budgets in [config/optimization.yaml](config/optimization.yaml), and `GET /api/v1/cost/summary`.
- Calls out that Persatrix's own budget controls are best-effort and that **provider-side hard spending limits are the authoritative safeguard**.
- Keeps the user-supplied v0.2.1 $35 anecdote and links the v0.2.2 fix to [RFC 0017](docs/rfcs/0017-persona-memory-injection-budget.md).
- Cross-links `SECURITY.md § Responsible Use`.

### `SECURITY.md`
- New **"Responsible Use"** section appended after *Security Design*, mirroring the README warning but framed around operator responsibilities (deny-by-default tool permissions, stopping agents explicitly, reporting cost bugs).
- Cross-links the README cost warning and `LICENSE`.

### `agents/server_persona.py`
- Three `logger.warning(...)` lines emitted in `initialize_persona_agents()` at the exact moment a tick scheduler starts for a `semi-autonomous` or `autonomous` persona — the moment LLM spend begins.
- Warning includes the agent id and the concrete `tick_interval_seconds` / `max_actions_per_tick` / `idle_after_ticks` / `max_llm_calls` values pulled from the agent's config, giving users evidence they were informed at runtime.
- Only fires for personas that actually run a tick loop; reactive personas and task agents are unaffected.

## Verification

- `python -m ruff check agents/server_persona.py` → clean
- `python -m mypy agents/server_persona.py --ignore-missing-imports` → clean
- `python scripts/pre_commit.py` → 7/7 pass (ruff, go fmt, cargo fmt, doc-links, doc-status, file-size, filemap)
- `python -m pytest tests/unit/python/test_event_dispatch_tick.py` → **63 passed** (covers `initialize_persona_agents` paths)

## Notes

- No schema, proto, RFC, or ROADMAP changes. This is a pure safety/docs PR and slots into v0.2.2 alongside the RFC 0017 work without touching any of its scope.
- The runtime warning is additive — the existing `logger.info("Started tick scheduler...")` line is preserved so nothing downstream that greps for it breaks.