### PR TITLE
docs(release): post-release follow-up for v0.2.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-22 (v0.2.2 release prep — checklist + prep plan added; README and persona-agents guide refreshed for RFC 0017; manual tests complete — execution report added; integration test fix for RFC 0017 §F)  
-> **Current phase**: v0.2.2 (Persona Memory Injection Token Budget) — ✅ Implemented  
-> **Current milestone**: v0.2.2 release prep — checklist drafted, version bump pending
+> **Last updated**: 2026-04-22 (v0.2.2 released — post-release document update: ROADMAP v0.2.2 section added, prep plan PR 4 marked merged, release checklist finalised)  
+> **Current phase**: v0.2.3 (Structured Logging + OpenTelemetry) — 📋 Planned  
+> **Current milestone**: v0.2.2 released; v0.2.3 planning next
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -17,7 +17,7 @@ A version is ready when a developer can do something meaningful they could not d
 | **v0.1.0** | Submit YAML workflows, orchestrate task agents via gRPC, poll status via REST | ✅ Complete — internal baseline |
 | **v0.2.0** ⭐ | Run persistent AI agents with personalities, memory, and evolving relationships from a terminal | ✅ Complete — first public release |
 | **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete — released |
-| **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | ✅ Implemented |
+| **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | ✅ Complete — released |
 | **v0.2.3** | Operability minor release — structured logs across Go/Python, working `persatrix logs` CLI, end-to-end OpenTelemetry traces from REST handler to LLM call | 📋 Planned |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
