### PR TITLE
fix(observability): issue #179 Should-Fix correctness cluster (sentinel collision + timestamp policy + SSE write deadline)

### DIFF
--- a/agents/observability/log_shipper.py
+++ b/agents/observability/log_shipper.py
@@ -40,7 +40,7 @@ import os
 import threading
 from collections import deque
 from collections.abc import Iterable
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 import grpc
@@ -347,8 +347,10 @@ def record_to_proto(record: dict[str, Any]) -> logpb.LogEntry:
         trace_id=str(record.get("trace_id", "")),
         span_id=str(record.get("span_id", "")),
     )
+    ts_parse_error = False
     if (ts := record.get("timestamp")) is not None:
-        e.timestamp.CopyFrom(_to_timestamp(ts))
+        proto_ts, ts_parse_error = _to_timestamp(ts)
+        e.timestamp.CopyFrom(proto_ts)
     if (src := record.get("source")) is not None and isinstance(src, dict):
         e.source.CopyFrom(logpb.LogEntry.Source(
             file=str(src.get("file", "")),
@@ -362,29 +364,52 @@ def record_to_proto(record: dict[str, Any]) -> logpb.LogEntry:
         and k not in _BOOKKEEPING_KEYS
         and not k.startswith("_")
     }
+    if ts_parse_error:
+        # Issue #179 Should-Fix #2: surface malformed-timestamp inputs
+        # rather than silently emitting an epoch-zero entry that would
+        # sort to the front of every chronological merge in the
+        # orchestrator's handleListLogs / SSE broadcast path.
+        extras["timestamp_parse_error"] = True
     if extras:
         e.attributes.CopyFrom(_dict_to_struct(extras))
     return e
 
 
-def _to_timestamp(ts: Any) -> timestamp_pb2.Timestamp:
+def _to_timestamp(ts: Any) -> tuple[timestamp_pb2.Timestamp, bool]:
+    """Convert a record timestamp to a proto Timestamp.
+
+    Returns ``(timestamp, parse_error)``.  ``parse_error`` is ``True``
+    only for string inputs that failed RFC 3339 parsing; callers
+    surface this as a ``timestamp_parse_error=true`` attribute so the
+    downstream merge path can distinguish stamped-now entries from
+    well-formed ones.  Issue #179 Should-Fix #2.
+    """
     out = timestamp_pb2.Timestamp()
     if isinstance(ts, datetime):
         out.FromDatetime(ts)
-    elif isinstance(ts, (int, float)):
+        return out, False
+    if isinstance(ts, (int, float)):
         # Preserve sub-second precision for float epoch inputs; the
         # previous FromSeconds(int(ts)) silently truncated milliseconds
         # so SSE / chronological merges across log sources lost
         # ordering information for entries within the same second.
         # (PR #173 review nice-to-have #5.)
         out.FromNanoseconds(int(ts * 1_000_000_000))
-    elif isinstance(ts, str):
-        # Best-effort RFC 3339 parse.  On failure leave the Timestamp
-        # at its zero value so the orchestrator still admits the entry
-        # rather than rejecting on a malformed time.
-        with contextlib.suppress(ValueError):
+        return out, False
+    if isinstance(ts, str):
+        # Best-effort RFC 3339 parse.  On failure stamp the current
+        # wall clock and flag the entry so it still sorts into the
+        # vicinity of its siblings rather than collapsing the whole
+        # merged view onto 1970-01-01.
+        try:
             out.FromDatetime(datetime.fromisoformat(ts.replace("Z", "+00:00")))
-    return out
+            return out, False
+        except ValueError:
+            out.FromDatetime(datetime.now(UTC))
+            return out, True
+    # Unknown type: stamp now to keep the entry chronologically sane.
+    out.FromDatetime(datetime.now(UTC))
+    return out, True
 
 
 def _dict_to_struct(d: dict[str, Any]) -> struct_pb2.Struct:

--- a/agents/observability/log_shipper.py
+++ b/agents/observability/log_shipper.py
@@ -364,11 +364,18 @@ def record_to_proto(record: dict[str, Any]) -> logpb.LogEntry:
         and k not in _BOOKKEEPING_KEYS
         and not k.startswith("_")
     }
-    if ts_parse_error:
+    if ts_parse_error and "timestamp_parse_error" not in extras:
         # Issue #179 Should-Fix #2: surface malformed-timestamp inputs
         # rather than silently emitting an epoch-zero entry that would
         # sort to the front of every chronological merge in the
         # orchestrator's handleListLogs / SSE broadcast path.
