### PR TITLE
docs(mt-otel-001): align walkthrough with current stack + surface propagation gap

### DIFF
--- a/docs/manual-tests/MT-OTEL-001.md
+++ b/docs/manual-tests/MT-OTEL-001.md
@@ -2,7 +2,7 @@
 
 **Test ID**: `MT-OTEL-001`
 **Feature Area**: Observability (traces + metrics)
-**Version**: 1.0
+**Version**: 1.1
 **Created**: 2026-04-24
 **Last Updated**: 2026-04-24
 **Status**: Active
@@ -54,11 +54,17 @@ RFC 0019 closeout follow-up issue's Loki query-path item); per-agent dashboard /
 ### System Requirements
 
 - Docker + Docker Compose (the test exercises the compose-managed observability stack).
+- Current images. Run `docker compose build` before the first `docker compose up -d`, and after any
+  change under [agents/](../../agents/) or [cmd/orchestrator/](../../cmd/orchestrator/). Stale
+  images silently skip the OTEL SDK init path — Steps 3 and 4 then fail because no agent spans
+  reach Jaeger and no agent metrics reach Prometheus.
 - `ANTHROPIC_API_KEY` exported in the shell environment for the workflow-driven steps. Without it,
   the workflow reaches a terminal `failed` state quickly; trace lookups still work but do not
   exercise the LLM-call span path.
-- Free local ports: `:16686` (Jaeger UI), `:9090` (Prometheus UI), `:8080` (orchestrator REST),
-  `:4317` / `:4318` (OTLP intake).
+- Free local ports: `:16686` (Jaeger UI), `:9091` (Prometheus UI), `:8080` (orchestrator REST),
+  `:9090` (orchestrator gRPC), `:4317` / `:4318` (OTLP intake). Note: Prometheus is published on
+  host `9091` (mapped to container `9090`) because the orchestrator already owns host `:9090` for
+  gRPC — see [docker-compose.yaml](../../docker-compose.yaml) `prometheus.ports`.
 
 ### Test Data
 
@@ -79,16 +85,18 @@ docker compose ps
 ```
 
 **Expected**:
-- All services listed: `persatrix-orchestrator`, `persatrix-agent-*`, `jaeger`, `prometheus`,
-  `loki`, `otel-collector`.
-- `prometheus` and `loki` report `(healthy)`. `otel-collector` reports `Up …` (no healthcheck — the
-  upstream `otel/opentelemetry-collector-contrib` image is distroless and ships no probe binary;
-  this is documented as a deferred item in the RFC 0019 closeout).
+- All compose services listed: `orchestrator`, `agent-planner`, `agent-coder`, `agent-reviewer`,
+  `jaeger`, `prometheus`, `loki`, `otel-collector` (container names are project-prefixed, e.g.
+  `persatrix-orchestrator-1`).
+- `orchestrator`, agent services, `prometheus`, and `loki` report `(healthy)`. `otel-collector`
+  reports `Up …` (no healthcheck — the upstream `otel/opentelemetry-collector-contrib` image is
+  distroless and ships no probe binary; this is documented as a deferred item in the RFC 0019
+  closeout).
 
 **Verification**:
 - [ ] All compose services running
 - [ ] Jaeger UI reachable at <http://localhost:16686>
-- [ ] Prometheus UI reachable at <http://localhost:9090>
+- [ ] Prometheus UI reachable at <http://localhost:9091>
 
 ---
 
@@ -97,42 +105,70 @@ docker compose ps
 **Action**:
 
 ```pwsh