@@ -297,6 +297,44 @@ v0.2.1 complete
 | Chat REST endpoint | `internal/server/` | — | 0016 | ✅ Complete (PR #123) |
 | Chat gRPC dispatch | `internal/executor/` | `agents/server_servicers.py` | 0016 | ✅ Complete (PR #121) |
 | `persatrix chat` CLI | — | — | 0016 (`cli/src/commands/chat.rs`) | ✅ Complete (PR #125) |
+
+---
+
+## v0.2.2 — Bounded Persona Memory ✅ Complete
+
+**What a user can do**: Persona agents now operate with a deterministic per-event memory token budget — predictable context size, lower per-tick cost, and no more silent spending when nothing is happening.
+
+### What ships in v0.2.2
+
+- **`MemoryBudget` allocator** — per-event token ceiling distributing the available budget across episodic, relationship, and notes tiers (RFC 0017 §B)
+- **`_inject_memory_context` rewrite** — allocate-loop replaces ad-hoc injection; budget tracked uniformly across all memory types (RFC 0017 §C)
+- **`min_score` relevance threshold** — `EpisodicMemory.recall` / `recall_notes` accept `min_score` and filter out low-scoring matches before injection; legacy opaque gates removed (RFC 0017 §D)
+- **Empty-context TICK short-circuit** — when a TICK fires with no admitted memory, no active goal, and no pending conversation turn, the LLM call is skipped and `idle_count` is incremented (RFC 0017 §F)
+
+### What does not ship in v0.2.2
+
+- Operator-facing config for `_MEMORY_BUDGET_TOKENS` — per-event budget constant is not yet exposed as a per-agent config field; deferred pending demand
+- RFC 0008 (Memory & Context Optimization) — structural prerequisite now met; RFC 0008 implementation planned for v0.3.0
+
+### RFC Scope
+
+| RFC | Title | Status | PRs | Merged |
+|-----|-------|--------|-----|--------|
+| [0017](docs/rfcs/0017-persona-memory-injection-budget.md) | Persona Memory Injection Token Budget | ✅ Implemented | 7 | 7/7 |
+
+### Dependency Chain (v0.2.2)
+
+```
+v0.2.1 complete (RFC 0016 ✅)
+    ↓
+RFC 0017 Phase B (MemoryBudget allocator + allocate-loop rewrite)
+    ↓
+RFC 0017 Phase D (min_score relevance threshold)
+    ↓
+RFC 0017 Phase F (empty-context TICK short-circuit)
+    ↓
+v0.2.2 complete
+```
 
 ---
 
@@ -617,6 +655,10 @@ v0.5.0 complete
 | [#152](https://github.com/mkhomutov/Persatrix/pull/152) | fix(agents): RFC 0017 PR 6 review follow-ups (PR 6/7) | 0017 (6/7) | 2026-04-22 |
 | [#153](https://github.com/mkhomutov/Persatrix/pull/153) | docs(rfc): close RFC 0017 status and roadmap | 0017 (close) | 2026-04-22 |
 | [#154](https://github.com/mkhomutov/Persatrix/pull/154) | docs(manual-tests): add MT-MEMORY-004 and MT-PERSONA-003 for RFC 0017 | 0017 (7/7) | 2026-04-22 |
+| [#155](https://github.com/mkhomutov/Persatrix/pull/155) | test(manual): v0.2.2 execution report and integration test fix for RFC 0017 §F | v0.2.2 release prep | 2026-04-22 |
+| [#156](https://github.com/mkhomutov/Persatrix/pull/156) | docs(release): v0.2.2 release checklist + prep plan + README/guide refresh | v0.2.2 release prep | 2026-04-22 |
+| [#157](https://github.com/mkhomutov/Persatrix/pull/157) | chore(release): bump to v0.2.2 + curated changelog | v0.2.2 release prep | 2026-04-22 |
+| [#158](https://github.com/mkhomutov/Persatrix/pull/158) | docs(release): final pre-tag verification — flip README to Released, check off all gates | v0.2.2 release prep | 2026-04-22 |
 
 ---
 

--- a/docs/v0.2.2-release-checklist.md
+++ b/docs/v0.2.2-release-checklist.md
@@ -55,7 +55,7 @@ Checklist:
 - [x] `CHANGELOG.md` contains a `[0.2.2]` section (PR #157)
 - [x] The existing curated `[0.2.1]` section is preserved verbatim — not overwritten (PR #157)
 - [x] The existing curated `[0.2.0]` section is preserved verbatim (PR #157)
-- [ ] The `[0.2.2]` section includes:
+- [x] The `[0.2.2]` section includes:
   - **Highlights**: per-event memory token budget, relevance-threshold filter on `recall` / `recall_notes`, empty-context TICK short-circuit (no more silent dollars on bored autonomous personas)
   - **Features**: `MemoryBudget` allocator (#145), allocate-loop rewrite of `_inject_memory_context` (#146), `min_score` threshold (#147), wire `min_score` and remove legacy gates (#148), empty-context TICK short-circuit (#149)
   - **Bug fixes**: PR 1–5 review follow-ups (#152), integration test fix for `test_tick_fires_and_stops` (recorded in the v0.2.2 manual test execution report)
@@ -139,10 +139,10 @@ git push origin v0.2.2
 
 GitHub Release checklist:
 
-- [ ] Create the GitHub Release from tag `v0.2.2` (post-merge manual step)
-- [ ] Use the curated v0.2.2 changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body
+- [x] Create the GitHub Release from tag `v0.2.2` (post-merge manual step)
+- [x] Use the curated v0.2.2 changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body
 - [ ] Attach binaries or container references if produced for this release
 
 ---
@@ -206,6 +206,6 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] No unresolved Fail in manual tests
 [x] Known gaps documented for release notes
 [x] Docker smoke test passes (workflow + chat + cost summary)
-[ ] git tag v0.2.2 created and pushed (post-merge manual step)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (post-merge manual step)
+[x] git tag v0.2.2 created and pushed (post-merge manual step)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (post-merge manual step)
 ```

--- a/docs/v0.2.2-release-prep-plan.md
+++ b/docs/v0.2.2-release-prep-plan.md
@@ -25,7 +25,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 1 | A | Manual test execution report (RFC 0017 surface) | `feature/v022-manual-test-execution-report` | ✅ Merged | #155 | 2026-04-22 |
 | 2 | A | README + ROADMAP + guide refresh + release checklist + prep plan | `feature/v022-release-prep-checklist` | ✅ Merged | #156 | 2026-04-22 |
 | 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog generation | `feature/v022-release-prep-version-bump` | ✅ Merged | #157 | 2026-04-22 |
-| 4 | B | Final pre-tag verification & release notes | `feature/v022-release-prep-final` | 🔀 PR open | — | — |
+| 4 | B | Final pre-tag verification & release notes | `feature/v022-release-prep-final` | ✅ Merged | #158 | 2026-04-22 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
## Summary

Post-release documentation housekeeping after the `v0.2.2` tag was pushed and the GitHub Release was published.

### Changes

**`ROADMAP.md`**
- Update header: `Last updated` message reflects the post-release pass; `Current phase` advances to v0.2.3 (📋 Planned); `Current milestone` updated to "v0.2.2 released; v0.2.3 planning next"
- Version Map: v0.2.2 status flipped from `✅ Implemented` → `✅ Complete — released`
- Add dedicated `## v0.2.2 — Bounded Persona Memory ✅ Complete` section (what shipped, what didn't, RFC scope, dependency chain) — mirrors the pattern used for v0.2.0 and v0.2.1
- Add PRs [#155](https://github.com/mkhomutov/Persatrix/pull/155)–[#158](https://github.com/mkhomutov/Persatrix/pull/158) to the Merged PR History table

**`docs/v0.2.2-release-prep-plan.md`**
- PR 4 row: `🔀 PR open | — | —` → `✅ Merged | #158 | 2026-04-22`

**`docs/v0.2.2-release-checklist.md`**
- Check off `[0.2.2]` changelog section content item (generated in PR #157)
- Check off GitHub Release procedure items (tag pushed, release published with changelog, upgrade notes, known gaps)
- Check off summary gate items: `git tag v0.2.2 created and pushed`, `GitHub Release published`
- Leave `Attach binaries` unchecked — no binary artifacts produced for v0.2.2

### Checklist

- [x] `make validate` passes (no YAML changes)
- [x] No new code changes — documentation only
- [x] Follows the v0.2.1 post-release follow-up pattern (PR #141)