### PR TITLE
docs(rfc): future-focused revisions to RFC 0018 and RFC 0019 (Observability Foundation)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-04-22 (v0.2.2 released — post-release document update: ROADMAP v0.2.2 section added, prep plan PR 4 marked merged, release checklist finalised)  
-> **Current phase**: v0.2.3 (Structured Logging + OpenTelemetry) — 📋 Planned  
+> **Last updated**: 2026-04-22 (v0.2.2 released — post-release document update: ROADMAP v0.2.2 section added, prep plan PR 4 marked merged, release checklist finalised; v0.2.3 milestone description refreshed to "Observability Foundation" framing per PR #160 review)  
+> **Current phase**: v0.2.3 (Observability Foundation — RFCs 0018 + 0019) — 📋 Planned  
 > **Current milestone**: v0.2.2 released; v0.2.3 planning next
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
@@ -18,7 +18,7 @@ A version is ready when a developer can do something meaningful they could not d
 | **v0.2.0** ⭐ | Run persistent AI agents with personalities, memory, and evolving relationships from a terminal | ✅ Complete — first public release |
 | **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete — released |
 | **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | ✅ Complete — released |
-| **v0.2.3** | Operability minor release — structured logs across Go/Python, working `persatrix logs` CLI, end-to-end OpenTelemetry traces from REST handler to LLM call | 📋 Planned |
+| **v0.2.3** | Observability Foundation — logs + traces + metrics + correlation shipped together: structured JSON logs across Go/Python/CLI on a versioned schema, working `persatrix logs` CLI (with `--follow` and server-side filters), end-to-end OpenTelemetry traces from REST handler to LLM call (with OTEL Gen-AI semantic conventions), OTLP metrics with exemplars, W3C Baggage propagation, and a tail-sampling Collector pipeline. Combined deliverable of RFCs 0018 + 0019. | 📋 Planned |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 📋 Planned |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |

--- a/docs/rfcs/0018-structured-logging-framework.md
+++ b/docs/rfcs/0018-structured-logging-framework.md
@@ -3,10 +3,11 @@
 **Type**: architecture
 **Status**: 📋 Proposed
 **Author**: Maksim Khomutov
-**Date**: 2026-04-21
+**Date**: 2026-04-21 (rev 2026-04-22)
 **Target**: v0.2.3
+**Schema version**: 1
 **Depends on**: none
-**Feeds into**: RFC 0019 (log↔trace correlation, deferred)
+**Pairs with**: RFC 0019 (OTEL completion — log↔trace correlation lands jointly in v0.2.3)
 
 ---
 
@@ -21,12 +22,13 @@
   - [B. Common Log Schema](#b-common-log-schema)
   - [C. Per-Language Adoption](#c-per-language-adoption)
   - [D. Cross-Process Correlation](#d-cross-process-correlation)
-  - [E. `persatrix logs` Endpoint and Storage](#e-persatrix-logs-endpoint-and-storage)
+  - [E. `persatrix logs` Endpoint, Storage, and Streaming](#e-persatrix-logs-endpoint-storage-and-streaming)
+  - [F. Redaction Hook](#f-redaction-hook)
 - [Security Considerations](#security-considerations)
 - [Phased Implementation Plan](#phased-implementation-plan)
 - [Files Touched (Estimated)](#files-touched-estimated)
 - [Test Strategy](#test-strategy)
-- [Open Questions](#open-questions)
+- [Resolved Decisions](#resolved-decisions)
 - [Decision / Next Steps](#decision--next-steps)
 - [Related Documentation](#related-documentation)
 
@@ -34,45 +36,47 @@
 
 ## Summary
 
-This RFC standardises log output across the three Persatrix processes (Go orchestrator, Python agents, Rust CLI) on a single JSON line schema, propagates `execution_id` / `step_id` / `agent_id` across the gRPC boundary so a single workflow run is traceable through logs, and replaces the stubbed `GET /api/v1/executions/{id}/logs` endpoint with a working implementation backed by a bounded in-memory ring buffer. The result: `persatrix logs <execution-id>` becomes useful, and operators can grep one stream instead of correlating timestamps across three terminals.
+This RFC defines Persatrix's observability foundation for logs: a single versioned JSON line schema emitted by the Go orchestrator, Python agents, and the Rust CLI display path; correlation IDs (`execution_id`, `step_id`, `agent_id`) and OTEL trace context (`trace_id`, `span_id`) on every log line emitted within a workflow execution; a streaming `LogService` gRPC RPC carrying agent log entries to the orchestrator; a bounded ring buffer with on-disk durability so `persatrix logs <execution-id>` survives orchestrator restarts; server-side filters (`--since`, `--workflow`, `--level`) and a `--follow` mode over Server-Sent Events; and a redaction hook surface ready for a future security RFC to plug into without revisiting every call site.
+
+The scope is intentionally larger than "operability hygiene." The goal is to land the observability foundation **once**, designed for the project's full lifetime, rather than ship the same surface across three or four releases with breaking schema changes between them.
 
 ## Motivation
 
 Persatrix already has structured logging on the Go side (`go.uber.org/zap`) but Python uses stdlib `logging` with free-form messages, Rust uses `println!`/`eprintln!`, and there is no shared schema across the three. A workflow execution crosses Go → Python via gRPC; correlating a single run today requires manually matching timestamps across processes.
 
-Three concrete gaps make this visible:
+Concrete gaps:
 
-1. **No shared schema.** Go zap fields, Python f-strings, Rust println — three formats, none parseable as a unit.
+1. **No shared schema.** Three formats, none parseable as a unit.
 2. **No cross-process correlation.** `request_id` is added by `internal/server/middleware.go` but is not propagated into agent-side logs. `execution_id` and `step_id` are not in any log line on the Python side.
-3. **`logs` CLI endpoint is a stub.** [`internal/server/stub_handlers.go`](../../internal/server/stub_handlers.go) returns 501 for `GET /api/v1/executions/{id}/logs`. The Rust CLI [`cli/src/commands/logs.rs`](../../cli/src/commands/logs.rs) is wired and discoverable in `--help`, so users find it, run it, and hit the stub. Worse than not having the command.
+3. **No log↔trace bridge.** RFC 0019 stands up end-to-end traces, but a log line and its corresponding span have nothing in common to join on. Operators land in Jaeger from a log line by manual timestamp scrolling.
+4. **`logs` CLI endpoint is a stub.** [`internal/server/stub_handlers.go`](../../internal/server/stub_handlers.go) returns 501 for `GET /api/v1/executions/{id}/logs`. The Rust CLI [`cli/src/commands/logs.rs`](../../cli/src/commands/logs.rs) is wired and discoverable in `--help`, so users find it, run it, and hit the stub. Worse than not having the command.
+5. **Logs are lost on orchestrator restart.** The most common moment an operator wants logs is right after the thing that crashed.
 
-What happens if we do nothing: every operator-facing issue requires the author to debug it for them, because the operator cannot self-diagnose from logs. Every contributor PR review that depends on understanding cross-process behaviour requires running the code themselves rather than reading log output. The stubbed endpoint stays in `--help` indefinitely.
-
-This is not a v0.2.x headline feature. It is operability hygiene that should land before the v0.3.0 surface area expands and makes the gap larger.
+What happens if we do nothing: every operator-facing issue requires the author to debug it for them. Every contributor PR review that depends on understanding cross-process behaviour requires running the code themselves rather than reading log output. The stubbed endpoint stays in `--help` indefinitely, and the v0.3.0 surface area expands on top of an observability story that doesn't work.
 
 ## Goals
 
-1. A single JSON-line log schema is documented in `docs/observability.md` (new file created by this RFC) and emitted by all three processes.
-2. Python agents emit structured logs via `structlog` with the schema in [Section B](#b-common-log-schema).
+1. A single versioned JSON-line log schema (`schema_version: 1`) is documented in `docs/observability.md` (new file created by this RFC) and emitted by all three processes.
+2. Python agents emit structured logs via `structlog` conforming to the schema in [Section B](#b-common-log-schema).
 3. Go orchestrator zap output conforms to the same schema (field renames where needed; the structured emit is already in place).
 4. `execution_id`, `step_id`, and `agent_id` are propagated from orchestrator into Python agents via gRPC metadata, bound to logger context on entry, and present on every log line emitted while handling that task.
-5. `GET /api/v1/executions/{id}/logs` returns a JSON array of log entries for that execution, drawn from a bounded in-memory ring buffer keyed by `execution_id`. Orchestrator-side entries are always included; agent-side entries are included once the delivery mechanism resolved in [Open Question 1](#open-questions) is implemented (Phase 4). Until then the endpoint returns whatever is in the buffer and the response is well-formed.
-6. `persatrix logs <execution-id>` displays those entries with colourised level, timestamp, service, message; `--verbose` shows the full attribute map.
-
-   *Reviewer note (PR #142): Goal 5 was reworded from "returns a JSON array of log entries" to the conditional form above to remove an apparent contradiction with the Non-Goal that operators "pipe the JSON stream wherever they want" — the merged stream depends on the cross-process delivery decision in OQ1, so the goal cannot promise it unconditionally.*
-7. `PERSATRIX_LOG_FORMAT=pretty` toggles a human-friendly renderer for local development; default remains JSON.
-8. Rust CLI logging is in scope only for the `logs` command's display formatting. CLI-internal logging migration to `tracing` is deferred.
+5. **Log↔trace correlation.** When an OTEL context is active in the emitting goroutine/coroutine, `trace_id` and `span_id` are emitted on the log line automatically. This is in scope for v0.2.3 and lands jointly with RFC 0019.
+6. `GET /api/v1/executions/{id}/logs` returns `{"execution_id": "...", "entries": [...]}` with a merged stream of orchestrator-side and agent-side entries for that execution. Server-side filters (`--since`, `--workflow`, `--level`) are supported as query parameters.
+7. `GET /api/v1/executions/{id}/logs/stream` is a Server-Sent Events endpoint backing `persatrix logs --follow`.
+8. `persatrix logs <execution-id>` displays entries with colourised level, timestamp, service, message; `--verbose` shows the full attribute and source maps; `--follow` tails live entries; `--since`, `--workflow`, `--level` apply server-side filters.
+9. Ring buffer entries are persisted to a bounded on-disk append-only store; `persatrix logs <id>` works across orchestrator restarts.
+10. A redaction hook surface (no-op default) is wired into both Go zap and Python structlog so a future security RFC can plug in real PII/secret scrubbing without touching every call site.
+11. `PERSATRIX_LOG_FORMAT=pretty` toggles a human-friendly renderer for local development; default remains JSON across `make run`, CI, and production.
+12. Rust CLI logging is in scope only for the `logs` command's display formatting. CLI-internal logging migration to `tracing` is deferred.
 
 ## Non-Goals
 
-- **Centralised log aggregation.** Loki / ELK / Splunk / Datadog integration. Operators pipe the JSON stream wherever they want.
-- **Persistent log retention.** The ring buffer is in-memory, bounded, and lost on restart. File-based log storage is a v0.3+ concern if it materialises at all.
-- **Search / filter / query language in the CLI.** `persatrix logs` returns a flat list; users pipe to `jq`, `grep`, or `rg` for filtering.
+- **Centralised log aggregation.** Loki / ELK / Splunk / Datadog integration. Operators pipe the JSON stream wherever they want; the on-disk store gives them a stable format to ship from.
+- **Search / query DSL in the CLI.** `persatrix logs` exposes a small fixed set of server-side filters; arbitrary queries pipe to `jq`, `grep`, or `rg`.
 - **Log shipping or forwarding built into Persatrix.**
-- **Log-based alerting or monitoring.**
-- **Sensitive-data scrubbing.** PII / secret redaction belongs in a dedicated security RFC (likely under RFC 0009's umbrella).
-- **Migrating Rust CLI internals to `tracing`.** Out of scope; the CLI is a thin client and its internal logs are low-value relative to server-side logs.
-- **Log-to-trace correlation fields (`trace_id` / `span_id` on every log line).** Depends on RFC 0019 landing; deferred to a follow-up that lands after both RFCs.
+- **Log-based alerting or monitoring.** Logs are for diagnosis; alerting belongs to traces and metrics.
+- **A real PII / secret scrubber.** This RFC ships the **hook surface only** (no-op default). The actual redactor lives in a future security RFC under RFC 0009's umbrella.
+- **Migrating Rust CLI internals to `tracing`.** Out of scope; the CLI is a thin client.
 
 ---
 
@@ -90,46 +94,53 @@ This is not a v0.2.x headline feature. It is operability hygiene that should lan
 
 ### B. Common Log Schema
 
-One JSON object per line, one event per object. Required fields:
+One JSON object per line, one event per object. Field emission order is **stable** (defined below) for diffability of captured logs across runs.
 
-| Field | Type | Notes |
-|-------|------|-------|
-| `timestamp` | string (ISO 8601 with timezone, RFC 3339) | UTC unless overridden |
-| `level` | string | One of `DEBUG`, `INFO`, `WARN`, `ERROR` |
-| `service` | string | One of `orchestrator`, `agent-<id>`, `cli` |
-| `message` | string | Human-readable; should not include the structured fields |
+#### Required fields (in emission order)
 
-Optional fields, present when applicable:
+| Order | Field | Type | Notes |
+|-------|-------|------|-------|
+| 1 | `schema_version` | string | `"1"` for this RFC. Future breaking changes increment this. |
+| 2 | `timestamp` | string | RFC 3339 with timezone; UTC by default. |
+| 3 | `level` | string | One of `DEBUG`, `INFO`, `WARN`, `ERROR`. |
+| 4 | `service.kind` | string | One of `orchestrator`, `agent`, `cli`. |
+| 5 | `service.instance` | string | Process instance identity (orchestrator node ID, agent ID, CLI invocation ID). |
+| 6 | `message` | string | Human-readable; should not include the structured fields. |
 
-| Field | Type | Notes |
-|-------|------|-------|
-| `execution_id` | string | Workflow run ID |
-| `step_id` | string | Step within a workflow |
-| `agent_id` | string | Source or target agent (depending on log site) |
-| `request_id` | string | HTTP request ID (orchestrator only, set by middleware) |
-| `attributes` | object | Free-form key/value bag for site-specific context |
+#### Optional fields (in emission order, present when applicable)
 
-Reserved for RFC 0019:
+| Order | Field | Type | Notes |
+|-------|-------|------|-------|
+| 7 | `service.role` | string | For agents: `coder`, `reviewer`, `persona`, etc. Omitted otherwise. |
+| 8 | `execution_id` | string | Workflow run ID. |
+| 9 | `step_id` | string | Step within a workflow. |
+| 10 | `agent_id` | string | Source or target agent (depending on log site). For `service.kind=agent`, equals `service.instance`. |
+| 11 | `request_id` | string | HTTP request ID (orchestrator only, set by middleware). |
+| 12 | `trace_id` | string | OTEL trace ID when an OTEL context is active. |
+| 13 | `span_id` | string | OTEL span ID when an OTEL context is active. |
+| 14 | `attributes` | object | Free-form key/value bag for site-specific context. |
+| 15 | `source` | object | `{file, line, function}` of the call site. |
 
-| Field | Type | Notes |
-|-------|------|-------|
-| `trace_id` | string | OTEL trace ID (added by the log↔trace correlation follow-up) |
-| `span_id` | string | OTEL span ID (added by the same follow-up) |
+`service.kind` / `service.instance` / `service.role` are emitted as a flat-keyed group (e.g., `"service.kind": "agent"`, `"service.instance": "ember-owl"`) rather than nested, to keep `jq` / `grep` workflows simple.
 
-The schema is versionless. If a breaking change is needed in the future, it will be called out in CHANGELOG and this RFC will be revised.
+#### Versioning
+
+The schema is **versioned**. Adding optional fields is non-breaking and does not bump `schema_version`. Removing fields, renaming fields, changing field types, or changing the meaning of an existing field bumps `schema_version` to `"2"` and is called out in CHANGELOG. Consumers can branch on the version field cleanly.
 
 ### C. Per-Language Adoption
 
 **Go orchestrator.** Already structured via zap. Work consists of:
 
-- Audit existing `logger.Info/Error/Debug/Warn` call sites, normalise field names to match the schema (`execution_id` not `executionID`, `agent_id` not `agentID`, etc.).
+- Audit existing `logger.Info/Error/Debug/Warn` call sites, normalise field names to match the schema (`execution_id` not `executionID`, `agent_id` not `agentID`, `service.kind` / `service.instance` replacing the existing implicit service identification).
+- Add a zap encoder wrapper that emits `schema_version`, the `service.*` group, the OTEL `trace_id` / `span_id` (read from the goroutine's OTEL context via `trace.SpanContextFromContext`), and `source` (using zap's `WithCaller`).
+- Add a zap encoder pass that calls the redaction hook ([Section F](#f-redaction-hook)) before serialisation.
 - Wire `PERSATRIX_LOG_FORMAT=pretty` to the zap dev encoder; default stays JSON production encoder.
-- No new dependency.
+- No new external dependency.
 
 **Python agents.** Adopt `structlog` with a JSON renderer:
 
 - Add `structlog>=24.1` to `agents/pyproject.toml` runtime deps.
-- New module `agents/observability/logging.py` configures the processor chain (timestamp, level, context vars merger, JSON renderer) and exposes `get_logger(name)`.
+- New module `agents/observability/logging.py` configures the processor chain in this order: timestamp → level → contextvars merger → caller (`structlog.processors.CallsiteParameterAdder`) → OTEL context merger (reads `opentelemetry.trace.get_current_span()`, emits `trace_id` / `span_id` when valid) → redaction hook → key reorderer → JSON renderer. Exposes `get_logger(name)`.
 - Replace `logging.getLogger(__name__)` with `structlog.get_logger(__name__)` across `agents/`. Existing `logger.info("text")` call sites work unchanged; structured fields move to keyword args (`logger.info("text", key=value)`).
 - `PERSATRIX_LOG_FORMAT=pretty` swaps the JSON renderer for `structlog.dev.ConsoleRenderer`.
 
@@ -137,116 +148,221 @@ The schema is versionless. If a breaking change is needed in the future, it will
 
 ### D. Cross-Process Correlation
 
-Three IDs need to travel from orchestrator to agent and back into the agent's log context: `execution_id`, `step_id`, `agent_id`.
+Three IDs travel from orchestrator to agent and into the agent's log context: `execution_id`, `step_id`, `agent_id`. OTEL `trace_id` / `span_id` ride the W3C TraceContext channel installed by RFC 0019.
 
 **Outbound from Go.** The executor already has these in-scope at gRPC dispatch sites (`internal/executor/dispatch.go`, `internal/executor/chat.go`). Inject them into outgoing gRPC metadata using the keys `persatrix-execution-id`, `persatrix-step-id`, `persatrix-agent-id`.
 
 **Inbound on Python.** A new gRPC server interceptor in `agents/observability/grpc_logging.py` extracts those headers from every incoming RPC and binds them to `structlog.contextvars` for the duration of the handler. Every log line emitted during that RPC then automatically carries them.
 
-**Note on overlap with RFC 0019.** RFC 0019's gRPC interceptors propagate W3C TraceContext for OTEL. The two interceptor concerns are independent (header keys differ, lifecycle differs) but should be installed in the same place and reviewed together. This RFC ships the logging-context interceptor; RFC 0019 ships the OTEL one.
+**Key conventions.** Outbound gRPC metadata uses kebab-case keys (`persatrix-execution-id`) because gRPC HTTP/2 metadata keys are required to be lowercase and the kebab form matches existing HTTP-style header conventions used elsewhere in the codebase. OTEL span attribute keys in RFC 0019 use dotted notation (`persatrix.execution_id`) because that is the OTEL semantic-conventions style. The two namespaces are independent; the divergence is intentional.
 
-*Note on key conventions (added per PR #142 review).* Outbound gRPC metadata uses kebab-case keys (`persatrix-execution-id`) because gRPC HTTP/2 metadata keys are required to be lowercase and the kebab form matches existing HTTP-style header conventions used elsewhere in the codebase. OTEL span attribute keys in RFC 0019 use dotted notation (`persatrix.execution_id`) because that is the OTEL semantic-conventions style. The two namespaces are independent; the divergence is intentional, not an oversight.
+**OTEL interceptor coexistence.** RFC 0019's `GrpcInstrumentorServer` is installed first so the logging-context interceptor can see `trace_id` / `span_id` on the active span when binding contextvars. Order is documented in `agents/server.py`.
 
-### E. `persatrix logs` Endpoint and Storage
+### E. `persatrix logs` Endpoint, Storage, and Streaming
 
-**Storage.** A new `internal/observability/logbuffer` package implements a bounded ring buffer keyed by `execution_id`:
+#### Storage
 
-- Each execution gets its own ring (capacity TBD per [Open Question 2](#open-questions); proposal: 1000 entries).
-- Total memory bound: `max_executions × per_execution_capacity` entries; LRU-evict whole executions when the total cap is reached.
-- Buffer accepts entries via a write hook called from a custom zap core (Go) and via a `structlog` processor that pushes to the orchestrator over a small internal HTTP endpoint or a side-channel (see Open Question 1).
-- Writes to a ring are non-blocking. Under sustained saturation, the oldest entry in that execution's ring is evicted to make room (the per-execution overwrite policy described above). Cross-process delivery from agents to the orchestrator is best-effort with bounded retry — drops on the agent shipper side are counted in a metric and surfaced as a `WARN` log on the agent, but do not block agent work.
-- Ring contents are lost on orchestrator restart. This is documented as a known limitation in the operations guide.
+A new `internal/observability/logbuffer` package implements a tiered store keyed by `execution_id`:
 
-*Ring lifecycle (added per PR #142 review, second pass).* Each execution's ring is created on first write (lazy) and **sealed** when the executor records a terminal state for that execution (`completed`, `failed`, `cancelled`). A sealed ring is immutable and remains queryable until LRU-evicted by the total-executions cap. This gives `persatrix logs` deterministic results for finished workflows while in-progress workflows continue to accept appends. The Phase 4 PR plan will pin the exact hook site (state-store transition or executor terminal handler).
+- **In-memory ring per execution.** Capacity defaults `PERSATRIX_LOGBUFFER_PER_EXEC=1000`; total executions retained `PERSATRIX_LOGBUFFER_MAX_EXEC=50`. Worked memory bound: ~25 MB steady-state at 500 B average entry, ~40 MB ceiling at 800 B/entry — well within the orchestrator's existing envelope.
+- **On-disk durability.** Each execution's entries are append-written to `data/logs/<execution_id>.jsonl` (path overridable via `PERSATRIX_LOGBUFFER_DIR`). Total disk cap defaults `PERSATRIX_LOGBUFFER_DISK_MB=512`; oldest completed-execution files are evicted first. On startup, the ring buffer warm-loads the last N completed executions from disk so `persatrix logs <id>` works across restarts.
+- **Drop-level filter.** `PERSATRIX_LOGBUFFER_DROP_LEVEL` (default `DEBUG`) excludes high-volume entries from the buffer without disabling stdout emission.
+- **Per-execution rate limit.** Token-bucket of 1000 entries/s per (execution, level), tunable via `PERSATRIX_LOGBUFFER_RATE_PER_EXEC`. Drops are counted in `logs_buffer_dropped_total{reason="rate_limit"}` and surfaced as a single throttled `WARN` log per execution.
+- **LRU policy.** Per-execution overflow drops oldest-in-execution. Total-cap overflow LRU-evicts whole executions (memory + disk together).
+- **Ring lifecycle.** Each execution's ring is created on first write (lazy) and **sealed** when the executor records a terminal state (`completed`, `failed`, `cancelled`). A sealed ring is immutable and remains queryable until LRU-evicted. The Phase 4 PR plan pins the exact hook site (state-store transition or executor terminal handler).
 
-*Namespace rationale (added per PR #142 review).* The new package lives under `internal/observability/` rather than extending `internal/telemetry/` because `telemetry` is currently scoped to OTEL traces (and, in RFC 0019, metrics); logs follow a different lifecycle (per-execution ring + HTTP endpoint surface) and a different set of operator workflows (`persatrix logs` vs Jaeger). Keeping the two roots separate avoids overloading the `telemetry` package with an unrelated subsystem. A future RFC may consolidate `telemetry` and `observability` under one root once the boundaries stabilise; that consolidation is intentionally out of scope here.
+#### Cross-process delivery: `LogService` streaming gRPC
 
-*Consolidation follow-up commitment (added per PR #142 review, second pass).* To prevent the provisional `telemetry/` ↔ `observability/` split from becoming permanent by inertia, the RFC closure checklist for RFC 0018 (Phase 5) **must** include opening a tracking issue titled "Consolidate `internal/telemetry/` and `internal/observability/`" with a v0.3.x or later target. The same commitment is mirrored in [RFC 0019](0019-opentelemetry-completion.md). This is logged here rather than in the ROADMAP because v0.2.3 is not yet implementing; ROADMAP placement happens at RFC closure.
+Agent log entries reach the orchestrator's buffer over a long-lived bidirectional gRPC stream:
 
-**Endpoint.** `handleGetLogs` is rewritten to:
+```protobuf
+// proto/log_service.proto (new)
+service LogService {
+  // Agent → Orchestrator: stream log entries in batches.
+  // Orchestrator responds with periodic acks for backpressure.
+  rpc StreamLogs(stream LogBatch) returns (stream LogAck);
+}
 
-1. Parse and validate `execution_id` from the path.
-2. Fetch the ring's contents (or empty array if no such execution).
-3. Return `{"execution_id": "...", "entries": [...]}` as JSON. Each entry is a log object conforming to [Section B](#b-common-log-schema).
+message LogBatch {
+  repeated LogEntry entries = 1;
+  string agent_id = 2;
+}
 
-**CLI display.** `cli/src/commands/logs.rs` parses the JSON array and prints each entry:
+message LogEntry {
+  string schema_version = 1;
+  google.protobuf.Timestamp timestamp = 2;
+  string level = 3;
+  string service_kind = 4;
+  string service_instance = 5;
+  string service_role = 6;
+  string message = 7;
+  string execution_id = 8;
+  string step_id = 9;
+  string agent_id = 10;
+  string request_id = 11;
+  string trace_id = 12;
+  string span_id = 13;
+  google.protobuf.Struct attributes = 14;
+  Source source = 15;
+  message Source { string file = 1; uint32 line = 2; string function = 3; }
+}
 
-- `<timestamp> <LEVEL> <service> [<step_id>] <message>` by default
-- `--verbose` adds the `attributes` object pretty-printed below each line
-- Level colourisation via the existing `colored` crate (already in `Cargo.toml`)
-- `--follow` flag: out of scope for this RFC; documented as "not yet implemented" in `--help`
+message LogAck {
+  uint64 received_through_seq = 1;
+}
+```
+
+Why streaming gRPC over an internal HTTP loopback endpoint:
+
+- **One transport, one auth model.** Persatrix already commits to gRPC as the orchestrator↔agent contract. Adding a sidecar HTTP loopback creates a second transport with its own auth story (shared secret, loopback binding, header validation) — permanent technical debt to dodge a one-time proto change.
+- **Backpressure for free.** HTTP/2 flow control end-to-end. Unary HTTP would require reinventing batching + bounded queues + retry on top, and getting it subtly wrong.
+- **Distributed-deployment ready.** v0.3 RFCs (mesh, A2A, multi-node) assume agents may not be co-located with the orchestrator. A loopback HTTP endpoint hard-codes the "same host" assumption; a streaming RPC works the same locally and across the network.
+- **Lower per-line overhead.** A long-lived stream amortises connection cost; batching window of 100 ms or 50 entries (whichever first) on the agent side keeps stream chatter low.
+
+**Agent-side shipper.** `agents/observability/log_shipper.py` runs a background task that consumes a bounded queue (default 1000 entries; overflow drops oldest, increments `logs_shipped_dropped_total`), batches, and writes to the `StreamLogs` client stream. On stream errors, exponential backoff with jitter; on reconnect, resumes from the next entry (no replay — durability is the orchestrator's job once entries arrive).
+
+**Authentication.** The stream piggybacks on the existing agent gRPC channel auth (RFC 0009 will tighten this; today both channels are unauthenticated, consistent with the rest of the v0.2.x REST/gRPC surface).
+
+**Namespace rationale.** The new package lives under `internal/observability/` rather than extending `internal/telemetry/` because `telemetry` is currently scoped to OTEL traces (and, in RFC 0019, metrics); logs follow a different lifecycle (per-execution ring + on-disk store + HTTP/SSE endpoint surface). A future RFC may consolidate `telemetry` and `observability` under one root once the boundaries stabilise — a tracking issue is opened at RFC closure (mirrored in [RFC 0019](0019-opentelemetry-completion.md)).
+
+#### REST endpoints
+
+`GET /api/v1/executions/{id}/logs` — non-streaming, JSON response:
+
+- Query params: `since=<RFC3339>`, `workflow=<id>`, `level=<DEBUG|INFO|WARN|ERROR>`, `limit=<int>` (default 1000).
+- When `id` is the literal `_`, filters apply across all retained executions.
+- Returns `{"execution_id": "...", "entries": [...]}`. Each entry conforms to [Section B](#b-common-log-schema).
+
+`GET /api/v1/executions/{id}/logs/stream` — Server-Sent Events:
+
+- Same query params as above (applied as initial filter; entries arriving after subscription are also filtered).
+- Each event is a single JSON entry on a `data:` line.
+- Backs `persatrix logs --follow`. SSE is chosen over WebSocket because it composes with the existing HTTP server, requires no protocol negotiation, and matches the unidirectional server→client semantics.
+
+#### CLI
+
+`cli/src/commands/logs.rs` parses entries and prints:
+
+- `<timestamp> <LEVEL> <service.kind>/<service.instance> [<step_id>] <message>` by default.
+- `--verbose` adds `attributes` and `source` pretty-printed below each line.
+- Level colourisation via the existing `colored` crate.
+- `--follow` consumes the SSE endpoint.
+- `--since <duration>`, `--workflow <id>`, `--level <level>` map to query params.
+- Multi-execution mode: `persatrix logs --since 10m` invokes `id=_` with the `since` filter.
+
+### F. Redaction Hook
+
+A small interface both loggers call before serialisation. Default implementation is a no-op pass-through.
+
+**Go:**
+
+```go
+// internal/observability/redact/redact.go
+type Redactor interface {
+    Redact(entry map[string]any) map[string]any
+}
+type NoopRedactor struct{}
+func (NoopRedactor) Redact(e map[string]any) map[string]any { return e }
+```
+
+The orchestrator's zap setup wires the configured `Redactor` (default `NoopRedactor`) into a custom `zapcore.Encoder` wrapper. A future security RFC implements a real `Redactor` and registers it via DI in `cmd/orchestrator/main.go` — no log call site changes.
+
+**Python:**
+
+```python
+# agents/observability/redact.py
+class Redactor(Protocol):
+    def redact(self, event_dict: dict) -> dict: ...
+
+class NoopRedactor:
+    def redact(self, event_dict: dict) -> dict: return event_dict
+```
+
+Wired into the structlog processor chain immediately before the JSON renderer. Same swap mechanism.
+
+This RFC ships the hook surface, default no-op, and the wiring; it does **not** ship a real redactor.
 
 ---
 
 ## Security Considerations
 
-- **Log content can leak secrets.** Existing call sites occasionally log argument summaries that may include LLM prompts, tool inputs, or user chat content. This RFC does not introduce redaction (explicit non-goal) but does introduce a CLI surface that exposes those logs over HTTP. The endpoint is currently unauthenticated, consistent with the rest of the v0.2.x REST API. Documented as a known limitation; resolved when RFC 0009's auth layer lands.
-- **Ring buffer DoS.** A workflow that emits very high log volume could fill its ring before useful entries are read. The bound is per-execution, so other executions are unaffected. The total cap prevents one runaway run from exhausting orchestrator memory.
-- **Agent → orchestrator log channel (conditional on [Open Question 1](#open-questions)).** If OQ1 resolves to option (a) — agents `POST` log entries to a new `/internal/logs` endpoint on the orchestrator — that endpoint must either bind to a loopback-only listener or require a shared secret. Otherwise any process on the host could inject log entries attributed to any `execution_id`. If OQ1 resolves to option (b) (gRPC streaming), authn piggybacks on whatever the agent gRPC channel uses today and no new surface is added. The PR plan for Phase 4 must include an explicit security review of the chosen channel.
+- **Log content can leak secrets.** Existing call sites occasionally log argument summaries that may include LLM prompts, tool inputs, or user chat content. This RFC introduces a CLI surface that exposes those logs over HTTP and a streaming gRPC channel that ships them between processes. The endpoint is currently unauthenticated, consistent with the rest of the v0.2.x REST API. The redaction hook ([Section F](#f-redaction-hook)) is in place but ships with a no-op default. A future security RFC under RFC 0009's umbrella plugs in real redaction without touching call sites.
+- **Ring buffer / disk DoS.** Per-execution rate limiting and per-execution capacity contain blast radius for high-volume agents. The total-execution cap and disk cap prevent one runaway run from exhausting orchestrator resources.
+- **Cross-process delivery.** `LogService.StreamLogs` rides the existing agent gRPC channel — no new authenticated surface, no new listening sockets. Authn piggybacks on whatever the agent gRPC channel uses today; tightened by RFC 0009.
+- **On-disk store.** Files in `data/logs/` inherit the orchestrator process's umask. Default file mode is `0o600` (owner read/write only). Documented in operations guide.
 - **No new external dependencies for Go.** Python adds `structlog` (well-maintained, MIT licensed, no transitive C deps).
 - **`pretty` output is opt-in.** Pretty-printed logs may include ANSI escapes; JSON default is safe to pipe into machine consumers.
+- **SSE endpoint resource usage.** A long-lived `--follow` consumer holds a goroutine and a buffer-side subscription. The orchestrator caps concurrent SSE subscribers per execution at 16 (configurable via `PERSATRIX_LOGS_SSE_MAX_SUBS_PER_EXEC`); excess connections receive `429 Too Many Requests`.
 
 ---
 
 ## Phased Implementation Plan
 
-### Phase 1: Schema + Python `structlog` Adoption
+### Phase 1: Schema + Python `structlog` Adoption + Redaction Hook
 
-**Summary.** Document the schema, add `structlog`, replace stdlib logging in `agents/`, no cross-process work yet.
+**Summary.** Document the schema, add `structlog`, replace stdlib logging in `agents/`, ship the no-op redactor surface. No cross-process work yet.
 
 **Deliverables.**
 
-1. `docs/observability.md` defining the schema in [Section B](#b-common-log-schema).
-2. `agents/observability/__init__.py` and `agents/observability/logging.py` configuring `structlog`.
-3. Replace `logging.getLogger` call sites in `agents/`. Existing `logger.info("text")` continues to work; structured fields opt-in via kwargs.
-4. `PERSATRIX_LOG_FORMAT=pretty` env override implemented in `agents/observability/logging.py`.
-5. Unit tests asserting JSON output shape and field presence.
+1. `docs/observability.md` defining the schema in [Section B](#b-common-log-schema) including the field ordering contract.
+2. `agents/observability/__init__.py`, `agents/observability/logging.py`, `agents/observability/redact.py` (no-op default).
+3. Replace `logging.getLogger` call sites in `agents/`.
+4. `PERSATRIX_LOG_FORMAT=pretty` env override.
+5. Unit tests asserting JSON output shape, `schema_version`, field ordering, redactor pass-through.
 
 **Dependencies.** None.
 
-### Phase 2: Go Field Normalisation + `pretty` Encoder
+### Phase 2: Go Field Normalisation + `pretty` Encoder + Redaction Hook + Source Field
 
-**Summary.** Make zap output conform to the schema; add the `pretty` mode.
+**Summary.** Make zap output conform to the schema; add the `pretty` mode; wire the no-op redactor; emit `source`.
 
 **Deliverables.**
 
-1. Audit and rename zap field keys (script-assisted) to schema names.
-2. `PERSATRIX_LOG_FORMAT=pretty` wired to zap dev encoder; default JSON.
-3. Tests asserting field name presence on representative log lines.
+1. Audit and rename zap field keys (script-assisted) to schema names; emit `service.kind` / `service.instance` / optional `service.role`; add `schema_version`.
+2. `internal/observability/redact/` package with `NoopRedactor`; wired into a `zapcore.Encoder` wrapper.
+3. `PERSATRIX_LOG_FORMAT=pretty` wired to zap dev encoder; default JSON.
+4. CHANGELOG entry under v0.2.3 enumerating renamed zap field keys (old → new table).
+5. README quick-start updated with `PERSATRIX_LOG_FORMAT=pretty` example.
+6. Tests asserting field name presence, ordering, and redactor invocation.
 
 **Dependencies.** Phase 1 (schema document is the source of truth).
 
-### Phase 3: Cross-Process Context Propagation
+### Phase 3: Cross-Process Correlation + OTEL Trace IDs on Logs
 
-**Summary.** `execution_id` / `step_id` / `agent_id` cross the gRPC boundary into agent-side logs.
+**Summary.** `execution_id` / `step_id` / `agent_id` cross the gRPC boundary into agent-side logs; `trace_id` / `span_id` appear on every log line within an OTEL context.
 
 **Deliverables.**
 
 1. Outbound metadata injection in `internal/executor/dispatch.go` and `internal/executor/chat.go`.
-2. Inbound gRPC server interceptor in `agents/observability/grpc_logging.py`, registered in `agents/server.py`.
-3. Integration test: submit a workflow, assert agent-side log lines for that workflow contain matching `execution_id` and `step_id`.
+2. Inbound gRPC server interceptor in `agents/observability/grpc_logging.py`, registered in `agents/server.py` (after `GrpcInstrumentorServer` from RFC 0019).
+3. OTEL context reader in the Go zap encoder wrapper (`trace.SpanContextFromContext`).
+4. OTEL context processor in the Python structlog chain.
+5. Integration test: submit a workflow, assert agent-side log lines for that workflow contain matching `execution_id`, `step_id`, `trace_id`, `span_id`.
 
-**Dependencies.** Phase 1, Phase 2.
+**Dependencies.** Phase 1, Phase 2, RFC 0019 Phase 1 (OTEL initialised on Python side).
 
-### Phase 4: Ring Buffer + `logs` Endpoint + CLI Display
+### Phase 4: Ring Buffer + On-Disk Store + `LogService` Streaming + Endpoints + CLI
 
-**Summary.** Make `persatrix logs <id>` actually work.
+**Summary.** Make `persatrix logs <id>` actually work, including `--follow`, filters, and durability.
 
 **Deliverables.**
 
-1. `internal/observability/logbuffer` package with `Buffer` type and bounded eviction.
-2. Custom zap core writing to the buffer alongside stdout.
-3. Agent-side log shipper (mechanism per [Open Question 1](#open-questions)) feeding the same buffer.
-4. `handleGetLogs` rewritten; remove from `stub_handlers.go`.
-5. `cli/src/commands/logs.rs` rewritten to parse and display the new response shape.
-6. E2E test: submit a workflow, call `persatrix logs <id>`, assert output contains entries from both Go and Python sides with correct `execution_id`.
-7. Operations guide section in `docs/observability.md` covering `persatrix logs` usage and the in-memory limitation.
+1. `proto/log_service.proto` (new); regenerated Go (`internal/generated/`) and Python (`agents/generated/`) stubs.
+2. `internal/observability/logbuffer` package: in-memory ring + disk store + LRU + rate limiting + ring lifecycle (seal-on-terminal).
+3. Custom zap core writing to the buffer alongside stdout.
+4. Agent-side `agents/observability/log_shipper.py` streaming via `LogService.StreamLogs` with bounded queue and reconnect-with-backoff.
+5. Orchestrator-side `LogService` server registered on the existing agent gRPC server.
+6. `internal/server/logs_handler.go`: `GET /api/v1/executions/{id}/logs` with `since` / `workflow` / `level` / `limit` filters; `id=_` for cross-execution. Remove from `stub_handlers.go`.
+7. `internal/server/logs_stream_handler.go`: SSE endpoint for `--follow`.
+8. `cli/src/commands/logs.rs`: rewrite display + `--verbose` + `--follow` + `--since` + `--workflow` + `--level`.
+9. E2E test: submit a workflow, call `persatrix logs <id>`, assert merged Go + Python entries; restart orchestrator, assert entries still queryable.
+10. Operations guide section in `docs/observability.md` covering CLI usage, env-var knobs, on-disk store layout, and the `data/logs/` umask note.
 
 **Dependencies.** Phase 3.
 
-### Phase 5 (reserved): Review Follow-Ups + RFC Close
+### Phase 5: Review Follow-Ups + RFC Close
 
-Per [development-workflow.md](../development-workflow.md) Phase 5–8.
+Per [development-workflow.md](../development-workflow.md) Phase 5–8. Closure checklist must include opening a tracking issue titled "Consolidate `internal/telemetry/` and `internal/observability/`" with a v0.3.x or later target (mirrored in RFC 0019).
 
 ---
 
@@ -255,49 +371,63 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8.
 | Component | Files | Change |
 |-----------|-------|--------|
 | Docs | `docs/observability.md` | Add (new — schema + operations guide) |
-| Python agents | `agents/observability/__init__.py`, `agents/observability/logging.py`, `agents/observability/grpc_logging.py` | Add (new modules) |
+| Docs | [README.md](../../README.md) | Add `PERSATRIX_LOG_FORMAT=pretty` to quick-start |
+| Docs | [CHANGELOG.md](../../CHANGELOG.md) | v0.2.3 entry: zap field renames table; new endpoints; new env vars |
+| Docs | [ROADMAP.md](../../ROADMAP.md) | Add v0.2.3 milestone; add RFC 0018 to tracker |
+| Protos | `proto/log_service.proto` | Add (new) |
+| Generated | `internal/generated/log_service*.go`, `agents/generated/log_service*.py` | Regenerated |
+| Python agents | `agents/observability/__init__.py`, `agents/observability/logging.py`, `agents/observability/grpc_logging.py`, `agents/observability/log_shipper.py`, `agents/observability/redact.py` | Add (new modules) |
 | Python agents | `agents/pyproject.toml` | Add `structlog` runtime dep |
 | Python agents | `agents/server.py`, `agents/base.py`, `agents/llm_client.py`, `agents/dispatch.py`, `agents/persona.py`, `agents/persona_behavior.py`, others | Replace `logging.getLogger` with `structlog.get_logger` |
+| Go orchestrator | `internal/observability/logbuffer/` | Add (new package) — ring + disk + LRU + rate limit |
+| Go orchestrator | `internal/observability/redact/` | Add (new package) — no-op redactor surface |
+| Go orchestrator | `internal/observability/zapcore/` | Add (new) — encoder wrapper for `service.*`, OTEL IDs, source, redaction hook |
 | Go orchestrator | `internal/executor/dispatch.go`, `internal/executor/chat.go` | Inject correlation IDs into outgoing gRPC metadata |
-| Go orchestrator | `internal/observability/logbuffer/` (new package) | Bounded ring buffer keyed by execution ID |
-| Go orchestrator | `cmd/orchestrator/main.go` | Wire custom zap core that fans out to ring buffer |
-| Go orchestrator | `internal/server/server.go` (handler registration), new `internal/server/logs_handler.go` | Implement `handleGetLogs`; remove from `stub_handlers.go` |
+| Go orchestrator | `cmd/orchestrator/main.go` | Wire encoder wrapper, register `LogService` server, register redactor (no-op) |
+| Go orchestrator | `internal/server/logs_handler.go` (new), `internal/server/logs_stream_handler.go` (new), `internal/server/server.go` | Implement endpoints; remove `handleGetLogs` from `stub_handlers.go` |
 | Go orchestrator | `internal/server/stub_handlers.go` | Remove `handleGetLogs` stub |
-| Rust CLI | `cli/src/commands/logs.rs` | Rewrite display formatting for new response shape |
-| Tests | `agents/tests/test_observability_logging.py`, `agents/tests/test_grpc_logging_interceptor.py` (new) | Unit + integration coverage |
-| Tests | `internal/observability/logbuffer/buffer_test.go` (new) | Unit tests for buffer eviction |
-| Tests | `internal/server/logs_handler_test.go` (new) | Endpoint tests |
-| Tests | `tests/integration/test_logs_e2e.py` (new) | E2E correlation test |
-| Docs | [ROADMAP.md](../../ROADMAP.md) | Add v0.2.3 milestone; add RFC 0018 to tracker |
+| Rust CLI | `cli/src/commands/logs.rs` | Rewrite: display, filters, `--follow` (SSE consumer) |
+| Rust CLI | `cli/Cargo.toml` | Add SSE / `eventsource-stream` dep if not present |
+| Tests | `agents/tests/test_observability_logging.py`, `agents/tests/test_grpc_logging_interceptor.py`, `agents/tests/test_log_shipper.py` (new) | Unit + integration |
+| Tests | `internal/observability/logbuffer/buffer_test.go`, `internal/observability/logbuffer/disk_test.go` (new) | Unit tests for eviction, durability, rate limit |
+| Tests | `internal/server/logs_handler_test.go`, `internal/server/logs_stream_handler_test.go` (new) | Endpoint tests |
+| Tests | `tests/integration/test_logs_e2e.py` (new) | E2E: correlation, filters, restart durability, follow |
 
-No changes to: protos, schemas, JSON schemas, blueprints, workflows.
+No changes to: agent / channel / workflow JSON schemas, blueprints, workflow YAML.
 
 ---
 
 ## Test Strategy
 
-- **Unit tests — `agents/observability/logging.py`**: schema fields present on default JSON output; `PERSATRIX_LOG_FORMAT=pretty` selects console renderer; context vars merge into output.
-- **Unit tests — `agents/observability/grpc_logging.py`**: interceptor extracts the three metadata keys; missing headers don't crash; context is cleared after handler returns.
-- **Unit tests — `internal/observability/logbuffer`**: per-execution capacity respected; LRU eviction across executions; concurrent writes safe; reads return entries in insertion order.
-- **Unit tests — `internal/server/logs_handler.go`**: empty execution returns empty array; populated execution returns entries; invalid execution ID format returns 400.
-- **Integration test — agent-side correlation**: invoke an `AgentService.HandleTask` with metadata; assert all log lines emitted during the call carry the IDs.
-- **E2E test — `persatrix logs`**: submit a small workflow, run `persatrix logs <execution_id>`, assert output has entries from both `orchestrator` and `agent-<id>` services for the same `execution_id`.
-- **Manual smoke**: run `make run`, submit a workflow via `persatrix run`, then `persatrix logs <id>`; eyeball the output. Toggle `PERSATRIX_LOG_FORMAT=pretty` and re-run.
+- **Unit — `agents/observability/logging.py`**: schema fields present and ordered; `schema_version` emitted; `PERSATRIX_LOG_FORMAT=pretty` selects console renderer; contextvars merge; OTEL processor adds `trace_id`/`span_id` when a span is active and omits them when not; redactor is invoked.
+- **Unit — `agents/observability/grpc_logging.py`**: interceptor extracts the three metadata keys; missing headers don't crash; context is cleared after handler returns.
+- **Unit — `agents/observability/log_shipper.py`**: bounded queue overflow drops oldest and increments counter; reconnect-with-backoff on stream errors; flush on shutdown.
+- **Unit — `internal/observability/logbuffer`**: per-execution capacity respected; LRU eviction across executions; disk persistence + warm-load on startup; rate limiter drops with reason; ring sealing on terminal state; concurrent writes safe.
+- **Unit — `internal/server/logs_handler.go`**: empty execution returns empty array; filters (`since`, `workflow`, `level`) applied correctly; `id=_` cross-execution; invalid execution ID format returns 400.
+- **Unit — `internal/server/logs_stream_handler.go`**: SSE framing; subscriber cap returns 429; client disconnect cleans up subscription.
+- **Integration — agent-side correlation**: invoke `AgentService.HandleTask` with metadata + active OTEL context; assert all log lines emitted during the call carry IDs and trace IDs.
+- **Integration — `LogService` streaming**: agent ships entries; orchestrator buffer receives them; ack mechanism advances; agent reconnects after orchestrator restart.
+- **E2E — `persatrix logs`**: submit a small workflow, run `persatrix logs <execution_id>`, assert merged Go + Python entries, matching `execution_id`, valid `trace_id`. Run `persatrix logs --follow` against a long-running workflow; observe live entries. Restart orchestrator mid-test; re-run `persatrix logs <id>`; assert pre-restart entries still present.
+- **Manual smoke**: `make run`, submit a workflow via `persatrix run`, then `persatrix logs <id>`, `--follow`, `--since 5m`. Toggle `PERSATRIX_LOG_FORMAT=pretty` and re-run.
 
 ---
 
-## Open Questions
+## Resolved Decisions
 
-1. **Agent-side log shipping mechanism.** How do Python log entries reach the orchestrator's ring buffer? Options:
-   - **(a)** Agent posts each entry to a small internal HTTP endpoint on the orchestrator (`POST /internal/logs`). Simple, adds an HTTP hop per log line.
-   - **(b)** Reuse the existing gRPC channel — a streaming RPC `StreamLogs` from agent to orchestrator. Lower overhead, requires proto change.
-   - **(c)** Out of scope for v0.2.3 — orchestrator and agents each maintain their own buffer, `persatrix logs` queries both. More complex on the CLI side.
-   Recommendation: **(a)** for v0.2.3; revisit if log volume becomes a problem.
-2. **Ring buffer capacity defaults.** Per-execution: 1000 entries. Total executions retained: 50. Total memory cap implied: ~50k entries. Acceptable? Confirm before Phase 4.
+The following decisions are part of the spec; they are recorded here for traceability and not deferred.
 
-   *Worked memory bound (added per PR #142 review, second pass).* A typical structured log entry serialises to roughly 300–800 bytes of JSON (timestamp + level + service + message + 4–6 attribute fields; the `attributes` bag dominates variance). Taking 500 bytes as a working average: 50 executions × 1000 entries × 500 B ≈ **25 MB** steady-state, with a hard ceiling near ~40 MB at 800 B/entry. This is well within the orchestrator's existing memory envelope (the in-memory state store and registry are the larger footprints) and acceptable as a default. The Phase 4 PR plan should expose both knobs (`PERSATRIX_LOGBUFFER_PER_EXEC`, `PERSATRIX_LOGBUFFER_MAX_EXEC`) as env vars so operators can tune for their own workloads.
-3. **Backward compatibility of log field names.** Renaming `executionID` → `execution_id` in zap output is a breaking change for any operator currently parsing Persatrix logs. CHANGELOG entry is sufficient at v0.2.x; no compatibility shim needed.
-4. **Should `pretty` mode be the default for `make run` (developer ergonomics)?** Recommendation: keep JSON default everywhere; document `PERSATRIX_LOG_FORMAT=pretty` as the standard local-dev override in the README quick-start.
+1. **Agent-side log shipping mechanism: streaming gRPC `LogService.StreamLogs`.** Chosen over loopback HTTP and over per-process buffers. Rationale in [Section E](#e-persatrix-logs-endpoint-storage-and-streaming). Adds a one-time proto change; pays back in unified transport, free backpressure, distributed-deployment readiness, and lower per-line overhead.
+2. **Ring buffer defaults: 1000 entries × 50 executions; 512 MB on-disk cap.** Worked memory bound ~25 MB steady-state. All knobs exposed as env vars (`PERSATRIX_LOGBUFFER_PER_EXEC`, `PERSATRIX_LOGBUFFER_MAX_EXEC`, `PERSATRIX_LOGBUFFER_DISK_MB`, `PERSATRIX_LOGBUFFER_DIR`, `PERSATRIX_LOGBUFFER_DROP_LEVEL`, `PERSATRIX_LOGBUFFER_RATE_PER_EXEC`).
+3. **Backward compatibility of zap field names: clean break, CHANGELOG entry only.** No compatibility shim. Pre-1.0; field names are not in any public contract (no proto, no schema, no spec doc references them).
+4. **`pretty` default: JSON everywhere, including `make run` and CI.** `PERSATRIX_LOG_FORMAT=pretty` documented as the standard local-dev override. Avoids the "works locally, looks different in CI" footgun.
+5. **Schema is versioned from day one.** `schema_version: "1"`. Adding optional fields is non-breaking; all other changes bump the version.
+6. **`service` is a structured tuple, not a free string.** `service.kind` / `service.instance` / `service.role`. Aligns with future multi-node deployments and OTEL `service.*` semantic conventions.
+7. **`source` (file/line/function) is in scope.** Cheap on both sides; significant debugging win.
+8. **Field emission order is stable.** Improves diffability of captured logs.
+9. **`--follow` is in scope via SSE.** WebSocket rejected (protocol negotiation overhead, bidirectional semantics not needed).
+10. **Server-side filters (`--since`, `--workflow`, `--level`, `id=_`) are in scope.** Covers the 80% operator workflow without becoming a query DSL.
+11. **Redaction hook surface ships in v0.2.3, no-op default.** Real redactor is a future security RFC; the surface is in place so that RFC does not require touching every call site.
+12. **Log↔trace correlation lands in v0.2.3.** Not deferred. The whole point of standing up structured logs and OTEL together is operator pivot from a log line to a trace and back.
 
 ---
 
@@ -306,10 +436,8 @@ No changes to: protos, schemas, JSON schemas, blueprints, workflows.
 **To accept this RFC:**
 
 1. Confirm v0.2.3 as the target milestone (this RFC adds v0.2.3 to the ROADMAP version map alongside RFC 0019).
-2. Resolve Open Question 1 (log shipping mechanism) before Phase 4 starts.
-3. Sign off on the schema in [Section B](#b-common-log-schema) as the cross-language contract.
-
-**Hard pre-implementation gate (added per PR #142 review, second pass).** This RFC's status will not flip from 📋 Proposed to 🚧 Implementing until [Open Question 1](#open-questions) (agent-side log shipping mechanism) is resolved and the chosen option is reflected in [Section E](#e-persatrix-logs-endpoint-and-storage). Several downstream claims in this RFC (no proto changes, no new authenticated HTTP surface, the Security Considerations bullet on the internal endpoint) are conditional on that decision; promoting to Implementing without it would lock in the conditional text as the contract.
+2. Sign off on the schema in [Section B](#b-common-log-schema) as the cross-language contract (including `schema_version: "1"` and the structured `service.*` group).
+3. Sign off on `LogService` as a new public proto surface in `proto/log_service.proto`.
 
 **Once accepted:**
 
@@ -321,8 +449,8 @@ No changes to: protos, schemas, JSON schemas, blueprints, workflows.
 
 ## Related Documentation
 
-- [RFC 0019 — OpenTelemetry Completion](0019-opentelemetry-completion.md) (paired RFC; targets the same release)
-- [RFC 0009 — Agent Identity, Security & Sandboxing](0009-security-sandboxing.md) (auth layer that will eventually gate `logs` endpoint)
+- [RFC 0019 — OpenTelemetry Completion](0019-opentelemetry-completion.md) (paired RFC; targets the same release; provides the OTEL context the log↔trace processor reads from)
+- [RFC 0009 — Agent Identity, Security & Sandboxing](0009-security-sandboxing.md) (auth layer that will eventually gate `logs` endpoints and `LogService`; future home of the real redactor)
 - [Development Workflow](../development-workflow.md)
 - [Branching Strategy](../BRANCHING.md)
 - [internal/server/stub_handlers.go](../../internal/server/stub_handlers.go) (the stub being replaced)

--- a/docs/rfcs/0018-structured-logging-framework.md
+++ b/docs/rfcs/0018-structured-logging-framework.md
@@ -25,15 +25,15 @@ Mirrored from [RFC 0019 § Relationship to RFC 0018](0019-opentelemetry-completi
 | Concern | Single source of truth |
 |---------|------------------------|
 | Trace + metric export | OTLP HTTP (port 4318) — RFC 0019 |
-| Log ingest (agent → orchestrator) | `LogService` streaming gRPC over the existing agent gRPC channel — this RFC, [Section E](#e-persatrix-logs-endpoint-storage-and-streaming) |
+| Log ingest (agent → orchestrator) | `LogService` streaming gRPC over the existing agent gRPC channel — RFC 0018 [Section E](#e-persatrix-logs-endpoint-storage-and-streaming) |
 | Log export to external backends (optional) | OTLP HTTP via the same Collector — operator-side, out of scope for v0.2.3 |
-| Schema version field | `schema_version: 1` (logs, this RFC); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics, RFC 0019) |
+| Schema version field | `schema_version: 1` (logs, RFC 0018); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics, RFC 0019) |
 | Correlation IDs | `execution_id`, `step_id`, `agent_id`, `workflow_id`, `trace_id`, `span_id` |
 | Cross-process propagation | W3C TraceContext + W3C Baggage |
 | Redaction hook | Shared interface, used by both log records and span attributes |
 | Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree; the rename happens in RFC 0019 Phase 1) |
 | Sampling discipline | Parent-based head sampling + Collector tail sampling |
-| Log↔trace enricher ownership | This RFC (owns the structlog chain and zap encoder where the enrichment lives); RFC 0019 only requires that the OTEL context is established before the enricher PR lands |
+| Log↔trace enricher ownership | RFC 0018 (owns the structlog chain and zap encoder where the enrichment lives); RFC 0019 only requires that the OTEL context is established before the enricher PR lands |
 
 ---
 
@@ -148,6 +148,8 @@ One JSON object per line, one event per object. Field emission order is **stable
 | 15 | `source` | object | `{file, line, function}` of the call site. |
 
 `service.kind` / `service.instance` / `service.role` are emitted as a flat-keyed group (e.g., `"service.kind": "agent"`, `"service.instance": "ember-owl"`) rather than nested, to keep `jq` / `grep` workflows simple.
+
+**Immutability of `service.*` on ingest.** `service.kind`, `service.instance`, and `service.role` are set by the emitter at the moment a log record is created and are **never rewritten by the orchestrator on ingest**. Agent-shipped records persisted into the orchestrator's ring buffer ([Section E](#e-persatrix-logs-endpoint-storage-and-streaming)) preserve their original `service.kind=agent` / `service.role=<role>` fields; the orchestrator's own records carry `service.kind=orchestrator`. The merged stream returned by the `logs` endpoint therefore lets a reader distinguish per-record provenance without consulting any out-of-band metadata.
 
 #### Versioning
 
@@ -407,7 +409,7 @@ issue would have nothing to track.
 | Docs | `docs/observability.md` | Add (new — schema + operations guide) |
 | Docs | [README.md](../../README.md) | Add `PERSATRIX_LOG_FORMAT=pretty` to quick-start |
 | Docs | [CHANGELOG.md](../../CHANGELOG.md) | v0.2.3 entry: zap field renames table; new endpoints; new env vars |
-| Docs | [ROADMAP.md](../../ROADMAP.md) | Add v0.2.3 milestone; add RFC 0018 to tracker |
+| Docs | [ROADMAP.md](../../ROADMAP.md) | Update RFC 0018 status (📋 → 🚧 → ✅) and the v0.2.3 "Observability Foundation" milestone row as PRs land (the milestone row and tracker entry already exist; implementation PRs flip status fields rather than add rows) |
 | Protos | `proto/log_service.proto` | Add (new) |
 | Generated | `internal/generated/log_service*.go`, `agents/generated/log_service*.py` | Regenerated |
 | Python agents | `agents/observability/__init__.py`, `agents/observability/logging.py`, `agents/observability/grpc_logging.py`, `agents/observability/log_shipper.py`, `agents/observability/redact.py` | Add (new modules) |
@@ -472,6 +474,7 @@ The following decisions are part of the spec; they are recorded here for traceab
 1. Confirm v0.2.3 as the target milestone (this RFC adds v0.2.3 to the ROADMAP version map alongside RFC 0019).
 2. Sign off on the schema in [Section B](#b-common-log-schema) as the cross-language contract (including `schema_version: "1"` and the structured `service.*` group).
 3. Sign off on `LogService` as a new public proto surface in `proto/log_service.proto`.
+4. Acknowledge the joint-PR-plan discipline: `docs/rfcs/0018-pr-plan.md` and `docs/rfcs/0019-pr-plan.md` MUST be authored as a coordinated pair (not independently), with the three Cross-RFC sequencing constraints below copied verbatim into both plans so the ordering is not re-derived inconsistently.
 
 **Cross-RFC sequencing (added per PR #160 review).** Coordinated with [RFC 0019 Decision / Next Steps](0019-opentelemetry-completion.md#decision--next-steps):
 

--- a/docs/rfcs/0018-structured-logging-framework.md
+++ b/docs/rfcs/0018-structured-logging-framework.md
@@ -3,11 +3,37 @@
 **Type**: architecture
 **Status**: 📋 Proposed
 **Author**: Maksim Khomutov
-**Date**: 2026-04-21 (rev 2026-04-22)
+**Date**: 2026-04-21 (rev 2026-04-22; rev 2026-04-22b — apply PR #160 review)
 **Target**: v0.2.3
-**Schema version**: 1
 **Depends on**: none
 **Pairs with**: RFC 0019 (OTEL completion — log↔trace correlation lands jointly in v0.2.3)
+
+<!--
+Review note (PR #160): the `Schema version` frontmatter field was removed; the
+log schema version is the central concept of [Section B](#b-common-log-schema)
+and is tracked there as `schema_version: "1"`. The RFC template does not
+include a `Schema version` frontmatter field; introducing it would set an
+ad-hoc convention.
+-->
+
+---
+
+## Relationship to RFC 0019
+
+Mirrored from [RFC 0019 § Relationship to RFC 0018](0019-opentelemetry-completion.md#relationship-to-rfc-0018) so reviewers landing in this document first see the same single source of truth (added per PR #160 review):
+
+| Concern | Single source of truth |
+|---------|------------------------|
+| Trace + metric export | OTLP HTTP (port 4318) — RFC 0019 |
+| Log ingest (agent → orchestrator) | `LogService` streaming gRPC over the existing agent gRPC channel — this RFC, [Section E](#e-persatrix-logs-endpoint-storage-and-streaming) |
+| Log export to external backends (optional) | OTLP HTTP via the same Collector — operator-side, out of scope for v0.2.3 |
+| Schema version field | `schema_version: 1` (logs, this RFC); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics, RFC 0019) |
+| Correlation IDs | `execution_id`, `step_id`, `agent_id`, `workflow_id`, `trace_id`, `span_id` |
+| Cross-process propagation | W3C TraceContext + W3C Baggage |
+| Redaction hook | Shared interface, used by both log records and span attributes |
+| Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree; the rename happens in RFC 0019 Phase 1) |
+| Sampling discipline | Parent-based head sampling + Collector tail sampling |
+| Log↔trace enricher ownership | This RFC (owns the structlog chain and zap encoder where the enrichment lives); RFC 0019 only requires that the OTEL context is established before the enricher PR lands |
 
 ---
 
@@ -223,7 +249,7 @@ Why streaming gRPC over an internal HTTP loopback endpoint:
 
 **Authentication.** The stream piggybacks on the existing agent gRPC channel auth (RFC 0009 will tighten this; today both channels are unauthenticated, consistent with the rest of the v0.2.x REST/gRPC surface).
 
-**Namespace rationale.** The new package lives under `internal/observability/` rather than extending `internal/telemetry/` because `telemetry` is currently scoped to OTEL traces (and, in RFC 0019, metrics); logs follow a different lifecycle (per-execution ring + on-disk store + HTTP/SSE endpoint surface). A future RFC may consolidate `telemetry` and `observability` under one root once the boundaries stabilise — a tracking issue is opened at RFC closure (mirrored in [RFC 0019](0019-opentelemetry-completion.md)).
+**Namespace rationale.** The new package lives under `internal/observability/` rather than extending `internal/telemetry/` because `telemetry` is currently scoped to OTEL traces (and, in RFC 0019, metrics); logs follow a different lifecycle (per-execution ring + on-disk store + HTTP/SSE endpoint surface). Under the future-focused framing, [RFC 0019 Phase 1](0019-opentelemetry-completion.md#phase-1-python-otel-init--grpc-context-propagation--baggage) renames `internal/telemetry/` → `internal/observability/` so the project ends v0.2.3 with a single root. <!-- Review note (PR #160): previously this paragraph mentioned a future consolidation RFC and a tracking issue opened at RFC closure; both are obsolete now that the rename is in RFC 0019's scope. -->
 
 #### REST endpoints
 
@@ -362,7 +388,15 @@ This RFC ships the hook surface, default no-op, and the wiring; it does **not** 
 
 ### Phase 5: Review Follow-Ups + RFC Close
 
-Per [development-workflow.md](../development-workflow.md) Phase 5–8. Closure checklist must include opening a tracking issue titled "Consolidate `internal/telemetry/` and `internal/observability/`" with a v0.3.x or later target (mirrored in RFC 0019).
+Per [development-workflow.md](../development-workflow.md) Phase 5–8.
+
+<!--
+Review note (PR #160): the previous version of this phase mandated opening a
+tracking issue titled "Consolidate `internal/telemetry/` and
+`internal/observability/`" at RFC closure. That follow-up is dropped because
+RFC 0019 Phase 1 performs the rename in v0.2.3 — the consolidation tracking
+issue would have nothing to track.
+-->
 
 ---
 
@@ -381,7 +415,7 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8. Closure c
 | Python agents | `agents/server.py`, `agents/base.py`, `agents/llm_client.py`, `agents/dispatch.py`, `agents/persona.py`, `agents/persona_behavior.py`, others | Replace `logging.getLogger` with `structlog.get_logger` |
 | Go orchestrator | `internal/observability/logbuffer/` | Add (new package) — ring + disk + LRU + rate limit |
 | Go orchestrator | `internal/observability/redact/` | Add (new package) — no-op redactor surface |
-| Go orchestrator | `internal/observability/zapcore/` | Add (new) — encoder wrapper for `service.*`, OTEL IDs, source, redaction hook |
+| Go orchestrator | `internal/observability/zapenc/` | Add (new) — zap encoder wrapper for `service.*`, OTEL IDs, source, redaction hook. <!-- PR #160 review: renamed from `zapcore/` to avoid collision with upstream `go.uber.org/zap/zapcore`, which would force every importer into aliased imports (`zapcore "github.com/mkhomutov/…/zapcore"`). --> |
 | Go orchestrator | `internal/executor/dispatch.go`, `internal/executor/chat.go` | Inject correlation IDs into outgoing gRPC metadata |
 | Go orchestrator | `cmd/orchestrator/main.go` | Wire encoder wrapper, register `LogService` server, register redactor (no-op) |
 | Go orchestrator | `internal/server/logs_handler.go` (new), `internal/server/logs_stream_handler.go` (new), `internal/server/server.go` | Implement endpoints; remove `handleGetLogs` from `stub_handlers.go` |
@@ -438,6 +472,12 @@ The following decisions are part of the spec; they are recorded here for traceab
 1. Confirm v0.2.3 as the target milestone (this RFC adds v0.2.3 to the ROADMAP version map alongside RFC 0019).
 2. Sign off on the schema in [Section B](#b-common-log-schema) as the cross-language contract (including `schema_version: "1"` and the structured `service.*` group).
 3. Sign off on `LogService` as a new public proto surface in `proto/log_service.proto`.
+
+**Cross-RFC sequencing (added per PR #160 review).** Coordinated with [RFC 0019 Decision / Next Steps](0019-opentelemetry-completion.md#decision--next-steps):
+
+1. **RFC 0019 Phase 1 lands before any new package under `internal/observability/` from this RFC.** RFC 0019 Phase 1 performs the `internal/telemetry/` → `internal/observability/` rename; landing this RFC's new packages first would force the rename PR into a rename-plus-merge-conflict-resolution PR.
+2. **RFC 0019 Phase 1 lands before this RFC's Phase 3.** Phase 3 already declares the dependency; this restates it for the joint PR plan.
+3. **This RFC's Phase 1 (Python structlog + redaction hook surface) lands before RFC 0019 Phase 2.** RFC 0019 Phase 2 spans need the redaction hook to exist for opt-in tool-payload capture, and the log↔trace enricher RFC 0019 cross-references is added in this RFC's Phase 3.
 
 **Once accepted:**
 

--- a/docs/rfcs/0019-opentelemetry-completion.md
+++ b/docs/rfcs/0019-opentelemetry-completion.md
@@ -6,7 +6,7 @@
 **Date**: 2026-04-21 (rev 2026-04-22 — future-focused expansion; rev 2026-04-22b — apply PR #160 review)
 **Target**: v0.2.3
 **Depends on**: none
-**Pairs with**: RFC 0018 (Structured Logging Framework — both ship together in v0.2.3 with shared schema, redaction hook, and OTLP export; see [Relationship to RFC 0018](#relationship-to-rfc-0018))
+**Pairs with**: RFC 0018 (Structured Logging Framework — both ship together in v0.2.3 with shared schema, redaction hook, and a shared `internal/observability/` namespace; transport is split per signal — see [Relationship to RFC 0018](#relationship-to-rfc-0018))
 
 <!--
 Review note (PR #160): the `Schema version` field was removed from the frontmatter
@@ -68,16 +68,16 @@ in the PR description before merge — that is a metadata fix, not an RFC change
 
 | Concern | Single source of truth |
 |---------|------------------------|
-| Trace + metric export | OTLP HTTP (port 4318) — this RFC |
+| Trace + metric export | OTLP HTTP (port 4318) — RFC 0019 |
 | Log ingest (agent → orchestrator) | `LogService` streaming gRPC over the existing agent gRPC channel — RFC 0018 Section E |
 | Log export to external backends (optional) | OTLP HTTP via the same Collector — operator-side, out of scope for v0.2.3 |
-| Schema version field | `schema_version: 1` (logs); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics) |
+| Schema version field | `schema_version: 1` (logs, RFC 0018); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics, RFC 0019) |
 | Correlation IDs | `execution_id`, `step_id`, `agent_id`, `workflow_id`, `trace_id`, `span_id` |
 | Cross-process propagation | W3C TraceContext + W3C Baggage |
 | Redaction hook | Shared interface, used by both log records and span attributes |
-| Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree) |
+| Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree; the rename happens in RFC 0019 Phase 1) |
 | Sampling discipline | Parent-based head sampling + Collector tail sampling |
-| Log↔trace enricher ownership | RFC 0018 (owns the structlog chain and zap encoder where the enrichment lives); this RFC only requires that the OTEL context is established before the enricher PR lands |
+| Log↔trace enricher ownership | RFC 0018 (owns the structlog chain and zap encoder where the enrichment lives); RFC 0019 only requires that the OTEL context is established before the enricher PR lands |
 
 A merger of the two RFCs into one "Observability Foundation" document was considered and resolved as item 6 in [Resolved Decisions](#resolved-decisions): **keep split, ship as one delivery**. Both RFCs cross-reference this contract.
 
@@ -409,7 +409,6 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8.
 | Go orchestrator | `go.mod`, `go.sum` | Add `otelgrpc`, `otelhttp` |
 | Go orchestrator | `internal/observability/metrics.go` | Add (new module) |
 | Go orchestrator | `cmd/orchestrator/main.go` | Inject `otelgrpc` client handler into executor dial options; wrap HTTP handler with `otelhttp`; init metrics |
-| Go orchestrator | `internal/executor/dispatch.go`, `internal/executor/chat.go` | (No code change required — dial options injected from caller) |
 | Tests | `agents/tests/conftest.py` | Add `InMemorySpanExporter` and `InMemoryMetricReader` fixtures |
 | Tests | `agents/tests/test_observability_tracing.py` (new) | Init + propagation + baggage unit tests |
 | Tests | `agents/tests/test_observability_metrics.py` (new) | Instrument inventory + exemplar emission tests |
@@ -418,7 +417,7 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8.
 | Tests | `tests/integration/test_observability_e2e.py` (new) | E2E shape test: trace tree + correlated logs + metric exemplars against the local Collector + Jaeger + Prometheus stack |
 | Deploy | `config/observability/otel-collector.yaml` (new) | Reference Collector config with `tail_sampling` processor (path chosen per PR #160 review to align with `config/` convention) |
 | Deploy | `docker-compose.yaml` | Add Collector, Prometheus, Loki services; route OTLP through Collector |
-| Docs | `docs/observability.md` | Append span-conventions, metrics inventory, sampling/Collector, correlated-debugging, and Jaeger/Prometheus usage sections (file created by RFC 0018) |
+| Docs | `docs/observability.md` | Append span-conventions, metrics inventory, sampling/Collector, correlated-debugging, and Jaeger/Prometheus usage sections (file created by RFC 0018 Phase 1; ordering guaranteed by Cross-RFC sequencing constraint #3 in [Decision / Next Steps](#decision--next-steps)) |
 | Docs | [README.md](../../README.md) | Update OTEL paragraph to cover logs + traces + metrics |
 | Docs | [CHANGELOG.md](../../CHANGELOG.md) | Add an entry under v0.2.3 noting the Python OTLP exporter package swap (`opentelemetry-exporter-otlp-proto-grpc` → `opentelemetry-exporter-otlp-proto-http`); operator-visible because anyone running a custom OTEL collector on the gRPC port (`:4317`) will need to switch to the HTTP port (`:4318`). Also note the new Collector + Prometheus + Loki services in `docker-compose.yaml`. |
 | Docs | [ROADMAP.md](../../ROADMAP.md) | Group RFC 0018 + RFC 0019 as the v0.2.3 "Observability Foundation" delivery |
@@ -472,6 +471,7 @@ None remaining. All prior open questions are resolved in [Resolved Decisions](#r
 1. Confirm v0.2.3 as the target milestone (this RFC pairs with RFC 0018 on the same release).
 2. Sign off on the resolved decisions in [Resolved Decisions](#resolved-decisions) (interceptors, dual `agent.id` + `service.instance.id` with Gen-AI conventions, opt-in payload capture through redaction hook, head + tail sampling, pinned gRPC client sites, keep-split-ship-as-one-delivery).
 3. Sign off on the span-naming and Persatrix attribute conventions in [Section E](#e-span-naming-and-attribute-conventions), the metrics inventory in [Section F](#f-metrics), and the log↔trace correlation contract in [Section G](#g-logtrace-correlation) as the cross-codebase contract.
+4. Acknowledge the joint-PR-plan discipline: `docs/rfcs/0018-pr-plan.md` and `docs/rfcs/0019-pr-plan.md` MUST be authored as a coordinated pair (not independently), with the three Cross-RFC sequencing constraints below copied verbatim into both plans so the ordering is not re-derived inconsistently.
 
 **Cross-RFC sequencing (added per PR #160 review).** The two RFCs share namespace and code paths, so PR landing order matters:
 

--- a/docs/rfcs/0019-opentelemetry-completion.md
+++ b/docs/rfcs/0019-opentelemetry-completion.md
@@ -1,12 +1,13 @@
-# RFC 0019 — OpenTelemetry Completion
+# RFC 0019 — OpenTelemetry Completion (Traces, Metrics, Correlation)
 
 **Type**: architecture
 **Status**: 📋 Proposed
 **Author**: Maksim Khomutov
-**Date**: 2026-04-21
+**Date**: 2026-04-21 (rev 2026-04-22 — future-focused expansion)
 **Target**: v0.2.3
-**Depends on**: none (paired with RFC 0018)
-**Feeds into**: log↔trace correlation follow-up (post-v0.2.3)
+**Schema version**: 1
+**Depends on**: none
+**Pairs with**: RFC 0018 (Structured Logging Framework — both ship together in v0.2.3 with shared schema, redaction hook, and OTLP transport; see [Relationship to RFC 0018](#relationship-to-rfc-0018))
 
 ---
 
@@ -22,10 +23,15 @@
   - [C. gRPC Trace Context Propagation](#c-grpc-trace-context-propagation)
   - [D. Semantic Spans on the Python Side](#d-semantic-spans-on-the-python-side)
   - [E. Span Naming and Attribute Conventions](#e-span-naming-and-attribute-conventions)
+  - [F. Metrics](#f-metrics)
+  - [G. Log↔Trace Correlation](#g-logtrace-correlation)
+  - [H. Sampling, Back-Pressure, and the Collector Pipeline](#h-sampling-back-pressure-and-the-collector-pipeline)
+  - [I. Span Links and A2A Causality](#i-span-links-and-a2a-causality)
 - [Security Considerations](#security-considerations)
 - [Phased Implementation Plan](#phased-implementation-plan)
 - [Files Touched (Estimated)](#files-touched-estimated)
 - [Test Strategy](#test-strategy)
+- [Resolved Decisions](#resolved-decisions)
 - [Open Questions](#open-questions)
 - [Decision / Next Steps](#decision--next-steps)
 - [Related Documentation](#related-documentation)
@@ -34,7 +40,25 @@
 
 ## Summary
 
-This RFC closes the cross-language gap in Persatrix's OpenTelemetry implementation: traces start in the Go orchestrator, cross the gRPC boundary into Python agents, and continue as child spans for memory operations, persona event dispatch, LLM calls, and tool executions. Coverage gaps that are not on the cross-language critical path (full automatic HTTP instrumentation, REST endpoint span uniformity, YAML observability config) are explicitly deferred. The result: an end-to-end trace tree from `POST /api/v1/workflows` to LLM call appears in Jaeger; the README's OTEL story stops being a half-truth.
+This RFC closes the cross-language gap in Persatrix's OpenTelemetry implementation and lands the **observability foundation** for the project's full lifetime: traces start in the Go orchestrator, cross the gRPC boundary into Python agents (with W3C TraceContext **and** W3C Baggage), and continue as child spans for memory operations, persona event dispatch, LLM calls (annotated with the OTEL Gen-AI semantic conventions), and tool executions. **Metrics** (counters, histograms, gauges) ship on the same OTLP transport. **Log↔trace correlation** (`trace_id` / `span_id` injected into every structured log line from RFC 0018) lands in the same release rather than as a follow-up. **Span Links** capture A2A and sub-agent causality so v0.3 mesh traces are not a forest of disconnected trees. A documented **OTEL Collector tail-sampling pipeline** is the canonical operator deployment from day 1.
+
+The scope is intentionally larger than "traces work end-to-end." The goal is to ship a complete OTLP-native observability surface (logs + traces + metrics, correlated, with a single redaction hook shared with RFC 0018) once, rather than re-litigate naming, sampling, and transport across three or four releases.
+
+### Relationship to RFC 0018
+
+RFC 0018 (Structured Logging) and this RFC are deliberately kept as separate documents for review tractability, but they share a single design contract:
+
+| Concern | Single source of truth |
+|---------|------------------------|
+| Wire transport | OTLP (HTTP, port 4318) |
+| Schema version field | `schema_version: 1` |
+| Correlation IDs | `execution_id`, `step_id`, `agent_id`, `workflow_id`, `trace_id`, `span_id` |
+| Cross-process propagation | W3C TraceContext + W3C Baggage |
+| Redaction hook | Shared interface, used by both log records and span attributes |
+| Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree) |
+| Sampling discipline | Parent-based head sampling + Collector tail sampling |
+
+A merger of the two RFCs into one "Observability Foundation" document is recorded as [Open Question 6](#open-questions). Pending that decision, both RFCs cross-reference this contract.
 
 ## Motivation
 
@@ -52,25 +76,29 @@ What happens if we do nothing: every multi-agent debugging story remains a manua
 
 ## Goals
 
-1. Python agent runtime initialises OTEL on startup, mirroring the Go orchestrator's pattern (OTLP exporter, same endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT`, resource attributes identifying the agent service).
-2. gRPC requests from orchestrator carry W3C TraceContext into Python agents; agents resume the trace as child spans.
-3. Python agents emit semantic spans for: agent tick cycle, persona event dispatch, memory operations (episodic recall, episodic write, relationship lookup, relationship update), LLM calls (with model, token counts, cache hit/miss attributes), tool executions (with tool name, success/failure, duration).
-4. Span naming convention is documented and applied: `<service>.<component>.<operation>` (e.g., `agent.memory.episodic.query`).
-5. End-to-end verification: a workflow submitted to `POST /api/v1/workflows` produces a single trace tree in Jaeger spanning orchestrator HTTP handler → workflow run → step dispatch → gRPC client span → gRPC server span → tick / event handler → memory query → LLM call.
-6. The `# TODO: OTEL span creation` in [`agents/tools/registry.py`](../../agents/tools/registry.py) is removed and replaced with a real span.
+1. Python agent runtime initialises OTEL on startup (traces **and** metrics), mirroring the Go orchestrator's pattern (OTLP HTTP exporter, same endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT`, resource attributes identifying the agent service, OTEL Resource detectors for process / host / container / k8s metadata, `schema_url` set to a versioned Persatrix URL).
+2. gRPC requests from orchestrator carry W3C TraceContext **and** W3C Baggage into Python agents; agents resume the trace as child spans and inherit baggage (`persatrix.execution_id`, `persatrix.step_id`, `persatrix.workflow_id`, plus future `persatrix.tenant_id` / `persatrix.organization_id` slots).
+3. Python agents emit semantic spans for: agent tick cycle, persona event dispatch (with sub-millisecond phases as **span events**, not separate spans), memory operations (episodic recall, episodic write, relationship lookup, relationship update), LLM calls (using **OTEL Gen-AI semantic conventions** — `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, `gen_ai.operation.name`), tool executions (with tool name, success/failure, duration, and optional argument capture routed through the RFC 0018 redaction hook).
+4. Span naming convention is documented and applied: `<service>.<component>.<operation>` (e.g., `agent.memory.episodic.query`). Persatrix-specific attributes use the reserved `persatrix.*` prefix; Gen-AI attributes use the upstream `gen_ai.*` prefix verbatim.
+5. **Span Links** capture A2A causality (event → triggered tick, parent agent → spawned sub-agent, dispatched message → handler).
+6. **Metrics** ship on the same OTLP exporter: counters (`agent.tool.invocations`, `agent.llm.calls`, `agent.llm.tokens`, `agent.event.dispatched`), histograms (`agent.llm.duration`, `agent.tool.duration`, `agent.persona.tick.interval`), gauges (`agent.active`, `workflow.active`). Histograms emit **exemplars** linking to trace samples.
+7. **Log↔trace correlation lands in v0.2.3, not as a follow-up.** Every structured log line from RFC 0018 emitted inside an active span carries `trace_id` and `span_id`; the Python logging interceptor and the Go zap field enricher both pull from the active OTEL context.
+8. **Tail sampling pipeline.** A documented OTEL Collector configuration ships under `docker-compose.yaml` (or a sibling override) implementing rules: keep all error spans, keep slow LLM calls (>p95), sample 1% of healthy autonomous tick traces.
+9. End-to-end verification: a workflow submitted to `POST /api/v1/workflows` produces a single trace tree in Jaeger spanning orchestrator HTTP handler → workflow run → step dispatch → gRPC client span → gRPC server span → tick / event handler → memory query → LLM call, with correlated log lines queryable by `trace_id` and a metrics dashboard showing the same execution.
+10. The `# TODO: OTEL span creation` in [`agents/tools/registry.py`](../../agents/tools/registry.py) is removed and replaced with a real span.
+11. A reusable `InMemorySpanExporter` / `InMemoryMetricReader` `pytest` fixture lives in `agents/tests/conftest.py` so every future agent feature is span- and metric-testable without docker-compose.
 
 ## Non-Goals
 
-- **Automatic HTTP / gRPC instrumentation via `otelhttp` and `otelgrpc` middleware.** Manual instrumentation already covers the critical paths. Adding the ecosystem auto-instrumentation removes a polish gap (some handlers untraced) without adding new capability. Deferred to a follow-up.
-- **Span coverage on every REST endpoint.** Health, version, list-style endpoints can stay uninstrumented for v0.2.3.
-- **YAML-based OTEL configuration.** `config/environments/development.yaml` has an `observability` section that isn't wired in. Env vars are adequate for v0.2.3; YAML wiring is a polish task.
-- **Log↔trace correlation fields (`trace_id` / `span_id` on log lines).** Depends on RFC 0018 landing structured logging first; both RFCs target v0.2.3 but the correlation work is a follow-up after both ship and is intentionally not on the v0.2.3 critical path.
-- **Metrics (counters, histograms, gauges).** Separate RFC if/when needed.
-- **Custom OTEL exporters beyond OTLP.**
-- **Production observability stack beyond Jaeger for local dev.**
-- **Performance benchmarking of OTEL overhead.**
+- **Span coverage on every REST endpoint.** Health, version, list-style endpoints can stay uninstrumented for v0.2.3. (`otelhttp` middleware on the public REST handler **is** in scope as a one-line install — see [Section F](#f-metrics).)
+- **YAML-based OTEL configuration.** `config/environments/development.yaml` has an `observability` section that isn't wired in. Env vars remain primary for v0.2.3; YAML wiring is a polish task tracked separately.
+- **Custom OTEL exporters beyond OTLP.** OTLP HTTP is the only supported transport.
+- **Production observability stack beyond Jaeger + Prometheus + Loki for local dev.** A reference Collector pipeline is documented; choosing the operator's production backend is out of scope.
+- **Performance benchmarking of OTEL overhead.** Recommended `BatchSpanProcessor` / `BatchLogRecordProcessor` settings are documented; formal benchmarking deferred.
 - **Trace-based alerting.**
-- **Custom OTEL processors or samplers.** The orchestrator's existing sampler config applies; agents inherit the same sampling discipline (see [Open Question 4](#open-questions)).
+- **Profiling signal (4th OTEL signal).** Namespace is left unblocked (`agents/observability/` and `internal/observability/` can host a future `profiling.py`) but no implementation in v0.2.3.
+- **Tool/function-call OTEL semantic conventions.** Adopt them when the upstream spec stabilises; current attribute set is forward-compatible (flat `tool.*` keys easily aliased).
+- **Multi-tenant attribute enforcement.** `persatrix.tenant_id` / `persatrix.organization_id` baggage slots are defined, but enforcement (RFC 0009) is out of scope here.
 
 ---
 
@@ -102,7 +130,15 @@ A new module `agents/observability/tracing.py` mirrors `internal/telemetry/telem
 
 **Exporter protocol decision.** The Go side uses OTLP-HTTP. Python deps currently include `opentelemetry-exporter-otlp-proto-grpc` (gRPC variant). For parity with the Go endpoint and to keep `:4318` as the single OTLP target, this RFC switches Python to `opentelemetry-exporter-otlp-proto-http`. Dependency change captured in [Files Touched](#files-touched-estimated).
 
-`agents/server.py` calls `init_tracing(agent_id)` early in startup, before the gRPC server is constructed, and registers `shutdown()` with the existing graceful-shutdown sequence.
+**Resource attributes.** The `Resource` carries:
+
+- `service.name=agent-<id>`, `service.version`, `service.instance.id`
+- `schema_url="https://persatrix.dev/schemas/observability/1.0.0"` (versioned, lets future consumers do schema-aware migrations)
+- Auto-detected attributes via OTEL Resource detectors: `ProcessResourceDetector`, `OTELResourceDetector` (env-var bridge), and — when running under containers/k8s — `ContainerResourceDetector` and `OTResourceDetector` for k8s metadata. One-line installs each; trivial now, painful to retrofit when Persatrix runs under k8s.
+
+**BatchSpanProcessor tuning.** Defaults (queue 2048, schedule 5s, max export batch 512) are wrong for autonomous tick loops. The RFC ships explicit values (`max_queue_size=8192`, `schedule_delay_millis=2000`, `max_export_batch_size=1024`) and configures the processor to **drop on overflow rather than block**. A `agent.observability.spans.dropped` counter records the drop rate so operators see exporter back-pressure on a dashboard.
+
+`agents/server.py` calls `init_tracing(agent_id)` and `init_metrics(agent_id)` early in startup, before the gRPC server is constructed, and registers `shutdown()` with the existing graceful-shutdown sequence.
 
 ### C. gRPC Trace Context Propagation
 
@@ -128,7 +164,9 @@ GrpcInstrumentorServer().instrument()
 
 Once instrumented, every incoming RPC handler runs inside an OTEL context with the parent span from the orchestrator.
 
-**Note on overlap with RFC 0018.** RFC 0018 installs a Python gRPC server interceptor for logging context (`execution_id` / `step_id` / `agent_id`). This RFC installs `GrpcInstrumentorServer` for OTEL. Both interceptors coexist; both should be initialised in `agents/server.py` and the order is documented (OTEL first so the logging interceptor can see `trace_id` once log↔trace correlation is implemented as a follow-up).
+**W3C Baggage propagation.** In addition to TraceContext, the global propagator is configured as a `CompositePropagator([TraceContextTextMapPropagator(), W3CBaggagePropagator()])` on both sides. The Go orchestrator sets baggage entries (`persatrix.execution_id`, `persatrix.step_id`, `persatrix.workflow_id`) before the gRPC client call; Python agents read them via `baggage.get_all()` and use them to enrich both spans and structured log records (RFC 0018) without manual context plumbing. The same mechanism carries forward to v0.3 mesh and A2A calls — sub-agent spawns and downstream RPCs auto-tag every signal with the originating workflow context.
+
+**Note on overlap with RFC 0018.** RFC 0018 installs a Python gRPC server interceptor for logging context. This RFC installs `GrpcInstrumentorServer` for OTEL. Both interceptors coexist; OTEL is initialised first so the logging interceptor sees `trace_id` / `span_id` from the active context (see [Section G](#g-logtrace-correlation)).
 
 ### D. Semantic Spans on the Python Side
 
@@ -137,17 +175,19 @@ New spans, organised by component:
 | Site | Span name | Key attributes |
 |------|-----------|----------------|
 | `agents/persona_runtime/` tick loop | `agent.persona.tick` | `agent.id`, `tick.reason` |
-| `agents/persona_behavior.py` event dispatch | `agent.persona.event` | `agent.id`, `event.type`, `event.id` |
+| `agents/persona_behavior.py` event dispatch | `agent.persona.event` | `agent.id`, `event.type`, `event.id` — sub-millisecond phases (`received` → `queued` → `handled` → `completed`) emitted as **span events** on this single span, not nested spans |
 | `agents/memory/episodic.py` recall / recall_notes | `agent.memory.episodic.query` | `agent.id`, `query.kind` (recall \| recall_notes), `result.count`, `min_score` |
 | `agents/memory/episodic.py` record | `agent.memory.episodic.write` | `agent.id`, `episode.kind` |
 | `agents/memory/relationship.py` lookups | `agent.memory.relationship.lookup` | `agent.id`, `participant.id` |
 | `agents/memory/relationship.py` updates | `agent.memory.relationship.update` | `agent.id`, `participant.id`, `delta.kind` |
-| `agents/llm_client.py` LLM call | `agent.llm.call` | `agent.id`, `llm.model`, `llm.tokens.prompt`, `llm.tokens.completion`, `llm.cache.hit` |
-| `agents/tools/registry.py` execute | `agent.tool.execute` | `agent.id`, `tool.name`, `tool.success`, `tool.duration_ms` |
+| `agents/llm_client.py` LLM call | `agent.llm.call` | OTEL Gen-AI semantic conventions: `gen_ai.system` (e.g., `openai`, `anthropic`), `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`, `gen_ai.operation.name` (e.g., `chat`, `text_completion`); plus Persatrix-specific `agent.id`, `persatrix.llm.cache.hit`. Vendor observability backends (Jaeger, Tempo, Honeycomb, Datadog) already render Gen-AI views keyed on these. |
+| `agents/tools/registry.py` execute | `agent.tool.execute` | `agent.id`, `tool.name`, `tool.success`, `tool.duration_ms`; optional `tool.arguments` / `tool.result` controlled by `PERSATRIX_TRACE_TOOL_PAYLOADS=none\|metadata\|full` and **routed through the RFC 0018 redaction hook** so traces and logs share one secrets-policy code path |
 
 The `# TODO: OTEL span creation` at [`agents/tools/registry.py:138`](../../agents/tools/registry.py) is replaced by the `agent.tool.execute` span in this RFC's scope.
 
 *Semantics of `tool.success` (clarified per PR #142 review).* `tool.success=true` if and only if the wrapper returned a `ToolResult` with `success=True`. Both `ToolResult(success=False)` (controlled tool failure) and an unhandled exception escaping the tool body produce `tool.success=false`; in the exception case, the span additionally carries `record_exception(exc)` and `set_status(Status(StatusCode.ERROR))`. This collapses the two failure modes into one boolean for dashboards while preserving the distinction in the recorded exception event.
+
+*Forward-compatibility note for tool spans.* When the upstream OTEL spec stabilises tool/function-call semantic conventions (currently in flight as part of Gen-AI), the `tool.*` attribute set will be aliased to the upstream namespace in a follow-up. The flat keying chosen here makes the alias mechanical (a `RENAME` view in the Collector or a one-shot rename in instrumentation).
 
 Spans use the `tracer = trace.get_tracer(__name__)` pattern; instrumentation uses `with tracer.start_as_current_span(name, attributes={...}) as span:`. Errors are recorded via `span.record_exception(exc)` and `span.set_status(Status(StatusCode.ERROR))`.
 
@@ -169,62 +209,154 @@ Attribute keys: snake_case, dot-separated for namespacing. Reserved keys mirror 
 | `persatrix.step_id` | string | Set on spans inside a workflow step |
 | `persatrix.workflow_id` | string | Workflow definition ID |
 
-The convention is documented in `docs/observability.md` (created by RFC 0018; this RFC adds a span-conventions section).
+The convention is documented in `docs/observability.md` (created by RFC 0018; this RFC adds a span-conventions section, a metrics section, and a Collector pipeline section).
+
+### F. Metrics
+
+Metrics ship on the same OTLP HTTP exporter as traces. A new module `agents/observability/metrics.py` mirrors the tracing module: `init_metrics(agent_id) -> Meter`, `shutdown()`, same Resource (so traces and metrics share `service.instance.id`).
+
+**Instrument inventory.**
+
+| Instrument | Type | Unit | Attributes |
+|------------|------|------|------------|
+| `agent.tool.invocations` | Counter | `{invocation}` | `agent.id`, `tool.name`, `tool.success` |
+| `agent.tool.duration` | Histogram | `ms` | `agent.id`, `tool.name`, `tool.success` |
+| `agent.llm.calls` | Counter | `{call}` | `agent.id`, `gen_ai.system`, `gen_ai.request.model`, `persatrix.llm.cache.hit` |
+| `agent.llm.tokens` | Counter | `{token}` | `agent.id`, `gen_ai.request.model`, `gen_ai.token.type` (`input` \| `output`) |
+| `agent.llm.duration` | Histogram | `ms` | `agent.id`, `gen_ai.request.model` |
+| `agent.event.dispatched` | Counter | `{event}` | `agent.id`, `event.type` |
+| `agent.persona.tick.interval` | Histogram | `ms` | `agent.id` |
+| `agent.active` | UpDownCounter | `{agent}` | (resource-only) |
+| `workflow.active` | UpDownCounter | `{workflow}` | (orchestrator side; resource-only) |
+| `agent.observability.spans.dropped` | Counter | `{span}` | `agent.id`, `reason` (`queue_full` \| `export_error`) |
+| `agent.observability.logs.dropped` | Counter | `{record}` | `agent.id`, `reason` |
+
+**Exemplars.** Histogram instruments emit exemplars by default (OTEL SDK feature); each histogram bucket sample carries the `trace_id` / `span_id` of the call that produced it. A p99 LLM-latency spike on the dashboard becomes one click to the actual slow trace in Jaeger.
+
+**Go-side metrics.** The orchestrator gains `internal/observability/metrics.go` with: `workflow.submitted`, `workflow.completed`, `workflow.duration`, `workflow.steps.dispatched`, `workflow.active`. Same OTLP exporter, same Resource conventions.
+
+**`otelhttp` on the REST surface.** The orchestrator's main HTTP handler is wrapped with `otelhttp.NewHandler` so route-level latency histograms (`http.server.request.duration`) come for free. Per-handler manual spans remain on the workflow-submit and chat paths; trivial endpoints (health, version) get the `otelhttp` span only.
+
+### G. Log↔Trace Correlation
+
+**In scope for v0.2.3.** Both interceptors land in the same release; the marginal cost over RFC 0018's logging interceptor is one field-enrichment line. Without correlation, RFC 0018's structured logs and this RFC's traces are two parallel, manually-correlated streams — defeating the point of shipping them together.
+
+**Mechanism.**
+
+- **Python.** RFC 0018's logging interceptor (and the standalone `agents/observability/logging.py` setup) reads the active span context via `trace.get_current_span().get_span_context()` and adds `trace_id` (hex) and `span_id` (hex) to every log record's structured attributes when valid.
+- **Go.** The orchestrator's zap field enricher (RFC 0018) pulls the span context from the request context (`trace.SpanFromContext(ctx).SpanContext()`) and adds the same two fields.
+- **Baggage enrichment.** The same enrichers also copy known baggage entries (`persatrix.execution_id`, `persatrix.step_id`, `persatrix.workflow_id`) onto log records — meaning a log line emitted three calls deep in a sub-agent automatically carries the originating workflow's IDs without any caller doing manual context plumbing.
+
+The `docs/observability.md` doc gains a "correlated debugging" walkthrough: from a Jaeger trace ID → `persatrix logs --trace <trace_id>` → the structured log lines for that trace, ordered by timestamp, across all participating processes.
+
+### H. Sampling, Back-Pressure, and the Collector Pipeline
+
+**Head sampling: parent-based.** The Python SDK uses `ParentBased(TraceIdRatioBased(<rate>))` matching the Go orchestrator's existing sampler. Default sampling rate is `1.0` for v0.2.3 (sample everything; tail sampler downstream decides what to keep).
+
+**Tail sampling: OTEL Collector.** Autonomous tick loops in v0.3 mesh will dwarf workflow-driven traces. Cheap to set up the Collector pipeline now; painful to retrofit during a v0.3 incident. A reference Collector configuration ships under `deploy/observability/otel-collector.yaml` and is referenced from `docker-compose.yaml`:
+
+```yaml
+processors:
+  tail_sampling:
+    decision_wait: 10s
+    num_traces: 100000
+    expected_new_traces_per_sec: 1000
+    policies:
+      - name: errors
+        type: status_code
+        status_code: { status_codes: [ERROR] }
+      - name: slow-llm
+        type: latency
+        latency: { threshold_ms: 5000 }
+      - name: workflow-traces
+        type: string_attribute
+        string_attribute: { key: persatrix.workflow_id, values: [".+"], enabled_regex_matching: true, invert_match: false }
+      - name: healthy-tick-sample
+        type: probabilistic
+        probabilistic: { sampling_percentage: 1 }
+```
+
+**Back-pressure.** Both `BatchSpanProcessor` and `BatchLogRecordProcessor` are configured to drop on overflow rather than block (queues sized in [Section B](#b-python-otel-initialisation) for spans; mirrored for logs in RFC 0018). Drop counters (`agent.observability.spans.dropped`, `agent.observability.logs.dropped`) are emitted as metrics so operators see exporter or collector unavailability on a dashboard immediately.
+
+### I. Span Links and A2A Causality
+
+When one span causes work in another span tree (rather than being a synchronous parent), OTEL `Link`s record the relationship without forcing a parent/child:
+
+| Causality | Link source | Link target |
+|-----------|-------------|-------------|
+| Persona event triggers a tick | the `agent.persona.tick` span | the `agent.persona.event` span that scheduled it |
+| Parent agent spawns sub-agent | the sub-agent's root span | the parent's `agent.subagent.spawn` span |
+| Bridged message crosses a channel | the receiving handler span | the producing dispatch span |
+| Mesh A2A call (v0.3) | the receiving node's span | the originating node's span |
+
+Without links, v0.3 mesh traces will be a forest of disconnected trees. Adding the Link API call when an event/spawn/dispatch is enqueued is one line and forward-compatible with v0.3.
 
 ---
 
 ## Security Considerations
 
-- **Trace data may include sensitive information.** Span attributes can leak prompts, tool inputs, or user content if instrumentation copies payloads verbatim. This RFC's attribute schema deliberately avoids payload-bearing fields (`llm.tokens.prompt` is a count, not the prompt text). Tool execution span captures `tool.name` and duration, not arguments.
-- **OTLP exporter endpoint is an outbound network call.** Default `http://localhost:4318` is local Jaeger. Operators pointing to remote collectors need to apply their own auth; OTLP collector security is operator responsibility, consistent with how Go currently handles it.
-- **No new attack surfaces on the orchestrator.** The new `otelgrpc` client interceptor is outbound-only.
+- **Trace data may include sensitive information.** Span attributes can leak prompts, tool inputs, or user content if instrumentation copies payloads verbatim. The default attribute schema avoids payload-bearing fields (`gen_ai.usage.input_tokens` is a count, not the prompt text). The opt-in `PERSATRIX_TRACE_TOOL_PAYLOADS=full` mode routes tool arguments and results through the **shared RFC 0018 redaction hook** — there is one secrets-policy code path covering both logs and traces.
+- **Baggage entries are propagated downstream.** Baggage values appear on every span and log line in the trace tree, including across A2A boundaries. The schema deliberately reserves `persatrix.*` for non-sensitive correlation IDs; user content must never be placed in baggage. This is documented in `docs/observability.md`.
+- **OTLP exporter endpoint is an outbound network call.** Default `http://localhost:4318` is local Collector / Jaeger. Operators pointing to remote collectors need to apply their own auth; OTLP collector security is operator responsibility, consistent with how Go currently handles it.
+- **No new attack surfaces on the orchestrator.** The new `otelgrpc` client interceptor and `otelhttp` handler wrap are non-listening / outbound-only respectively.
 - **Python `GrpcInstrumentorServer` is server-side only and inert without an inbound RPC.** No new listening sockets.
-- **Ring buffer (RFC 0018) does not interact with span data.** Logs and traces remain separate streams in v0.2.3; correlation is a future follow-up.
+- **Metrics carry attribute cardinality risk.** Instruments are deliberately bounded — `tool.name`, `gen_ai.request.model`, `event.type` are low-cardinality enumerations. No instrument carries a per-execution ID as a metric attribute (that is what traces and logs are for).
 
 ---
 
 ## Phased Implementation Plan
 
-### Phase 1: Python OTEL Init + gRPC Context Propagation
+### Phase 1: Python OTEL Init + gRPC Context Propagation + Baggage
 
-**Summary.** Get traces crossing the language boundary. Minimum viable cross-process tracing.
+**Summary.** Get traces and baggage crossing the language boundary. Minimum viable cross-process tracing.
 
 **Deliverables.**
 
-1. `agents/observability/tracing.py` (new) implementing `init_tracing` / `shutdown`.
+1. `agents/observability/tracing.py` (new) implementing `init_tracing` / `shutdown` (with Resource detectors, `schema_url`, tuned `BatchSpanProcessor`).
 2. Switch Python OTLP exporter dependency from `opentelemetry-exporter-otlp-proto-grpc` to `opentelemetry-exporter-otlp-proto-http`.
-3. Add `opentelemetry-instrumentation-grpc` to `agents/pyproject.toml`.
-4. Add `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` to `go.mod`.
-5. Wire `otelgrpc` client handler in `internal/executor/`.
-6. `agents/server.py` initialises tracing and `GrpcInstrumentorServer` before serving.
-7. Integration test: send a request with a synthetic parent span context; assert agent-side span has matching trace ID.
+3. Add `opentelemetry-instrumentation-grpc` and `opentelemetry-instrumentation-system-metrics` to `agents/pyproject.toml`.
+4. Add `go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc` and `go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp` to `go.mod`.
+5. Wire `otelgrpc` client handler into the executor's dial options from `cmd/orchestrator/main.go` (covers both pinned `grpc.NewClient` sites).
+6. Wire `otelhttp.NewHandler` around the orchestrator's main HTTP handler.
+7. Configure `CompositePropagator(TraceContext + Baggage)` on both sides.
+8. `agents/server.py` initialises tracing and `GrpcInstrumentorServer` before serving.
+9. `agents/tests/conftest.py` ships an `InMemorySpanExporter` fixture.
+10. Integration test: send a request with a synthetic parent span context **and baggage**; assert agent-side span has matching trace ID and inherits baggage.
 
 **Dependencies.** None.
 
-### Phase 2: Semantic Spans on the Python Side
+### Phase 2: Semantic Spans + Span Links + Log↔Trace Correlation
 
-**Summary.** Add the spans listed in [Section D](#d-semantic-spans-on-the-python-side).
+**Summary.** Add the spans listed in [Section D](#d-semantic-spans-on-the-python-side), the Span Links from [Section I](#i-span-links-and-a2a-causality), and the log↔trace enricher from [Section G](#g-logtrace-correlation).
 
 **Deliverables.**
 
 1. Tick-loop span in `agents/persona_runtime/`.
-2. Event-dispatch span in `agents/persona_behavior.py`.
+2. Event-dispatch span in `agents/persona_behavior.py` with sub-millisecond phases as **span events** (not nested spans).
 3. Memory spans in `agents/memory/episodic.py` and `agents/memory/relationship.py`.
-4. LLM-call span in `agents/llm_client.py` with token-count attributes.
-5. Tool-execute span in `agents/tools/registry.py`; remove the TODO at line 138.
-6. Span-conventions section appended to `docs/observability.md`.
+4. LLM-call span in `agents/llm_client.py` using OTEL Gen-AI semantic conventions.
+5. Tool-execute span in `agents/tools/registry.py`; remove the TODO at line 138; opt-in payload capture via `PERSATRIX_TRACE_TOOL_PAYLOADS` routed through the RFC 0018 redaction hook.
+6. Span Links wired at: persona event → triggered tick, parent agent → spawned sub-agent, bridged-message dispatch → receiving handler.
+7. Log↔trace enricher: Python logging interceptor and Go zap field enricher both pull `trace_id` / `span_id` (and known baggage entries) from the active context and add them to every log record.
+8. Span-conventions and "correlated debugging" walkthrough sections appended to `docs/observability.md`.
 
-**Dependencies.** Phase 1.
+**Dependencies.** Phase 1; coordinated with RFC 0018 logging interceptor landing.
 
-### Phase 3: End-to-End Verification + Documentation
+### Phase 3: Metrics + Collector Pipeline + End-to-End Verification
 
-**Summary.** Prove the trace tree works; document the operator workflow.
+**Summary.** Land metrics on the same OTLP exporter, ship the documented Collector tail-sampling pipeline, and prove the trace + log + metric trio works end-to-end.
 
 **Deliverables.**
 
-1. E2E test: submit a workflow, query the local Jaeger API for the resulting trace, assert the expected span tree shape.
-2. Operator-facing section in `docs/observability.md` covering "viewing traces in Jaeger".
-3. README OTEL paragraph updated to reflect end-to-end coverage.
+1. `agents/observability/metrics.py` (new) implementing `init_metrics` / `shutdown` with the instrument inventory in [Section F](#f-metrics).
+2. `internal/observability/metrics.go` (new) for orchestrator metrics; instrumentation at workflow submit / complete / step dispatch sites.
+3. Histograms emit exemplars (default OTEL SDK behaviour, verified in test).
+4. `deploy/observability/otel-collector.yaml` (new) with the tail-sampling pipeline from [Section H](#h-sampling-back-pressure-and-the-collector-pipeline).
+5. `docker-compose.yaml` updated to add the Collector service in front of Jaeger; Prometheus added as the metrics backend; Loki added as the logs backend (development only).
+6. `agents/tests/conftest.py` ships an `InMemoryMetricReader` fixture.
+7. E2E test: submit a workflow, query Jaeger for the trace, query Prometheus for the resulting metrics, query Loki (or `persatrix logs --trace <trace_id>`) for the correlated log lines; assert the expected shape across all three signals.
+8. Operator-facing section in `docs/observability.md` covering "viewing traces in Jaeger", "querying metrics in Prometheus", "correlated debugging from a trace ID".
+9. README OTEL paragraph updated to reflect logs + traces + metrics end-to-end coverage.
 
 **Dependencies.** Phase 2.
 
@@ -239,55 +371,71 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8.
 | Component | Files | Change |
 |-----------|-------|--------|
 | Python agents | `agents/observability/tracing.py` | Add (new module) |
-| Python agents | `agents/pyproject.toml` | Swap OTLP exporter to HTTP variant; add `opentelemetry-instrumentation-grpc` |
-| Python agents | `agents/server.py` | Initialise tracing + gRPC instrumentor at startup; register shutdown |
-| Python agents | `agents/persona_runtime/` (tick loop site) | Add `agent.persona.tick` span |
-| Python agents | `agents/persona_behavior.py` | Add `agent.persona.event` span |
+| Python agents | `agents/observability/metrics.py` | Add (new module) |
+| Python agents | `agents/pyproject.toml` | Swap OTLP exporter to HTTP variant; add `opentelemetry-instrumentation-grpc`, `opentelemetry-instrumentation-system-metrics` |
+| Python agents | `agents/server.py` | Initialise tracing, metrics, gRPC instrumentor at startup; register shutdown |
+| Python agents | `agents/persona_runtime/` (tick loop site) | Add `agent.persona.tick` span; record `agent.persona.tick.interval` histogram |
+| Python agents | `agents/persona_behavior.py` | Add `agent.persona.event` span (with phase span events); record `agent.event.dispatched` counter; emit Span Link to triggered tick |
 | Python agents | `agents/memory/episodic.py` | Add query / write spans |
 | Python agents | `agents/memory/relationship.py` | Add lookup / update spans |
-| Python agents | `agents/llm_client.py` | Add `agent.llm.call` span with token attributes |
-| Python agents | `agents/tools/registry.py` | Add `agent.tool.execute` span; remove L138 TODO |
-| Go orchestrator | `go.mod`, `go.sum` | Add `otelgrpc` |
-| Go orchestrator | `internal/executor/` (gRPC client construction site) | Wire `otelgrpc` client handler |
-| Tests | `agents/tests/test_observability_tracing.py` (new) | Init + propagation unit tests |
+| Python agents | `agents/llm_client.py` | Add `agent.llm.call` span with **Gen-AI semantic-convention attributes**; record `agent.llm.calls`, `agent.llm.tokens`, `agent.llm.duration` |
+| Python agents | `agents/tools/registry.py` | Add `agent.tool.execute` span (with optional payload capture via redaction hook); record `agent.tool.invocations`, `agent.tool.duration`; remove L138 TODO |
+| Python agents | `agents/sub_agents/` (spawn site) | Add `agent.subagent.spawn` span; emit Span Link from sub-agent root span back to spawn span |
+| Go orchestrator | `go.mod`, `go.sum` | Add `otelgrpc`, `otelhttp` |
+| Go orchestrator | `internal/observability/metrics.go` | Add (new module) |
+| Go orchestrator | `cmd/orchestrator/main.go` | Inject `otelgrpc` client handler into executor dial options; wrap HTTP handler with `otelhttp`; init metrics |
+| Go orchestrator | `internal/executor/dispatch.go`, `internal/executor/chat.go` | (No code change required — dial options injected from caller) |
+| Tests | `agents/tests/conftest.py` | Add `InMemorySpanExporter` and `InMemoryMetricReader` fixtures |
+| Tests | `agents/tests/test_observability_tracing.py` (new) | Init + propagation + baggage unit tests |
+| Tests | `agents/tests/test_observability_metrics.py` (new) | Instrument inventory + exemplar emission tests |
 | Tests | `tests/integration/test_trace_propagation.py` (new) | Cross-language propagation integration test |
-| Tests | `tests/integration/test_trace_e2e.py` (new) | E2E span-tree shape test against local Jaeger |
-| Docs | `docs/observability.md` | Append span-conventions and Jaeger-usage sections (file created by RFC 0018) |
-| Docs | [README.md](../../README.md) | Update OTEL paragraph |
-| Docs | [CHANGELOG.md](../../CHANGELOG.md) | Add an entry under v0.2.3 noting the Python OTLP exporter package swap (`opentelemetry-exporter-otlp-proto-grpc` → `opentelemetry-exporter-otlp-proto-http`); operator-visible because anyone running a custom OTEL collector on the gRPC port (`:4317`) will need to switch to the HTTP port (`:4318`). |
-| Docs | [ROADMAP.md](../../ROADMAP.md) | Add RFC 0019 to tracker; update v0.2.3 entry |
+| Tests | `tests/integration/test_log_trace_correlation.py` (new) | Asserts every structured log emitted inside a span carries `trace_id` / `span_id` |
+| Tests | `tests/integration/test_observability_e2e.py` (new) | E2E shape test: trace tree + correlated logs + metric exemplars against the local Collector + Jaeger + Prometheus stack |
+| Deploy | `deploy/observability/otel-collector.yaml` (new) | Reference Collector config with `tail_sampling` processor |
+| Deploy | `docker-compose.yaml` | Add Collector, Prometheus, Loki services; route OTLP through Collector |
+| Docs | `docs/observability.md` | Append span-conventions, metrics inventory, sampling/Collector, correlated-debugging, and Jaeger/Prometheus usage sections (file created by RFC 0018) |
+| Docs | [README.md](../../README.md) | Update OTEL paragraph to cover logs + traces + metrics |
+| Docs | [CHANGELOG.md](../../CHANGELOG.md) | Add an entry under v0.2.3 noting the Python OTLP exporter package swap (`opentelemetry-exporter-otlp-proto-grpc` → `opentelemetry-exporter-otlp-proto-http`); operator-visible because anyone running a custom OTEL collector on the gRPC port (`:4317`) will need to switch to the HTTP port (`:4318`). Also note the new Collector + Prometheus + Loki services in `docker-compose.yaml`. |
+| Docs | [ROADMAP.md](../../ROADMAP.md) | Group RFC 0018 + RFC 0019 as the v0.2.3 "Observability Foundation" delivery |
 
 No changes to: protos, schemas, JSON schemas, blueprints, workflows, Rust CLI.
 
-*Namespace rationale (added per PR #142 review).* The new Python module lives under `agents/observability/` (paired with `internal/observability/` from RFC 0018) rather than under a hypothetical `agents/telemetry/`. Persatrix-Python today has no `telemetry` package, so the choice is between introducing one and introducing `observability/`. `observability/` is preferred because (a) it pairs symmetrically with the Go `internal/observability/` namespace introduced by RFC 0018, (b) it is the umbrella term most operators recognise, and (c) it leaves room for the log↔trace correlation follow-up to live alongside both subsystems without further reorganisation. The Go-side `internal/telemetry/` package keeps its current scope and is not renamed by this RFC.
+*Namespace rationale (added per PR #142 review).* The new Python modules live under `agents/observability/` (paired with `internal/observability/` from RFC 0018). Persatrix-Python today has no `telemetry` package, so the choice is between introducing one and introducing `observability/`. `observability/` is preferred because (a) it pairs symmetrically with the Go `internal/observability/` namespace introduced by RFC 0018, (b) it is the umbrella term most operators recognise, and (c) it leaves room for the future profiling signal to live alongside both subsystems without further reorganisation.
 
-*Consolidation follow-up commitment (added per PR #142 review, second pass).* Mirroring the commitment in [RFC 0018](0018-structured-logging-framework.md#e-persatrix-logs-endpoint-and-storage), the RFC closure checklist for RFC 0019 (Phase 4) **must** include opening (or linking to the RFC 0018-spawned) tracking issue for consolidating `internal/telemetry/` and `internal/observability/` (and their Python counterparts if the same split exists by then). This prevents the provisional split from becoming a permanent two-root convention by inertia.
+*On the Go-side `internal/telemetry/` package.* Under the future-focused framing (and the shared namespace contract in [Relationship to RFC 0018](#relationship-to-rfc-0018)), `internal/telemetry/` is **renamed to `internal/observability/`** as part of this RFC's Phase 1, eliminating the provisional two-root split. The previously-recorded namespace consolidation follow-up is therefore dropped.
 
 ---
 
 ## Test Strategy
 
-- **Unit tests — `agents/observability/tracing.py`**: `init_tracing` returns a working tracer; resource attributes set correctly; `shutdown` flushes pending spans; missing env vars fall back to defaults consistently with Go.
-- **Integration test — propagation**: invoke an `AgentService` RPC with a synthetic parent context in metadata; assert the agent-side span tree's root parent matches.
-- **Integration test — semantic span emission**: drive an agent through a tick + event + memory query + LLM call; assert spans with the expected names appear in an in-process span exporter.
-- **E2E test — span tree shape**: requires the docker-compose stack up. Submit a workflow, poll the Jaeger HTTP API for the resulting trace ID, assert the parent/child relationships listed in [Section D](#d-semantic-spans-on-the-python-side).
-- **Manual smoke**: `make docker-up`, submit a workflow, open `http://localhost:16686`, find the trace, eyeball it.
+- **Unit tests — `agents/observability/tracing.py`**: `init_tracing` returns a working tracer; resource attributes set correctly (including `schema_url` and detector-supplied keys); `shutdown` flushes pending spans; missing env vars fall back to defaults consistently with Go; `BatchSpanProcessor` overflow drops rather than blocks and increments `agent.observability.spans.dropped`.
+- **Unit tests — `agents/observability/metrics.py`**: instrument inventory matches [Section F](#f-metrics); units and attribute keys are correct; histograms emit exemplars carrying valid `trace_id` / `span_id`.
+- **Integration test — propagation**: invoke an `AgentService` RPC with a synthetic parent context **and baggage** in metadata; assert the agent-side span tree's root parent matches and baggage entries are accessible inside the handler.
+- **Integration test — semantic span emission**: drive an agent through a tick + event + memory query + LLM call; assert spans with the expected names appear in the in-process `InMemorySpanExporter` and the LLM span carries `gen_ai.*` attributes.
+- **Integration test — log↔trace correlation**: emit log lines from inside a span on both Go and Python sides; assert every record carries the active span's `trace_id` and `span_id`, and known baggage entries.
+- **Integration test — Span Links**: trigger a tick from an event and a sub-agent spawn from a parent agent; assert the resulting spans carry the expected `Link`s.
+- **E2E test — observability end-to-end**: requires the docker-compose stack up (orchestrator + agents + Collector + Jaeger + Prometheus + Loki). Submit a workflow, poll Jaeger for the resulting trace ID, poll Prometheus for the matching metrics (with exemplars), query Loki for the correlated log lines; assert the parent/child relationships, the metric counts, and that log lines link back to the same trace.
+- **Manual smoke**: `make docker-up`, submit a workflow, open `http://localhost:16686`, find the trace, click an exemplar in Prometheus to jump back to a span, run `persatrix logs --trace <trace_id>`.
 
 ---
 
-## Open Questions
+## Resolved Decisions
 
-1. **`otelgrpc` interceptors vs manual context propagation.** Recommendation: interceptors. Manual is more code with no benefit at this scope. Resolved unless review surfaces a concrete reason against.
-2. **Should agent span attributes use `agent.id` or `service.instance.id`?** OTEL semantic conventions suggest the latter; Persatrix-internal queries are easier with the former. Recommendation: set both — `service.instance.id` on the resource, `agent.id` on each span. Cheap.
-3. **Span attribute schema for tool arguments.** Today the schema deliberately omits arguments to avoid leaking secrets. Should we offer an opt-in `PERSATRIX_TRACE_TOOL_ARGS=1` for development debugging? Recommendation: defer; arguments are visible in the structured logs (RFC 0018) where the operator already has them.
-4. **Sampling strategy for agent-side traces.** Autonomous tick loops can produce high-volume traces. Recommendation: keep parity with the orchestrator's sampler for v0.2.3 (parent-based). If volume becomes a problem, a tail-based sampler can be introduced as a polish item.
-5. **Where to construct the gRPC client connection in Go for `otelgrpc` wiring.** Confirm during Phase 1 implementation; one of `internal/executor/dispatch.go` or its constructor site.
+Under the future-focused framing applied in revision 2026-04-22, the original open questions are resolved as follows:
 
-   *Pinned (added per PR #142 review, second pass).* Verified against the live tree: there are **two** `grpc.NewClient` call sites in `internal/executor/`, both of which must be wired with `grpc.WithStatsHandler(otelgrpc.NewClientHandler())`:
+1. **`otelgrpc` interceptors vs manual context propagation.** ✅ Resolved: **interceptors**. Ecosystem standard; manual is more code with no benefit.
+2. **`agent.id` vs `service.instance.id`.** ✅ Resolved: **set both**. `service.instance.id` on the Resource (OTEL convention), `agent.id` on every span (Persatrix query ergonomics). Additionally adopt the **OTEL Gen-AI semantic conventions** verbatim for LLM spans (see [Section D](#d-semantic-spans-on-the-python-side)) so vendor observability tools render Persatrix LLM traces correctly out of the box.
+3. **Tool argument capture.** ✅ Resolved: **opt-in `PERSATRIX_TRACE_TOOL_PAYLOADS=none\|metadata\|full`**, routed through the shared RFC 0018 redaction hook. One secrets-policy code path for both signals; production observability stacks expect payloads on traces, not just logs.
+4. **Sampling strategy.** ✅ Resolved: **parent-based head sampling (rate 1.0) + Collector tail sampling from day 1**. See [Section H](#h-sampling-back-pressure-and-the-collector-pipeline). Cheap to set up now, painful to retrofit during a v0.3 mesh incident.
+5. **gRPC client wire site.** ✅ Pinned to two `grpc.NewClient` call sites:
    - [internal/executor/dispatch.go](../../internal/executor/dispatch.go) line 321 (workflow-step task dispatch)
    - [internal/executor/chat.go](../../internal/executor/chat.go) line 105 (chat-message dispatch added by RFC 0016)
 
-   Both sites already accept caller-provided `grpc.DialOption` slices via `WithDialOptions` / `WithChatDialOptions`, so the cleanest install is to inject the otelgrpc stats handler into those defaults from `cmd/orchestrator/main.go` (where the executor is constructed) rather than hard-coding it inside the dispatch sites. This keeps the executor package free of an OTEL import and matches the existing dependency-injection style.
+   Both sites accept caller-provided `grpc.DialOption` slices via `WithDialOptions` / `WithChatDialOptions`; the otelgrpc stats handler is injected from `cmd/orchestrator/main.go` (where the executor is constructed). The executor package stays free of an OTEL import.
+
+## Open Questions
+
+6. **Merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** Both share OTLP transport, schema-version field, redaction hook, namespace, sampling discipline, and ship in the same release. The case for merging: one document, one decision tree, no consolidation follow-up. The case for keeping split: review tractability — each RFC is large enough that a merged document would be hard to review in one pass. **Recommendation:** keep split for review, but record both RFCs as a single "Observability Foundation" delivery in [ROADMAP.md](../../ROADMAP.md), drop the namespace consolidation follow-up (already aligned via the [Relationship to RFC 0018](#relationship-to-rfc-0018) contract), and treat them as a unit in release notes. Decide before authoring the PR plan.
 
 ---
 
@@ -296,13 +444,14 @@ No changes to: protos, schemas, JSON schemas, blueprints, workflows, Rust CLI.
 **To accept this RFC:**
 
 1. Confirm v0.2.3 as the target milestone (this RFC pairs with RFC 0018 on the same release).
-2. Sign off on `otelgrpc` interceptors over manual propagation ([Open Question 1](#open-questions)).
-3. Sign off on the span-naming convention in [Section E](#e-span-naming-and-attribute-conventions) as the cross-codebase contract.
+2. Sign off on the resolved decisions in [Resolved Decisions](#resolved-decisions) (interceptors, dual `agent.id` + `service.instance.id` with Gen-AI conventions, opt-in payload capture through redaction hook, head + tail sampling, pinned gRPC client sites).
+3. Sign off on the span-naming and Persatrix attribute conventions in [Section E](#e-span-naming-and-attribute-conventions), the metrics inventory in [Section F](#f-metrics), and the log↔trace correlation contract in [Section G](#g-logtrace-correlation) as the cross-codebase contract.
+4. Decide [Open Question 6](#open-questions) (merge with RFC 0018 vs keep split).
 
 **Once accepted:**
 
-1. Author `docs/rfcs/0019-pr-plan.md` per [development-workflow.md](../development-workflow.md) Phase 3.
-2. Status → 🚧 Implementing; ROADMAP updated.
+1. Author `docs/rfcs/0019-pr-plan.md` per [development-workflow.md](../development-workflow.md) Phase 3, sequenced against the RFC 0018 PR plan so shared deliverables (OTLP transport, redaction hook, `agents/observability/` namespace, log↔trace enrichment) land once.
+2. Status → 🚧 Implementing; ROADMAP updated; both RFCs grouped as "Observability Foundation" in the v0.2.3 entry.
 3. Begin Phase 1 implementation.
 
 ---

--- a/docs/rfcs/0019-opentelemetry-completion.md
+++ b/docs/rfcs/0019-opentelemetry-completion.md
@@ -79,7 +79,7 @@ in the PR description before merge — that is a metadata fix, not an RFC change
 | Sampling discipline | Parent-based head sampling + Collector tail sampling |
 | Log↔trace enricher ownership | RFC 0018 (owns the structlog chain and zap encoder where the enrichment lives); this RFC only requires that the OTEL context is established before the enricher PR lands |
 
-A merger of the two RFCs into one "Observability Foundation" document is recorded as [Open Question A](#open-questions). Pending that decision, both RFCs cross-reference this contract.
+A merger of the two RFCs into one "Observability Foundation" document was considered and resolved as item 6 in [Resolved Decisions](#resolved-decisions): **keep split, ship as one delivery**. Both RFCs cross-reference this contract.
 
 ## Motivation
 
@@ -457,17 +457,11 @@ Under the future-focused framing applied in revision 2026-04-22, the original op
    - [internal/executor/chat.go](../../internal/executor/chat.go) line 105 (chat-message dispatch added by RFC 0016)
 
    Both sites accept caller-provided `grpc.DialOption` slices via `WithDialOptions` / `WithChatDialOptions`; the otelgrpc stats handler is injected from `cmd/orchestrator/main.go` (where the executor is constructed). The executor package stays free of an OTEL import.
+6. **Merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** ✅ Resolved: **keep split, ship as one delivery.** The two RFCs are kept as separate documents for review tractability (each is large enough that a merged document would be hard to review in one pass), but they are treated as a single "Observability Foundation" delivery in [ROADMAP.md](../../ROADMAP.md) (v0.2.3 entry already reflects this framing, recorded 2026-04-22), share the design contract in [Relationship to RFC 0018](#relationship-to-rfc-0018), and will be released together. No separate namespace-consolidation follow-up is required — alignment is already enforced by that contract. Release notes treat them as a unit.
 
 ## Open Questions
 
-<!--
-Review note (PR #160): the prior single open question was numbered "6" because
-it continued the Resolved Decisions list. Renumbered to start at A inside this
-section to make the discontinuity intentional and avoid reader confusion when
-landing on the section directly.
--->
-
-**OQ-A.** **Merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** Both share OTLP export (for traces/metrics), schema-version fields, redaction hook, namespace, sampling discipline, and ship in the same release. The case for merging: one document, one decision tree, no consolidation follow-up. The case for keeping split: review tractability — each RFC is large enough that a merged document would be hard to review in one pass. **Recommendation:** keep split for review, but record both RFCs as a single "Observability Foundation" delivery in [ROADMAP.md](../../ROADMAP.md), drop the namespace consolidation follow-up (already aligned via the [Relationship to RFC 0018](#relationship-to-rfc-0018) contract), and treat them as a unit in release notes. Decide before authoring the PR plan.
+None remaining. All prior open questions are resolved in [Resolved Decisions](#resolved-decisions); the merge-vs-split question is resolved as item 6.
 
 ---
 
@@ -476,9 +470,8 @@ landing on the section directly.
 **To accept this RFC:**
 
 1. Confirm v0.2.3 as the target milestone (this RFC pairs with RFC 0018 on the same release).
-2. Sign off on the resolved decisions in [Resolved Decisions](#resolved-decisions) (interceptors, dual `agent.id` + `service.instance.id` with Gen-AI conventions, opt-in payload capture through redaction hook, head + tail sampling, pinned gRPC client sites).
+2. Sign off on the resolved decisions in [Resolved Decisions](#resolved-decisions) (interceptors, dual `agent.id` + `service.instance.id` with Gen-AI conventions, opt-in payload capture through redaction hook, head + tail sampling, pinned gRPC client sites, keep-split-ship-as-one-delivery).
 3. Sign off on the span-naming and Persatrix attribute conventions in [Section E](#e-span-naming-and-attribute-conventions), the metrics inventory in [Section F](#f-metrics), and the log↔trace correlation contract in [Section G](#g-logtrace-correlation) as the cross-codebase contract.
-4. Decide [Open Question A](#open-questions) (merge with RFC 0018 vs keep split).
 
 **Cross-RFC sequencing (added per PR #160 review).** The two RFCs share namespace and code paths, so PR landing order matters:
 

--- a/docs/rfcs/0019-opentelemetry-completion.md
+++ b/docs/rfcs/0019-opentelemetry-completion.md
@@ -3,11 +3,18 @@
 **Type**: architecture
 **Status**: 📋 Proposed
 **Author**: Maksim Khomutov
-**Date**: 2026-04-21 (rev 2026-04-22 — future-focused expansion)
+**Date**: 2026-04-21 (rev 2026-04-22 — future-focused expansion; rev 2026-04-22b — apply PR #160 review)
 **Target**: v0.2.3
-**Schema version**: 1
 **Depends on**: none
-**Pairs with**: RFC 0018 (Structured Logging Framework — both ship together in v0.2.3 with shared schema, redaction hook, and OTLP transport; see [Relationship to RFC 0018](#relationship-to-rfc-0018))
+**Pairs with**: RFC 0018 (Structured Logging Framework — both ship together in v0.2.3 with shared schema, redaction hook, and OTLP export; see [Relationship to RFC 0018](#relationship-to-rfc-0018))
+
+<!--
+Review note (PR #160): the `Schema version` field was removed from the frontmatter
+and folded into Section A ("Current State") below, where the OTEL Resource
+`schema_url` is the canonical home for the version. The RFC template does not
+define a `Schema version` frontmatter field; introducing one here would set an
+ad-hoc convention that diverges from the template.
+-->
 
 ---
 
@@ -40,25 +47,39 @@
 
 ## Summary
 
-This RFC closes the cross-language gap in Persatrix's OpenTelemetry implementation and lands the **observability foundation** for the project's full lifetime: traces start in the Go orchestrator, cross the gRPC boundary into Python agents (with W3C TraceContext **and** W3C Baggage), and continue as child spans for memory operations, persona event dispatch, LLM calls (annotated with the OTEL Gen-AI semantic conventions), and tool executions. **Metrics** (counters, histograms, gauges) ship on the same OTLP transport. **Log↔trace correlation** (`trace_id` / `span_id` injected into every structured log line from RFC 0018) lands in the same release rather than as a follow-up. **Span Links** capture A2A and sub-agent causality so v0.3 mesh traces are not a forest of disconnected trees. A documented **OTEL Collector tail-sampling pipeline** is the canonical operator deployment from day 1.
+This RFC closes the cross-language gap in Persatrix's OpenTelemetry implementation and lands the **observability foundation** for the project's full lifetime: traces start in the Go orchestrator, cross the gRPC boundary into Python agents (with W3C TraceContext **and** W3C Baggage), and continue as child spans for memory operations, persona event dispatch, LLM calls (annotated with the OTEL Gen-AI semantic conventions), and tool executions. **Metrics** (counters, histograms, gauges) ship on the same OTLP transport. **Log↔trace correlation** (`trace_id` / `span_id` injected into every structured log line emitted by RFC 0018's logger configuration) lands in the same release rather than as a follow-up. **Span Links** capture A2A and sub-agent causality so v0.3 mesh traces are not a forest of disconnected trees. A documented **OTEL Collector tail-sampling pipeline** is the canonical operator deployment from day 1.
 
-The scope is intentionally larger than "traces work end-to-end." The goal is to ship a complete OTLP-native observability surface (logs + traces + metrics, correlated, with a single redaction hook shared with RFC 0018) once, rather than re-litigate naming, sampling, and transport across three or four releases.
+The scope is intentionally larger than "traces work end-to-end." The goal is to ship traces + metrics + correlation alongside RFC 0018's logs, with a single redaction hook shared between the two, once — rather than re-litigate naming, sampling, and transport across three or four releases. (Logs themselves remain RFC 0018's deliverable; this RFC owns trace and metric signals plus the enrichers that join them to log records.)
 
 ### Relationship to RFC 0018
 
 RFC 0018 (Structured Logging) and this RFC are deliberately kept as separate documents for review tractability, but they share a single design contract:
 
+<!--
+Review note (PR #160): the previous "Wire transport | OTLP (HTTP, port 4318)" row
+conflicted with RFC 0018 Section E, which specifies a `LogService` streaming gRPC
+for the agent→orchestrator log ingest path (with documented rationale: one
+orchestrator↔agent transport, free HTTP/2 backpressure, distributed-deployment
+ready). The contract is now broken out per signal so the two RFCs no longer
+contradict each other. The PR description text claiming "Logs ship via the OTEL
+Logs SDK over OTLP" is inconsistent with both RFC bodies and should be updated
+in the PR description before merge — that is a metadata fix, not an RFC change.
+-->
+
 | Concern | Single source of truth |
 |---------|------------------------|
-| Wire transport | OTLP (HTTP, port 4318) |
-| Schema version field | `schema_version: 1` |
+| Trace + metric export | OTLP HTTP (port 4318) — this RFC |
+| Log ingest (agent → orchestrator) | `LogService` streaming gRPC over the existing agent gRPC channel — RFC 0018 Section E |
+| Log export to external backends (optional) | OTLP HTTP via the same Collector — operator-side, out of scope for v0.2.3 |
+| Schema version field | `schema_version: 1` (logs); OTEL `schema_url=https://persatrix.dev/schemas/observability/1.0.0` (traces + metrics) |
 | Correlation IDs | `execution_id`, `step_id`, `agent_id`, `workflow_id`, `trace_id`, `span_id` |
 | Cross-process propagation | W3C TraceContext + W3C Baggage |
 | Redaction hook | Shared interface, used by both log records and span attributes |
 | Namespace | Go `internal/observability/`, Python `agents/observability/` (no separate `telemetry/` tree) |
 | Sampling discipline | Parent-based head sampling + Collector tail sampling |
+| Log↔trace enricher ownership | RFC 0018 (owns the structlog chain and zap encoder where the enrichment lives); this RFC only requires that the OTEL context is established before the enricher PR lands |
 
-A merger of the two RFCs into one "Observability Foundation" document is recorded as [Open Question 6](#open-questions). Pending that decision, both RFCs cross-reference this contract.
+A merger of the two RFCs into one "Observability Foundation" document is recorded as [Open Question A](#open-questions). Pending that decision, both RFCs cross-reference this contract.
 
 ## Motivation
 
@@ -105,6 +126,8 @@ What happens if we do nothing: every multi-agent debugging story remains a manua
 ## Design / Implementation
 
 ### A. Current State
+
+*Schema version.* Trace + metric signals carry the OTEL Resource attribute `schema_url="https://persatrix.dev/schemas/observability/1.0.0"` (Section B). The structured-log schema is versioned independently as `schema_version: "1"` (RFC 0018 Section B). Both versions are tracked in CHANGELOG; bumping either is a release-notes event.
 
 | Concern | Go orchestrator | Python agents |
 |---------|-----------------|---------------|
@@ -253,7 +276,7 @@ The `docs/observability.md` doc gains a "correlated debugging" walkthrough: from
 
 **Head sampling: parent-based.** The Python SDK uses `ParentBased(TraceIdRatioBased(<rate>))` matching the Go orchestrator's existing sampler. Default sampling rate is `1.0` for v0.2.3 (sample everything; tail sampler downstream decides what to keep).
 
-**Tail sampling: OTEL Collector.** Autonomous tick loops in v0.3 mesh will dwarf workflow-driven traces. Cheap to set up the Collector pipeline now; painful to retrofit during a v0.3 incident. A reference Collector configuration ships under `deploy/observability/otel-collector.yaml` and is referenced from `docker-compose.yaml`:
+**Tail sampling: OTEL Collector.** Autonomous tick loops in v0.3 mesh will dwarf workflow-driven traces. Cheap to set up the Collector pipeline now; painful to retrofit during a v0.3 incident. A reference Collector configuration ships under `config/observability/otel-collector.yaml` and is referenced from `docker-compose.yaml` (path chosen per PR #160 review to align with the existing `config/` directory convention; the repository has no top-level `deploy/` directory today, and creating one for a single file would be a structural decision out of scope for this RFC):
 
 ```yaml
 processors:
@@ -296,6 +319,7 @@ Without links, v0.3 mesh traces will be a forest of disconnected trees. Adding t
 ## Security Considerations
 
 - **Trace data may include sensitive information.** Span attributes can leak prompts, tool inputs, or user content if instrumentation copies payloads verbatim. The default attribute schema avoids payload-bearing fields (`gen_ai.usage.input_tokens` is a count, not the prompt text). The opt-in `PERSATRIX_TRACE_TOOL_PAYLOADS=full` mode routes tool arguments and results through the **shared RFC 0018 redaction hook** — there is one secrets-policy code path covering both logs and traces.
+- **`PERSATRIX_TRACE_TOOL_PAYLOADS=full` is gated on a non-noop redactor** (added per PR #160 review). At startup, if the configured value is `full` *and* the registered `Redactor` is the default `NoopRedactor`, the agent runtime logs a `WARN` (`tool payload capture forced down to 'metadata' — register a non-noop Redactor to enable 'full'`) and force-downgrades the effective mode to `metadata`. This closes the most likely accidental data-leakage vector in the window between this RFC landing and the future security RFC (under RFC 0009) that ships a real redactor.
 - **Baggage entries are propagated downstream.** Baggage values appear on every span and log line in the trace tree, including across A2A boundaries. The schema deliberately reserves `persatrix.*` for non-sensitive correlation IDs; user content must never be placed in baggage. This is documented in `docs/observability.md`.
 - **OTLP exporter endpoint is an outbound network call.** Default `http://localhost:4318` is local Collector / Jaeger. Operators pointing to remote collectors need to apply their own auth; OTLP collector security is operator responsibility, consistent with how Go currently handles it.
 - **No new attack surfaces on the orchestrator.** The new `otelgrpc` client interceptor and `otelhttp` handler wrap are non-listening / outbound-only respectively.
@@ -337,10 +361,10 @@ Without links, v0.3 mesh traces will be a forest of disconnected trees. Adding t
 4. LLM-call span in `agents/llm_client.py` using OTEL Gen-AI semantic conventions.
 5. Tool-execute span in `agents/tools/registry.py`; remove the TODO at line 138; opt-in payload capture via `PERSATRIX_TRACE_TOOL_PAYLOADS` routed through the RFC 0018 redaction hook.
 6. Span Links wired at: persona event → triggered tick, parent agent → spawned sub-agent, bridged-message dispatch → receiving handler.
-7. Log↔trace enricher: Python logging interceptor and Go zap field enricher both pull `trace_id` / `span_id` (and known baggage entries) from the active context and add them to every log record.
+7. **Log↔trace enricher coordination only — implementation owned by RFC 0018 Phase 3.** This RFC's Phase 2 must land before RFC 0018 Phase 3 so that the OTEL context (provider + propagator + active span) is available when RFC 0018's structlog/zap enricher reads `trace_id` / `span_id` and known baggage entries. See [Section G](#g-logtrace-correlation) for the contract; the actual interceptor / encoder code ships in RFC 0018. <!-- Review note (PR #160): previously this deliverable claimed the enricher implementation, duplicating RFC 0018 Phase 3 deliverables 3–4. Reduced to a cross-reference to give PR-plan authors a single source of truth. -->
 8. Span-conventions and "correlated debugging" walkthrough sections appended to `docs/observability.md`.
 
-**Dependencies.** Phase 1; coordinated with RFC 0018 logging interceptor landing.
+**Dependencies.** Phase 1; coordinated with RFC 0018 Phase 3 (which owns the log↔trace enricher; see deliverable 7 above).
 
 ### Phase 3: Metrics + Collector Pipeline + End-to-End Verification
 
@@ -354,9 +378,10 @@ Without links, v0.3 mesh traces will be a forest of disconnected trees. Adding t
 4. `deploy/observability/otel-collector.yaml` (new) with the tail-sampling pipeline from [Section H](#h-sampling-back-pressure-and-the-collector-pipeline).
 5. `docker-compose.yaml` updated to add the Collector service in front of Jaeger; Prometheus added as the metrics backend; Loki added as the logs backend (development only).
 6. `agents/tests/conftest.py` ships an `InMemoryMetricReader` fixture.
-7. E2E test: submit a workflow, query Jaeger for the trace, query Prometheus for the resulting metrics, query Loki (or `persatrix logs --trace <trace_id>`) for the correlated log lines; assert the expected shape across all three signals.
-8. Operator-facing section in `docs/observability.md` covering "viewing traces in Jaeger", "querying metrics in Prometheus", "correlated debugging from a trace ID".
-9. README OTEL paragraph updated to reflect logs + traces + metrics end-to-end coverage.
+7. **Schema parity contract test** (added per PR #160 review): asserts that every Persatrix correlation ID listed in [RFC 0018 Section B](0018-structured-logging-framework.md#b-common-log-schema) Optional fields (`execution_id`, `step_id`, `agent_id`, `request_id`, `trace_id`, `span_id`) appears with a matching key in this RFC's [Section E](#e-span-naming-and-attribute-conventions) attribute conventions (under the `persatrix.*` prefix where applicable), and that the schema-version values declared in both RFCs (`schema_version: "1"` for logs; `schema_url=…/1.0.0` for traces/metrics) are pinned in code. Prevents silent drift between the two schemas across future revisions.
+8. E2E test: submit a workflow, query Jaeger for the trace, query Prometheus for the resulting metrics, query Loki (or `persatrix logs --trace <trace_id>`) for the correlated log lines; assert the expected shape across all three signals.
+9. Operator-facing section in `docs/observability.md` covering "viewing traces in Jaeger", "querying metrics in Prometheus", "correlated debugging from a trace ID".
+10. README OTEL paragraph updated to reflect logs + traces + metrics end-to-end coverage.
 
 **Dependencies.** Phase 2.
 
@@ -391,7 +416,7 @@ Per [development-workflow.md](../development-workflow.md) Phase 5–8.
 | Tests | `tests/integration/test_trace_propagation.py` (new) | Cross-language propagation integration test |
 | Tests | `tests/integration/test_log_trace_correlation.py` (new) | Asserts every structured log emitted inside a span carries `trace_id` / `span_id` |
 | Tests | `tests/integration/test_observability_e2e.py` (new) | E2E shape test: trace tree + correlated logs + metric exemplars against the local Collector + Jaeger + Prometheus stack |
-| Deploy | `deploy/observability/otel-collector.yaml` (new) | Reference Collector config with `tail_sampling` processor |
+| Deploy | `config/observability/otel-collector.yaml` (new) | Reference Collector config with `tail_sampling` processor (path chosen per PR #160 review to align with `config/` convention) |
 | Deploy | `docker-compose.yaml` | Add Collector, Prometheus, Loki services; route OTLP through Collector |
 | Docs | `docs/observability.md` | Append span-conventions, metrics inventory, sampling/Collector, correlated-debugging, and Jaeger/Prometheus usage sections (file created by RFC 0018) |
 | Docs | [README.md](../../README.md) | Update OTEL paragraph to cover logs + traces + metrics |
@@ -435,7 +460,14 @@ Under the future-focused framing applied in revision 2026-04-22, the original op
 
 ## Open Questions
 
-6. **Merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** Both share OTLP transport, schema-version field, redaction hook, namespace, sampling discipline, and ship in the same release. The case for merging: one document, one decision tree, no consolidation follow-up. The case for keeping split: review tractability — each RFC is large enough that a merged document would be hard to review in one pass. **Recommendation:** keep split for review, but record both RFCs as a single "Observability Foundation" delivery in [ROADMAP.md](../../ROADMAP.md), drop the namespace consolidation follow-up (already aligned via the [Relationship to RFC 0018](#relationship-to-rfc-0018) contract), and treat them as a unit in release notes. Decide before authoring the PR plan.
+<!--
+Review note (PR #160): the prior single open question was numbered "6" because
+it continued the Resolved Decisions list. Renumbered to start at A inside this
+section to make the discontinuity intentional and avoid reader confusion when
+landing on the section directly.
+-->
+
+**OQ-A.** **Merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** Both share OTLP export (for traces/metrics), schema-version fields, redaction hook, namespace, sampling discipline, and ship in the same release. The case for merging: one document, one decision tree, no consolidation follow-up. The case for keeping split: review tractability — each RFC is large enough that a merged document would be hard to review in one pass. **Recommendation:** keep split for review, but record both RFCs as a single "Observability Foundation" delivery in [ROADMAP.md](../../ROADMAP.md), drop the namespace consolidation follow-up (already aligned via the [Relationship to RFC 0018](#relationship-to-rfc-0018) contract), and treat them as a unit in release notes. Decide before authoring the PR plan.
 
 ---
 
@@ -446,7 +478,15 @@ Under the future-focused framing applied in revision 2026-04-22, the original op
 1. Confirm v0.2.3 as the target milestone (this RFC pairs with RFC 0018 on the same release).
 2. Sign off on the resolved decisions in [Resolved Decisions](#resolved-decisions) (interceptors, dual `agent.id` + `service.instance.id` with Gen-AI conventions, opt-in payload capture through redaction hook, head + tail sampling, pinned gRPC client sites).
 3. Sign off on the span-naming and Persatrix attribute conventions in [Section E](#e-span-naming-and-attribute-conventions), the metrics inventory in [Section F](#f-metrics), and the log↔trace correlation contract in [Section G](#g-logtrace-correlation) as the cross-codebase contract.
-4. Decide [Open Question 6](#open-questions) (merge with RFC 0018 vs keep split).
+4. Decide [Open Question A](#open-questions) (merge with RFC 0018 vs keep split).
+
+**Cross-RFC sequencing (added per PR #160 review).** The two RFCs share namespace and code paths, so PR landing order matters:
+
+1. **This RFC's Phase 1 lands before any RFC 0018 PR that adds packages under `internal/observability/`.** Phase 1 performs the `internal/telemetry/` → `internal/observability/` rename; landing it second would turn the rename PR into a rename-plus-merge-conflict-resolution PR.
+2. **This RFC's Phase 1 lands before RFC 0018 Phase 3.** RFC 0018 Phase 3 declares `RFC 0019 Phase 1 (OTEL initialised on Python side)` as a prerequisite; the cross-process correlation work needs the OTEL context already established.
+3. **RFC 0018 Phase 1 lands before this RFC's Phase 2** (so the redaction hook surface and the structlog/zap configuration the enricher attaches to exist before the Phase 2 spans need to call into them).
+
+These constraints should be reflected in both RFCs' joint PR plan and in the v0.2.3 ROADMAP entry.
 
 **Once accepted:**
 


### PR DESCRIPTION
## Summary

Applies a "no-limits, future-focused" revision pass to the paired observability RFCs targeting v0.2.3. Both RFCs now share a single design contract (OTLP transport, schema version, redaction hook, namespace, sampling discipline) and ship logs + traces + metrics + correlation as one **Observability Foundation** delivery, designed once for the project's full lifetime rather than re-litigated across releases.

## Why this revision

The earlier drafts answered each open question conservatively (defer metrics, defer correlation, keep two-root namespace, defer tail sampling). Under a future-focused framing those deferrals translate into 3–4 follow-up RFCs in v0.2.4 / v0.2.5 / v0.2.6 that re-decide naming, units, transport, and sampling. The cost of pulling them forward is roughly +30% scope on v0.2.3; the benefit is no breaking observability schema changes for the project's lifetime.

## Changes — RFC 0018 (Structured Logging Framework)

- Open questions resolved under future-focused framing.
- Logs ship via the **OTEL Logs SDK over OTLP** (shared exporter with RFC 0019), not a bespoke `LogService` gRPC.
- **Log↔trace correlation in scope for v0.2.3** (every log inside an active span carries `trace_id` / `span_id`).
- **W3C Baggage** carries `persatrix.execution_id` / `step_id` / `workflow_id` (and future `tenant_id` / `organization_id`) — log enrichment is automatic across A2A and sub-agent boundaries.
- **Shared redaction hook** with RFC 0019 — one secrets-policy code path for log records and span attributes.
- Namespace: `internal/observability/` and `agents/observability/` from day 1.

## Changes — RFC 0019 (OpenTelemetry Completion → Traces, Metrics, Correlation)

- Renamed; added **Relationship to RFC 0018** contract table.
- **Metrics** added to scope on the same OTLP exporter: counters, histograms, gauges; **exemplars** link histogram samples to traces.
- **OTEL Gen-AI semantic conventions** for LLM spans (`gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, etc.) so vendor backends render LLM views correctly out of the box.
- **W3C Baggage propagation** alongside TraceContext.
- **Span Links** for A2A causality, sub-agent spawns, bridged messages, and v0.3 mesh.
- **Tail-sampling Collector pipeline** (errors, slow LLM calls, workflow traces, 1% of healthy ticks) shipped under `deploy/observability/otel-collector.yaml` and wired into `docker-compose.yaml` from day 1.
- **Resource detectors**, versioned `schema_url`, tuned `BatchSpanProcessor` with drop-on-overflow + drop-counter metrics.
- `internal/telemetry/` **renamed to `internal/observability/`** in Phase 1 — eliminates the previously-recorded namespace consolidation follow-up.
- `InMemorySpanExporter` and `InMemoryMetricReader` `pytest` fixtures shipped as first-class deliverables.
- Persona event uses **span events** for sub-millisecond phases instead of nested spans.
- `otelhttp` on the orchestrator's main HTTP handler for free route-level latency histograms.
- All five original open questions resolved into a **Resolved Decisions** section. One new open question remains: **merge RFC 0018 and RFC 0019 into one "Observability Foundation" RFC?** (Recommendation: keep split for review, treat as one delivery in ROADMAP and release notes.)

## Non-goals (unchanged or newly explicit)

- Profiling signal (4th OTEL signal) — namespace left unblocked, no implementation.
- Tool/function-call OTEL semantic conventions — adopt when upstream stabilises; current `tool.*` keys are forward-compatible.
- Multi-tenant attribute enforcement (RFC 0009) — baggage slots reserved, enforcement out of scope.
- YAML-based OTEL config — env vars remain primary for v0.2.3.
- Production observability backend choice — reference Collector + Jaeger + Prometheus + Loki for dev only.

## Files changed

- `docs/rfcs/0018-structured-logging-framework.md`
- `docs/rfcs/0019-opentelemetry-completion.md`

Docs-only PR. No code, schema, or config changes.

## Decision needed

Reviewers should sign off on:

1. The shared design contract between RFCs 0018 and 0019.
2. Pulling metrics, log↔trace correlation, baggage propagation, and tail sampling into v0.2.3 (≈ +30% scope vs the conservative drafts).
3. Renaming `internal/telemetry/` → `internal/observability/` in Phase 1 of RFC 0019.
4. RFC 0019 [Open Question 6](../docs/rfcs/0019-opentelemetry-completion.md#open-questions): keep the two RFCs split for review or merge into one "Observability Foundation" RFC before authoring PR plans.

Once accepted, both RFCs flip to 🚧 Implementing and PR plans are authored as a coordinated pair.