### PR TITLE
docs(rfc): close RFC 0017 (PR 7/7)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-22 (RFC 0017 🚧 Implementing — PR 5/7 merged)  
-> **Current phase**: v0.2.2 (Persona Memory Injection Token Budget) — 🚧 Implementing  
-> **Current milestone**: RFC 0017 PR 6 — review follow-ups
+> **Last updated**: 2026-04-22 (RFC 0017 ✅ Implemented — PR 6/7 merged; PR 7 open)  
+> **Current phase**: v0.2.2 (Persona Memory Injection Token Budget) — ✅ Implemented  
+> **Current milestone**: v0.2.2 release prep kickoff
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -17,7 +17,7 @@ A version is ready when a developer can do something meaningful they could not d
 | **v0.1.0** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
 | **v0.2.0** ⭐ | Run persistent AI agents with personalities, memory, and evolving relationships from a terminal | ✅ Complete — first public release |
 | **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete — released |
-| **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | 🚧 Implementing |
+| **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | ✅ Implemented |
 | **v0.2.3** | Operability minor release — structured logs across Go/Python, working `persatrix logs` CLI, end-to-end OpenTelemetry traces from REST handler to LLM call | 📋 Planned |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
@@ -48,7 +48,7 @@ Internal RFCs are the engineering planning tool. They do not drive version numbe
 | [0014](docs/rfcs/0014-agent-skill-registry-lifecycle.md) | Agent Skill Registry & Lifecycle | v0.4.0 | 📋 Proposed |
 | [0015](docs/rfcs/0015-process-automation-pattern-extraction.md) | Process Automation & Pattern Extraction | v0.5.0 | 📋 Proposed |
 | [0016](docs/rfcs/0016-human-participant-chat-interface.md) | Human Participant & Chat Interface | v0.2.1 | ✅ Implemented |
-| [0017](docs/rfcs/0017-persona-memory-injection-budget.md) | Persona Memory Injection Token Budget | v0.2.2 | 🚧 Implementing (5/7) |
+| [0017](docs/rfcs/0017-persona-memory-injection-budget.md) | Persona Memory Injection Token Budget | v0.2.2 | ✅ Implemented (7/7) |
 | [0018](docs/rfcs/0018-structured-logging-framework.md) | Structured Logging Framework | v0.2.3 | 📋 Proposed |
 | [0019](docs/rfcs/0019-opentelemetry-completion.md) | OpenTelemetry Completion | v0.2.3 | 📋 Proposed |
 
@@ -614,6 +614,7 @@ v0.5.0 complete
 | [#147](https://github.com/mkhomutov/Persatrix/pull/147) | feat(memory): min_score relevance threshold on recall/recall_notes (RFC 0017 PR 3/7) | 0017 (3/7) | 2026-04-21 |
 | [#148](https://github.com/mkhomutov/Persatrix/pull/148) | feat(agents): wire min_score and remove legacy gates (RFC 0017 PR 4/7) | 0017 (4/7) | 2026-04-21 |
 | [#149](https://github.com/mkhomutov/Persatrix/pull/149) | fix(agents): short-circuit empty-context TICKs (RFC 0017 PR 5/7) | 0017 (5/7) | 2026-04-21 |
+| [#152](https://github.com/mkhomutov/Persatrix/pull/152) | fix(agents): RFC 0017 PR 6 review follow-ups (PR 6/7) | 0017 (6/7) | 2026-04-22 |
 
 ---
 

--- a/docs/rfcs/0017-persona-memory-injection-budget.md
+++ b/docs/rfcs/0017-persona-memory-injection-budget.md
@@ -1,7 +1,7 @@
 # RFC 0017 — Persona Memory Injection Token Budget
 
 **Type**: architecture
-**Status**: 🚧 Implementing
+**Status**: ✅ Implemented
 **Author**: Maksim Khomutov
 **Date**: 2026-04-21
 **Accepted**: 2026-04-21

--- a/docs/rfcs/0017-pr-plan.md
+++ b/docs/rfcs/0017-pr-plan.md
@@ -652,6 +652,8 @@ Test gaps deferred from earlier PR reviews are added here.
 - [x] `make lint` clean
 - [x] `make validate` passes
 
+**Merged**: PR #152 — 2026-04-22
+
 #### Status by finding (PR 6 implementation)
 
 PR 1: #1 ✅ fixed; #2 ⏭ deferred (nice-to-have, see PR 2 #13); #3 ✅ test added (`TestPR6Followups.test_default_min_tokens_floor_is_32`); #4 ✅ inlined; #5 ✅ test added (`test_greedy_admits_smaller_item_after_larger_dropped`).
@@ -692,9 +694,9 @@ No new tests. `make test`, `make lint`, and `make validate` are run to confirm n
 
 #### PR checklist
 
-- [ ] RFC 0017 status = `✅ Implemented`
-- [ ] ROADMAP.md RFC Tracker updated
-- [ ] ROADMAP.md merged-PR history includes PRs 1–7
-- [ ] `make test` passes
-- [ ] `make lint` clean
-- [ ] `make validate` passes
+- [x] RFC 0017 status = `✅ Implemented`
+- [x] ROADMAP.md RFC Tracker updated
+- [x] ROADMAP.md merged-PR history includes PRs 1–6 (PR 7 row is added on merge)
+- [ ] `make test` passes (known pre-existing failure on main: `tests/integration/test_persona_e2e.py::TestTickSchedulerIntegration::test_tick_fires_and_stops`)
+- [x] `make lint` clean
+- [x] `make validate` passes


### PR DESCRIPTION
## Summary
Closes RFC 0017 as the planned PR 7/7 status-hygiene step.

### What changed
- Flip RFC 0017 status to `✅ Implemented` in `docs/rfcs/0017-persona-memory-injection-budget.md`
- Update `docs/rfcs/0017-pr-plan.md`:
  - mark PR 6 as merged (`#152`)
  - complete PR 7 checklist items for status/roadmap/lint/validate
  - keep `make test` unchecked with explicit note about the known pre-existing integration failure
- Update `ROADMAP.md`:
  - header (`Last updated`, `Current phase`, `Current milestone`)
  - v0.2.2 version-map status to `✅ Implemented`
  - RFC 0017 master-index row to `✅ Implemented (7/7)`
  - merged PR history with PR 6 row (`#152`)

## Verification
- `make lint` ✅
- `make validate` ✅
- `make test` ⚠️ fails on pre-existing known issue on `main`:
  - `tests/integration/test_persona_e2e.py::TestTickSchedulerIntegration::test_tick_fires_and_stops`

## Notes
- This PR intentionally does not update `CHANGELOG.md` (deferred to the v0.2.2 release process per the PR plan).