-$run = ./bin/persatrix run feature-builder --input '{"user_request":"Add a ping endpoint"}' --wait | ConvertFrom-Json
-$run.execution_id
+$output = ./bin/persatrix run feature-builder --input '{"user_request":"Add a ping endpoint"}'
+$run_id = ($output | Select-String 'run_id:\s*([0-9a-f-]+)').Matches.Groups[1].Value
+$run_id
+
+# Poll until the run reaches a terminal state (succeeded or failed).
+do {
+    Start-Sleep -Seconds 3
+    $status = ./bin/persatrix status $run_id
+    $status | Select-String 'Status:'
+} while ($status -match 'Status:\s*(pending|running)')
 ```
 
 **Expected**:
-- Exit code 0; the wrapper prints a JSON object containing `execution_id`. Terminal state may be
-  `succeeded` or `failed` depending on API key availability — both produce trace data.
+- `persatrix run` submits asynchronously and prints
+  `OK Workflow feature-builder submitted (run_id: <uuid>)` followed by `Status: pending` — plain
+  text, not JSON. The `run_id` parse above captures it.
+- Terminal state may be `succeeded` or `failed` depending on API key availability and workflow
+  execution — both produce trace data.
 
 **Verification**:
-- [ ] `execution_id` captured
+- [ ] `run_id` captured
+- [ ] Run reaches a terminal state (`succeeded` or `failed`)
 
 ---
 
 ### Step 3: Jaeger trace lookup by `persatrix.workflow_id`
 
+Service names are set via `OTEL_SERVICE_NAME`. The orchestrator ships as `persatrix-server`
+(docker-compose `orchestrator.environment`); the three agent containers share the Python default
+`persatrix-agent` (no per-agent override in compose today).
+
 **Action**:
 
 1. Open <http://localhost:16686>.
-2. Service: `persatrix-orchestrator`. Click **Find Traces**.
+2. Service: `persatrix-server`. Click **Find Traces**.
 3. In **Tags** add `persatrix.workflow_id=feature-builder` and re-run the search.
 4. Open the most recent trace. Inspect the span tree.
+5. Switch Service to `persatrix-agent` and confirm agent-side spans exist for the same time window
+   (see the known gap note below on why they may currently be in a separate trace).
 
 **Expected**:
-- The trace contains spans from both the orchestrator (`workflow.submit`, `workflow.run`,
-  `step.dispatch`, gRPC client) **and** at least one agent (`agent.persona.tick` /
-  `agent.event.dispatch`, `agent.memory.episodic.recall` and/or `agent.llm.call`).
-- The tree is connected (single root, no orphan service nodes) — confirming W3C TraceContext
-  propagated across the gRPC boundary.
+- The orchestrator trace contains `workflow.run`, `workflow.step`, and `agent.dispatch` spans,
+  all carrying `persatrix.workflow_id=feature-builder`.
+- An agent trace exists for the same time window with `/persatrix.v1.AgentService/ExecuteTask`
+  plus `agent.llm.call` (and, when exercised, `agent.tool.execute`, `agent.memory.episodic.recall`,
+  `agent.persona.tick`).
 - The LLM-call span (when the API key was present) carries the OTEL Gen-AI semantic-convention
   attributes: `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`,
   `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons` (a list, even when length 1).
 
 **Verification**:
-- [ ] Single connected trace tree
-- [ ] Both orchestrator and agent service nodes present
+- [ ] `persatrix-server` trace found by the `persatrix.workflow_id=feature-builder` tag filter
+- [ ] `persatrix-agent` trace visible for the same time window
 - [ ] `gen_ai.*` attributes present on the LLM-call span (when API key configured)
+
+> **Known gap — cross-process trace propagation (tracked in RFC 0019 closeout follow-up)**:
+> Agent spans currently land in a **separate** root trace instead of being stitched as children of
+> the orchestrator's `agent.dispatch` span. The Go client injects W3C TraceContext into gRPC
+> metadata via `otelgrpc.NewClientHandler()`, but the Python
+> `GrpcAioInstrumentorServer().instrument()` does not re-parent the incoming RPC to it — the
+> `ExecuteTask` server span has no parent reference. The test therefore verifies the two sides
+> independently (both services appear, correct spans and attributes) rather than a single
+> connected tree. Once the propagation bug is fixed, this step's verification flips back to
+> "single connected trace tree, both service nodes present."
 
 ---
 
@@ -140,17 +176,22 @@ $run.execution_id
 
 **Action**:
 
-1. Open <http://localhost:9090/graph>.
-2. Query: `histogram_quantile(0.95, sum by (le) (rate(agent_llm_duration_bucket[5m])))`.
+1. Open <http://localhost:9091/graph>.
+2. Query: `histogram_quantile(0.95, sum by (le) (rate(agent_llm_duration_milliseconds_bucket[5m])))`.
 3. Switch the panel to **Table** view, click **Show exemplars**.
 4. Click an exemplar dot; copy its `trace_id`.
 5. In Jaeger, paste the `trace_id` into the **Lookup by Trace ID** field at the top.
 
 **Expected**:
-- The exemplar resolves to a Jaeger trace whose root span belongs to the same workflow run.
-- The metric name reaches Prometheus in OTLP-translated form (underscores, no dots) — i.e.
-  `agent_llm_duration_bucket`, not `agent.llm.duration_bucket`. This is the documented
-  Collector → Prometheus exporter behaviour.
+- The exemplar resolves to a Jaeger trace. While the Step 3 known gap is outstanding the
+  exemplar will typically land in the agent-side trace (LLM spans emit the exemplar), not the
+  orchestrator trace.
+- The metric name reaches Prometheus in OTLP-translated form (underscores, no dots) **and** with
+  the unit suffix applied — i.e. `agent_llm_duration_milliseconds_bucket`, not
+  `agent.llm.duration_bucket` and not `agent_llm_duration_bucket`. The Collector's Prometheus
+  exporter appends `_milliseconds` because the OTLP metric declares unit `ms`; this is the
+  default behaviour (`add_metric_suffixes` is not disabled in
+  [config/observability/otel-collector.yaml](../../config/observability/otel-collector.yaml)).
 - If no exemplars are visible, confirm Prometheus was started with
   `--enable-feature=exemplar-storage` (the dev compose `prometheus` service `command:` block
   in [docker-compose.yaml](../../docker-compose.yaml) already enables it; forks pointing at
@@ -167,32 +208,35 @@ $run.execution_id
 
 **Action**:
 
-1. Submit one workflow that fails (omit `ANTHROPIC_API_KEY` for the orchestrator process or pass
-   an obviously invalid input):
+1. Submit one workflow that fails (pass an obviously invalid input — the orchestrator will fail
+   dispatch and mark the run `failed`):
 
    ```pwsh