+        #
+        # Guard: if a producer record already carries its own
+        # `timestamp_parse_error` key (unlikely but possible for
+        # pass-through / replay logs), preserve the user value rather
+        # than silently overwriting it.  The shipper's flag is a
+        # best-effort signal; an explicit producer value takes
+        # precedence.  (PR #182 review Should-Fix #1.)
         extras["timestamp_parse_error"] = True
     if extras:
         e.attributes.CopyFrom(_dict_to_struct(extras))

--- a/agents/tests/test_log_shipper.py
+++ b/agents/tests/test_log_shipper.py
@@ -50,6 +50,35 @@ def test_record_to_proto_handles_datetime_timestamp() -> None:
     assert proto.timestamp.seconds == int(ts.timestamp())
 
 
+def test_record_to_proto_malformed_timestamp_stamps_now_and_flags() -> None:
+    # Issue #179 Should-Fix #2: malformed RFC 3339 timestamps must not
+    # collapse to epoch-zero (which would pull the entry to the front
+    # of every chronological merge).  The shipper stamps now() and
+    # surfaces the failure via a `timestamp_parse_error=true` attribute.
+    before = datetime.now(UTC)
+    proto = record_to_proto({
+        "timestamp": "not-a-real-timestamp",
+        "level": "INFO",
+        "message": "m",
+    })
+    after = datetime.now(UTC)
+    # Stamped with the current wall clock, not 1970.
+    stamped = proto.timestamp.ToDatetime(tzinfo=UTC)
+    assert before <= stamped <= after
+    # Flagged in attributes so downstream consumers can distinguish
+    # stamped-now entries from well-formed ones.
+    assert proto.attributes.fields["timestamp_parse_error"].bool_value is True
+
+
+def test_record_to_proto_valid_string_timestamp_no_flag() -> None:
+    ts = "2026-01-01T12:00:00+00:00"
+    proto = record_to_proto({"timestamp": ts, "level": "INFO", "message": "m"})
+    assert proto.timestamp.seconds == int(
+        datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC).timestamp(),
+    )
+    assert "timestamp_parse_error" not in proto.attributes.fields
+
+
 def test_record_to_proto_with_source() -> None:
     proto = record_to_proto({
         "level": "ERROR",

--- a/agents/tests/test_log_shipper.py
+++ b/agents/tests/test_log_shipper.py
@@ -79,6 +79,44 @@ def test_record_to_proto_valid_string_timestamp_no_flag() -> None:
     assert "timestamp_parse_error" not in proto.attributes.fields
 
 
+@pytest.mark.parametrize("bad_ts", [[1, 2], {"bad": True}, object()])
+def test_record_to_proto_unknown_timestamp_type_stamps_now_and_flags(
+    bad_ts: Any,
+) -> None:
+    # Issue #179 Should-Fix #2 / PR #182 review Should-Fix #2: the
+    # `_to_timestamp` fallback branch for unknown types (anything that
+    # is not datetime | int | float | str) must also stamp-now and
+    # flag, not silently emit an epoch-zero entry.  Covers the final
+    # `# Unknown type` arm of the helper that the original PR #182
+    # tests did not exercise directly.
+    before = datetime.now(UTC)
+    proto = record_to_proto({"timestamp": bad_ts, "level": "INFO", "message": "m"})
+    after = datetime.now(UTC)
+    stamped = proto.timestamp.ToDatetime(tzinfo=UTC)
+    assert before <= stamped <= after
+    assert proto.attributes.fields["timestamp_parse_error"].bool_value is True
+
+
+def test_record_to_proto_preserves_producer_timestamp_parse_error() -> None:
+    # PR #182 review Should-Fix #1: a producer record that already
+    # carries its own `timestamp_parse_error` key must not have that
+    # value silently overwritten by the shipper's fallback flag.
+    # Unlikely in practice (structlog producers don't set this key),
+    # but the invariant should be explicit so pass-through / replay
+    # pipelines behave predictably.
+    proto = record_to_proto({
+        "timestamp": "not-a-real-timestamp",
+        "timestamp_parse_error": "producer-value",
+        "level": "INFO",
+        "message": "m",
+    })
+    # User value wins; shipper flag does not overwrite.
+    assert (
+        proto.attributes.fields["timestamp_parse_error"].string_value
+        == "producer-value"
+    )
+
+
 def test_record_to_proto_with_source() -> None:
     proto = record_to_proto({
         "level": "ERROR",

--- a/internal/observability/logbuffer/buffer.go
+++ b/internal/observability/logbuffer/buffer.go
@@ -100,6 +100,18 @@ const (
 // neither needed nor safe to widen.
 var executionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
 
+// reservedExecutionIDs are well-formed-but-reserved execution IDs that
+// the pattern would otherwise admit.  Currently contains only the
+// single-underscore sentinel the REST/SSE layer uses as the "merged
+// cross-execution view" path segment (see crossExecutionToken in
+// internal/server/logs_handler.go).  Without this guard a producer
+// could Append an entry with ExecutionID="_" and that ring would be
+// unreachable via REST/SSE (the handlers early-return on "_" and
+// never call Snapshot("_")).  Issue #179 Should-Fix #1.
+var reservedExecutionIDs = map[string]struct{}{
+	"_": {},
+}
+
 // validExecutionID guards every code path that uses ExecutionID as a
 // filesystem path component (see disk.flush / disk.read /
 // disk.evictIfOverCap). A producer that supplies "../../etc" or
@@ -108,7 +120,14 @@ var executionIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
 // expose Append to network input, at which point this validator is
 // the single boundary preventing OWASP A03 (Injection) /
 // path-traversal abuse — keep it strict.
+//
+// Values in reservedExecutionIDs are rejected even when the character
+// regex matches, so the REST/SSE sentinel cannot be shadowed by a
+// real ring.
 func validExecutionID(s string) bool {
+	if _, reserved := reservedExecutionIDs[s]; reserved {
+		return false
+	}
 	return executionIDPattern.MatchString(s)
 }
 

--- a/internal/observability/logbuffer/buffer_test.go
+++ b/internal/observability/logbuffer/buffer_test.go
@@ -105,6 +105,22 @@ func TestAppend_InvalidExecutionIDIsRejected(t *testing.T) {
 	}
 }
 
+// Issue #179 Should-Fix #1: the cross-execution REST/SSE sentinel "_"
+// matches executionIDPattern, so without an explicit reserved-list
+// check a producer could Append ExecutionID="_" and that ring would
+// be unreachable (handlers early-return on "_" before Snapshot).
+// Reject it at the validator so the Append surfaces as DropInvalidID
+// instead of silently populating a shadow ring.
+func TestAppend_ReservedCrossExecutionTokenRejected(t *testing.T) {
+	b := newTestBuffer(t, Config{})
+	assert.Equal(t, DropInvalidID, b.Append(mkEntry("_", "INFO", "shadow-merge")))
+	assert.Equal(t, uint64(1), b.Stats().DroppedInvalidID)
+	assert.Equal(t, 0, b.Stats().ActiveRings)
+	assert.Error(t, b.Seal("_"))
+	assert.Nil(t, b.Snapshot("_"))
+	assert.False(t, ValidExecutionID("_"))
+}
+
 func TestAppend_ClosedBufferReturnsDropClosed(t *testing.T) {
 	// Regression for PR-172 review Should-Fix #2: post-Close appends
 	// previously aliased to DropBelowLevel; they now surface as

--- a/internal/server/logs_handler.go
+++ b/internal/server/logs_handler.go
@@ -24,8 +24,9 @@ import (
 
 // crossExecutionToken is the path-segment value used to request the
 // merged cross-execution view.  Documented as `id=_` in the RFC and
-// CLI; chosen because it is unambiguously not a valid execution ID
-// (the buffer's executionIDPattern does not match a single underscore).
+// CLI; chosen because it is reserved by the buffer's validator
+// (reservedExecutionIDs) so a producer cannot Append with
+// ExecutionID="_" and shadow the merged view.  Issue #179 Should-Fix #1.
 const crossExecutionToken = "_"
 
 // maxLogsLimit caps `limit` to keep a single response from holding the

--- a/internal/server/logs_stream_handler.go
+++ b/internal/server/logs_stream_handler.go
@@ -23,6 +23,28 @@ import (
 // (nginx default 60s, Cloudflare 100s) without flooding the stream.
 const sseHeartbeatInterval = 15 * time.Second
 
+// sseWriteTimeout caps how long a single SSE write may block on a
+// stalled TCP peer.  Without it a dead client pins the subscriber slot
+// indefinitely; with MaxSubscribersDefault=64 that lets ~64 dead
+// clients soft-deny the SSE endpoint.  Issue #179 Should-Fix #3.
+// Sized a few heartbeat intervals wide so a transient pause on a
+// healthy client never trips the deadline.
+const sseWriteTimeout = 30 * time.Second
+
+// sseWrite applies the per-write deadline and writes a single chunk,
+// returning any error.  ErrNotSupported from the ResponseController
+// (test doubles, middleware without deadline support) is treated as
+// best-effort: the write proceeds without a deadline rather than
+// failing the whole stream.
+func sseWrite(rc *http.ResponseController, w http.ResponseWriter, p []byte) error {
+	if err := rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout)); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	_, err := w.Write(p)
+	return err
+}
+
 // handleStreamLogs serves GET /api/v1/executions/{id}/logs/stream.
 //
 // TODO(RFC-0009): authenticate.  Same surface as the REST list
@@ -81,6 +103,7 @@ func (s *Server) handleStreamLogs(w http.ResponseWriter, r *http.Request) {
 	heartbeat := time.NewTicker(sseHeartbeatInterval)
 	defer heartbeat.Stop()
 	ctx := r.Context()
+	rc := http.NewResponseController(w)
 
 	for {
 		select {
@@ -91,7 +114,7 @@ func (s *Server) handleStreamLogs(w http.ResponseWriter, r *http.Request) {
 		case <-heartbeat.C:
 			// SSE comment frame; the colon prefix tells the EventSource
 			// parser to ignore the line — pure keep-alive.
-			if _, err := w.Write([]byte(": heartbeat\n\n")); err != nil {
+			if err := sseWrite(rc, w, []byte(": heartbeat\n\n")); err != nil {
 				return
 			}
 			flusher.Flush()
@@ -105,13 +128,13 @@ func (s *Server) handleStreamLogs(w http.ResponseWriter, r *http.Request) {
 				s.logger.Warn("sse: marshal entry failed", zap.Error(err))
 				continue
 			}
-			if _, err := w.Write([]byte("data: ")); err != nil {
+			if err := sseWrite(rc, w, []byte("data: ")); err != nil {
 				return
 			}
-			if _, err := w.Write(data); err != nil {
+			if err := sseWrite(rc, w, data); err != nil {
 				return
 			}
-			if _, err := w.Write([]byte("\n\n")); err != nil {
+			if err := sseWrite(rc, w, []byte("\n\n")); err != nil {
 				return
 			}
 			flusher.Flush()

--- a/internal/server/logs_stream_handler.go
+++ b/internal/server/logs_stream_handler.go
@@ -36,6 +36,15 @@ const sseWriteTimeout = 30 * time.Second
 // (test doubles, middleware without deadline support) is treated as
 // best-effort: the write proceeds without a deadline rather than
 // failing the whole stream.
+//
+// Deadline lifetime: SetWriteDeadline persists on the underlying
+// net.Conn until reset or cleared.  We intentionally do not clear it
+// when the caller's loop exits — the connection is closed by the
+// http.Server on handler return, which releases any pending deadline
+// along with the socket.  A subsequent flusher.Flush() issued by the
+// caller runs under the most-recently-set deadline, which is the
+// desired behavior (a slow peer on Flush should still trip the
+// timeout rather than block indefinitely).  PR #182 review Low #2.
 func sseWrite(rc *http.ResponseController, w http.ResponseWriter, p []byte) error {
 	if err := rc.SetWriteDeadline(time.Now().Add(sseWriteTimeout)); err != nil &&
 		!errors.Is(err, http.ErrNotSupported) {

--- a/internal/server/logs_stream_handler_test.go
+++ b/internal/server/logs_stream_handler_test.go
@@ -88,3 +88,14 @@ func TestSSE_StreamsAppendedEntries(t *testing.T) {
 	require.NotEmpty(t, dataLine, "expected at least one data: frame")
 	assert.Contains(t, dataLine, `"hello-sse"`)
 }
+
+// Issue #179 Should-Fix #3: sseWrite must gracefully degrade when the
+// underlying ResponseWriter doesn't support SetWriteDeadline (test
+// doubles, middleware without deadline support).  ErrNotSupported must
+// not surface as a write failure — the write still proceeds.
+func TestSSEWrite_DeadlineUnsupportedStillWrites(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rc := http.NewResponseController(rec)
+	require.NoError(t, sseWrite(rc, rec, []byte("data: hello\n\n")))
+	assert.Equal(t, "data: hello\n\n", rec.Body.String())
+}


### PR DESCRIPTION
Addresses three of the four **Should-Fix** items explicitly listed in [#179](https://github.com/mkhomutov/Persatrix/issues/179) (RFC 0018 PR 4/5 review deferred residuals). The fourth Should-Fix — "incoming-message-rate cap on the LogService stream" — is explicitly deferred to the RFC 0009 (security/auth) hand-off per the issue text and is not in scope here.

Each fix is independent and self-contained; combined diff is **~140 lines across 7 files**, well under the BRANCHING.md 500-line soft cap.

## 1. logbuffer — reserve the cross-execution sentinel `_`

**Problem.** `crossExecutionToken = "_"` is used by the REST/SSE handlers as the "merged cross-execution view" path segment, but `executionIDPattern = ^[A-Za-z0-9_-]{1,128}$` happily matches a single underscore. A producer that `Append`s an entry with `ExecutionID="_"` creates a ring that is **unreachable** via REST/SSE (both handlers early-return on `"_"` and never call `Snapshot("_")` / `Subscribe("_")`).

**Fix.** Add a `reservedExecutionIDs` map consulted by `validExecutionID`; `_` now rejects at `Append` and surfaces as `DropInvalidID` with stats visibility. `crossExecutionToken` comment updated to reflect the reservation rather than claiming the pattern excludes it.

**Why this over renaming the sentinel to `__all__`?** Keeps CLI UX (`persatrix logs _ …`), REST URL examples in [docs/observability.md](docs/observability.md#121-snapshot-vs-follow), and every already-documented RFC/MT reference stable. The issue text explicitly allows either approach.

Regression test: `TestAppend_ReservedCrossExecutionTokenRejected` asserts `DropInvalidID`, zero `ActiveRings`, `Seal` error, nil `Snapshot`, and public `ValidExecutionID("_") == false`.

## 2. log_shipper — stop emitting epoch-zero on malformed timestamps

**Problem.** `_to_timestamp` silently left the proto `Timestamp` at its zero value (1970-01-01) when an RFC 3339 string failed to parse. That entry then sorted to the **front** of every chronological merge in `handleListLogs` and surfaced as the "next" event on every SSE stream — one malformed producer poisoned every viewer.

**Fix.** Widen `_to_timestamp` return to `(Timestamp, bool)`. On parse failure stamp `datetime.now(UTC)` and return `parse_error=True`; `record_to_proto` injects `timestamp_parse_error=true` into the attributes `Struct` so downstream consumers can distinguish stamped-now entries from well-formed ones. Unknown non-datetime/non-numeric types also get stamped-now to keep the entry chronologically sane.

Regression tests:

- `test_record_to_proto_malformed_timestamp_stamps_now_and_flags` — asserts stamped timestamp is within `[before, after]` wall-clock bounds and the attribute is set.
- `test_record_to_proto_valid_string_timestamp_no_flag` — asserts well-formed RFC 3339 parses cleanly and **no** attribute is added.

## 3. SSE — per-write deadline via `http.NewResponseController`

**Problem.** Each `w.Write(...)` in `handleStreamLogs` had no deadline; a stalled TCP peer pinned a subscriber slot indefinitely. With `MaxSubscribersDefault = 64`, ~64 dead clients could soft-deny the SSE endpoint.

**Fix.** New `sseWrite` helper sets a per-write deadline (`sseWriteTimeout = 30s`, wider than any heartbeat cadence to avoid tripping on transient pauses of healthy clients) via `http.NewResponseController(w).SetWriteDeadline(...)`. All four write sites (heartbeat + three-part data frame) route through it. `http.ErrNotSupported` (test doubles, middleware without deadline support) is treated as best-effort — the write proceeds without a deadline rather than failing the whole stream.

Regression test: `TestSSEWrite_DeadlineUnsupportedStillWrites` asserts the helper writes successfully through an `httptest.ResponseRecorder` (which returns `ErrNotSupported` from `SetWriteDeadline`). The existing `TestSSE_StreamsAppendedEntries` continues to exercise the success path end-to-end against a real `httptest.NewServer`.

## Test plan

```
go test ./internal/observability/logbuffer/... ./internal/server/... -count=1
→ ok ... logbuffer 0.926s
→ ok ... server     0.584s

pytest agents/tests/test_log_shipper.py -v
→ 8 passed

go vet ./internal/...          → clean
ruff check agents/observability/log_shipper.py agents/tests/test_log_shipper.py → clean
mypy agents/observability/log_shipper.py → Success: no issues found
```

## Scope / non-goals

- **Does not close #179.** The remaining 4th Should-Fix (gRPC ingest rate cap) is on the RFC 0009 hand-off list, and all Nice-to-Have / Nit items from that issue remain deferred. Tracker stays open.
- No changes to on-disk log layout, proto schema, CLI UX, or env-var knobs. Pure correctness / hardening.
- RFC 0018 is already `Implemented`; this lands against `main` as a correctness follow-up and does not re-open RFC status.

Closes part of #179.
