### PR TITLE
chore(release): bump to v0.2.2 + curated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,59 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2026-04-22
+
+> **Codename:** Bounded Persona Memory Injection
+
+### Highlights
+
+- Persona-agent memory injection now enforces a per-event token budget. A new
+  `MemoryBudget` allocator distributes available tokens across the three memory
+  tiers (episodic, relationship, working) and truncates injected context to fit.
+- Episodic and relationship `recall` / `recall_notes` calls now accept a
+  `min_score` relevance threshold, reducing noise in injected memory.
+- TICK events that admit zero memory items after budget allocation are
+  short-circuited before reaching the LLM, eliminating spurious cost on
+  persona agents with empty context windows.
+
+### Upgrade Notes
+
+- **No breaking changes.** All RFC 0017 changes are internal to the Python
+  agent runtime. No proto changes, no new REST endpoints, no config schema
+  changes.
+- **Optional:** `min_score` defaults to `0.0` (matches previous behaviour).
+  Set it in `recall`/`recall_notes` tool calls to filter low-relevance
+  memories proactively.
+
+### 🚀 Features
+
+- *(agents)* `MemoryBudget` allocator + token-aware truncation (RFC 0017 PR 1/7) (#145)
+- *(agents)* `_inject_memory_context` allocate-loop rewrite (RFC 0017 PR 2/7) (#146)
+- *(memory)* `min_score` relevance threshold on `recall`/`recall_notes` (RFC 0017 PR 3/7) (#147)
+- *(agents)* Wire `min_score` and remove legacy gates (RFC 0017 PR 4/7) (#148)
+
+### 🐛 Bug Fixes
+
+- *(agents)* Short-circuit empty-context TICKs (RFC 0017 PR 5/7) (#149)
+- *(agents)* RFC 0017 PR 6 review follow-ups (#152)
+
+### 📚 Documentation
+
+- *(safety)* Add cost warning, responsible-use section, and runtime cost notice (#150)
+- *(rfcs)* Close RFC 0017 — Persona Memory Injection Token Budget (#153)
+- *(manual-tests)* Add MT-MEMORY-004 and MT-PERSONA-003 runbooks for RFC 0017 (#154)
+- *(release)* v0.2.2 release checklist + prep plan + README/guide refresh (#156)
+
+### 🧪 Testing
+
+- *(manual)* v0.2.2 execution report — 18 pass, 1 accepted-with-known-gap (#155)
+
+### 📦 Miscellaneous
+
+- *(deps)* Bump `rustls-webpki` from 0.103.10 to 0.103.12 in `/cli` (#139)
+
+[0.2.2]: https://github.com/mkhomutov/Persatrix/compare/v0.2.1...v0.2.2
+
 ## [0.2.1] - 2026-04-21
 
 > **Codename:** Talk to Your Agents

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.2.1"
+version = "0.2.2"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -879,7 +879,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/docs/v0.2.2-release-prep-plan.md
+++ b/docs/v0.2.2-release-prep-plan.md
@@ -24,7 +24,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 |----|-------|-------|--------|--------|-----------|--------|
 | 1 | A | Manual test execution report (RFC 0017 surface) | `feature/v022-manual-test-execution-report` | 🔀 PR open | #155 | — |
 | 2 | A | README + ROADMAP + guide refresh + release checklist + prep plan | `feature/v022-release-prep-checklist` | 🔄 In progress | — | — |
-| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog generation | `feature/v022-release-prep-version-bump` | ⬜ Not started | — | — |
+| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog generation | `feature/v022-release-prep-version-bump` | 🔀 PR open | #157 | — |
 | 4 | B | Final pre-tag verification & release notes | `feature/v022-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged


### PR DESCRIPTION
## v0.2.2 Release Prep — PR 3: Version Bump + Changelog

Part of the [v0.2.2 release preparation plan](docs/v0.2.2-release-prep-plan.md).

**Depends on**: #156 (PR 2 — docs + checklist) ✅ merged

---

### Changes

| File | Change |
|------|--------|
| `agents/pyproject.toml` | `version` 0.2.1 → 0.2.2 |
| `cli/Cargo.toml` | `version` 0.2.1 → 0.2.2 |
| `cli/Cargo.lock` | Regenerated at 0.2.2 |
| `CHANGELOG.md` | Prepended curated `[0.2.2]` section |

### Changelog section

The new `[0.2.2]` section includes:
- **Highlights** — MemoryBudget allocator, `min_score` threshold, empty-context TICK short-circuit
- **Upgrade Notes** — no breaking changes; `min_score` defaults to `0.0`
- **Features** — RFC 0017 PRs 1–4 (#145–#148)
- **Bug Fixes** — RFC 0017 PRs 5–6 (#149, #152)
- **Documentation** — safety notice, RFC close, runbooks, release docs (#150, #153, #154, #156)
- **Testing** — v0.2.2 execution report (#155)
- **Miscellaneous** — rustls-webpki dep bump (#139)

Prior `[0.2.1]` and `[0.2.0]` sections are preserved verbatim.

### Acceptance criteria

- [x] `agents/pyproject.toml` → `0.2.2`
- [x] `cli/Cargo.toml` → `0.2.2`
- [x] `cli/Cargo.lock` regenerated
- [x] `CHANGELOG.md` has curated `[0.2.2]` section
- [x] Prior version sections untouched
- [x] All pre-commit checks pass

### Next

PR 4 (`feature/v022-release-prep-final`) — final pre-tag verification, Docker smoke test, flip README roadmap row to ✅ Released, then `git tag v0.2.2`.