-   ./bin/persatrix run feature-builder --input '{}' --wait | Out-Null
+   ./bin/persatrix run feature-builder --input '{}' | Out-Null
    ```
 
 2. Submit ~20 quick `feature-builder` runs back-to-back (or let an autonomous persona tick for a
    few minutes if one is configured). The healthy-tick policy samples 1 % of unmarked traces, so a
    handful of runs is enough to see the rule applied.
-3. In Jaeger search by `service=persatrix-orchestrator` over the last 15 minutes.
+3. In Jaeger search by `service=persatrix-server` over the last 15 minutes.
 
 **Expected**:
 - The error trace from sub-step 1 is **always retained** (matches the `errors` policy on
   `status_code: ERROR`).
-- Workflow-driven traces from sub-step 2 are **all retained** (the `workflow-traces` policy keeps
-  every trace carrying `persatrix.workflow_id`). This is by design — operators want full visibility
-  on user-driven runs.
-- If autonomous tick traces are present, they are sampled at ~1 % (the `healthy-tick-sample`
-  probabilistic policy). Ten ticks should produce roughly zero kept traces; a hundred should
-  produce roughly one.
+- Orchestrator-side traces from sub-step 2 are **all retained** (the `workflow-traces` policy
+  keeps every trace carrying `persatrix.workflow_id`; this attribute is currently set on
+  orchestrator spans — see Step 3's known gap for the agent side). This is by design — operators
+  want full visibility on user-driven runs.
+- Agent-side traces (the orphaned `persatrix-agent` traces from the Step 3 known gap) do **not**
+  carry `persatrix.workflow_id`, so they fall through to `healthy-tick-sample` and are retained
+  at ~1 %. This sampling behaviour is what we want long-term for autonomous tick traces; we
+  currently see it applied to workflow-driven agent traces as a side-effect of the propagation
+  bug.
 
 **Verification**:
-- [ ] Error trace visible in Jaeger
-- [ ] All workflow-tagged traces from sub-step 2 visible in Jaeger
-- [ ] (If autonomous ticks were running) tick-trace count in Jaeger ≪ ticks emitted
+- [ ] Error trace visible in Jaeger (`persatrix-server` service)
+- [ ] All workflow-tagged orchestrator traces from sub-step 2 visible in Jaeger
+- [ ] Agent-side (`persatrix-agent`) trace count in Jaeger ≪ workflow runs emitted
 
 ---
 
@@ -222,6 +266,10 @@ docker compose logs --tail=200 otel-collector | Select-String -Pattern "TracesEx
 
 - **Pass**: Steps 1–6 each meet their Verification checkboxes.
 - **Accepted-with-known-gap**:
+  - Cross-process trace propagation: agent spans land in a separate root trace from the
+    orchestrator (see Step 3 callout). Both sides are verified independently until the Python
+    `GrpcAioInstrumentorServer` re-parenting bug is fixed. Tracked in the RFC 0019 closeout
+    follow-up issue.
   - Loki LogQL `{trace_id="<id>"}` correlation may return zero matches against an unconfigured
     Loki 3.x OTLP receiver (`trace_id` lands as a structured-metadata field rather than a stream
     label). The cross-signal correlation is otherwise validated by Jaeger ↔ Prometheus exemplars
@@ -232,7 +280,7 @@ docker compose logs --tail=200 otel-collector | Select-String -Pattern "TracesEx
     drop the first batch (visible as a one-off non-zero `agent.observability.{spans,logs}.dropped`
     metric on first boot). Steady-state operation is unaffected. Tracked in the same follow-up
     issue.
-- **Fail**: Any step's Verification fails, or the Jaeger trace tree is not connected end-to-end.
+- **Fail**: Any step's Verification fails.
 
 ---
 


### PR DESCRIPTION
## Summary

Walked [docs/manual-tests/MT-OTEL-001.md](docs/manual-tests/MT-OTEL-001.md) end-to-end against a live `docker compose` stack. Five doc drifts and one real functional gap surfaced. This PR fixes the doc drifts and documents the functional gap as an "Accepted-with-known-gap" entry pointing at the RFC 0019 closeout follow-up; the code fix is out of scope.

### Doc fixes applied

| # | Step(s) | Before | After |
|---|---|---|---|
| 1 | Preconditions, 1, 4 | Prometheus UI on `:9090` | `:9091` (orchestrator owns host `:9090` for gRPC; compose maps `9091:9090`) |
| 2 | 2 | `--wait` flag + `ConvertFrom-Json` + `execution_id` | Async submit, plain-text output, `Select-String` parse of `run_id`, explicit poll loop |
| 3 | 3, 5 | `persatrix-orchestrator` as the Jaeger service name | `persatrix-server` (orchestrator) / `persatrix-agent` (agents), matching actual `OTEL_SERVICE_NAME` |
| 4 | 4 | `agent_llm_duration_bucket` in the histogram query | `agent_llm_duration_milliseconds_bucket` (OTLP unit `ms` → Prometheus `_milliseconds` suffix by default) |
| 5 | Preconditions | Jumped straight to `docker compose up -d` | Added "current images" precondition: `docker compose build` before first `up -d`, and after any change under `agents/` or `cmd/orchestrator/` |

### Known gap surfaced (not fixed in this PR)

Cross-process trace propagation is broken: the Go client injects W3C TraceContext via `otelgrpc.NewClientHandler()` v0.68.0, but the Python `GrpcAioInstrumentorServer` v0.62b0 in `agents/server.py` does not re-parent the incoming `/persatrix.v1.AgentService/ExecuteTask` — the agent-side trace starts with `parentRef=[]` and lands as a separate root. Step 3 now verifies both services independently, and the Pass/Fail section includes a prominent callout explaining the bug and how the verification flips back to "single connected trace tree" once it's fixed. Belongs with the RFC 0019 closeout follow-up issue.

### How the issues were found

A fresh `docker compose up -d` initially showed zero `persatrix-agent` spans in Jaeger and an empty Prometheus exporter endpoint. Root cause: agent images were built before the OTEL SDK was added to `agents/server.py` (342-line installed `server.py` vs 483-line source; `opentelemetry-instrumentation-grpc` and `opentelemetry-exporter-otlp-proto-http` missing from the container). `docker compose build --no-cache agent-*` fixed this — hence the new "current images" precondition. Post-rebuild the agent spans appear but don't re-parent, which is the remaining functional gap.

## Test plan

- [x] `docker compose up -d` and verify all services per the fixed Step 1
- [x] Step 2: CLI produces `run_id`, Select-String parse works, poll loop reaches terminal state
- [x] Step 3: `persatrix-server` tag-filter trace has `persatrix.workflow_id=feature-builder` spans; `persatrix-agent` trace has `agent.llm.call` with `gen_ai.*` attributes
- [x] Step 4: `agent_llm_duration_milliseconds_bucket` query returns data; exemplar `trace_id` resolves in Jaeger (the old `agent_llm_duration_bucket` query correctly returns `[]`)
- [x] Step 5: error trace and workflow-tagged orchestrator traces retained; agent-side count << workflow runs (side-effect of the known gap)
- [x] Step 6: no payload dumps in collector logs; `debug` absent from `service.pipelines.*`
- [x] `docs links` + `doc status` pre-commit checks pass