### PR TITLE
feat(docker): wire persona agent ember-owl into compose stack

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -13,8 +13,8 @@ RUN pip install --no-cache-dir agents/
 # Security: run as non-root to limit blast radius if agent code is compromised
 # (agents execute LLM-suggested actions and must be sandboxed).
 RUN useradd -r -s /bin/false appuser \
-    && mkdir -p /workspace \
-    && chown appuser:appuser /workspace
+    && mkdir -p /workspace /app/data \
+    && chown appuser:appuser /workspace /app/data
 USER appuser
 
 ENTRYPOINT ["python", "-m", "persatrix_agents.server"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -125,6 +125,36 @@ services:
       timeout: 5s
       retries: 3
 
+  # ─── Persona Agent: Ember Owl (v0.2+) ────────────
+  # Declared in config/agents.yaml as type: "persona". Shares the same
+  # Dockerfile.agent runtime as the task agents above; the persona tick
+  # loop + three-tier memory are selected by the agent's type field.
+  agent-ember-owl:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+    restart: unless-stopped
+    command: ["--agent", "ember-owl", "--port", "50054", "--host", "0.0.0.0", "--orchestrator-url", "http://orchestrator:8080", "--advertise-address", "agent-ember-owl:50054"]
+    ports:
+      - "50054:50054"
+    volumes:
+      - ./config:/app/config:ro
+      - workspace:/workspace
+      # Persona memory (SQLite) resolves `data/memory.db` relative to the
+      # container WORKDIR (/app). The non-root `appuser` cannot write to
+      # the baked /app/data, so mount a dedicated writable volume here.
+      - ember-owl-data:/app/data
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set — export it or add to .env}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    depends_on:
+      - orchestrator
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 50054), timeout=5); s.close()"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
   # ─── Observability: OpenTelemetry Collector ──────
   # RFC 0019 § H — central tail-sampling pipeline. Traces fan out to Jaeger,
   # metrics to Prometheus, logs to Loki. Reference config under
@@ -219,4 +249,9 @@ volumes:
   # disk-persisted sealed rings (PERSATRIX_LOGBUFFER_DIR). Separated
   # from `workspace` so it is not mounted into agent containers.
   orchestrator-data:
+    driver: local
+  # Persona memory SQLite store (ember-owl) — mounted at /app/data so the
+  # relative `db_path: data/memory.db` in config/agents.yaml resolves to a
+  # writable path for the non-root container user.
+  ember-owl-data:
     driver: local

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -71,8 +71,15 @@ services:
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set — export it or add to .env}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    # NOTE(review-PR188, N3): wait for orchestrator /healthz (healthcheck at
+    # line ~54) to pass before starting. Without `service_healthy`, a cold
+    # `compose up -d` may race the orchestrator's HTTP listener and the
+    # agent's first registration dial fails, logging a spurious reconnect
+    # cycle. Only gates initial startup — a post-startup orchestrator blip
+    # does not stop already-running agents (`restart: unless-stopped`).
     depends_on:
-      - orchestrator
+      orchestrator:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 50051), timeout=5); s.close()"]
       interval: 10s
@@ -94,8 +101,10 @@ services:
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set — export it or add to .env}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    # See agent-planner depends_on comment for rationale (PR188 N3).
     depends_on:
-      - orchestrator
+      orchestrator:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 50052), timeout=5); s.close()"]
       interval: 10s
@@ -117,8 +126,10 @@ services:
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set — export it or add to .env}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    # See agent-planner depends_on comment for rationale (PR188 N3).
     depends_on:
-      - orchestrator
+      orchestrator:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 50053), timeout=5); s.close()"]
       interval: 10s
@@ -139,16 +150,37 @@ services:
       - "50054:50054"
     volumes:
       - ./config:/app/config:ro
-      - workspace:/workspace
+      # NOTE(review-PR188, N1): `:ro` intentional. The ember-owl persona in
+      # config/agents.yaml declares `tools: [file_read, mcp:github]` but has
+      # NO `permissions.filesystem` block, so both PermissionGate.check
+      # ("filesystem:read") and PathValidator (empty allow_read) deny every
+      # file_read at the tool layer. The read-only mount is defense-in-depth
+      # in case a compromised MCP server bypasses the tool sandbox with raw
+      # Python I/O, and matches the code-reviewer service's pattern. If a
+      # future config grants the persona `permissions.filesystem.read`, this
+      # mount is already in place; only flip to rw if write access is also
+      # granted.
+      - workspace:/workspace:ro
       # Persona memory (SQLite) resolves `data/memory.db` relative to the
       # container WORKDIR (/app). The non-root `appuser` cannot write to
       # the baked /app/data, so mount a dedicated writable volume here.
+      #
+      # Ops note (review-PR188, N2): named-volume ownership is inherited
+      # from the image's target-dir owner ONLY on first creation. If an
+      # orphaned `persatrix_ember-owl-data` volume exists from a prior run
+      # (e.g. created before the /app/data chown in Dockerfile.agent, or
+      # hand-rolled with a different UID), Docker mounts it as-is and the
+      # SQLite init will fail with "unable to open database file" despite
+      # the Dockerfile fix. Recovery: `docker compose down && docker volume
+      # rm persatrix_ember-owl-data && docker compose up -d`.
       - ember-owl-data:/app/data
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:?ANTHROPIC_API_KEY must be set — export it or add to .env}
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+    # See agent-planner depends_on comment for rationale (PR188 N3).
     depends_on:
-      - orchestrator
+      orchestrator:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "python", "-c", "import socket; s = socket.create_connection(('localhost', 50054), timeout=5); s.close()"]
       interval: 10s


### PR DESCRIPTION
## Summary
- Add `agent-ember-owl` service to `docker-compose.yaml` so the v0.2 persona stack runs out of the box alongside the task agents (port 50054, same `Dockerfile.agent` runtime — persona behavior comes from `config/agents.yaml` `type: "persona"`).
- Fix a two-layer permission bug that prevented persona memory init on a fresh host:
  - `Dockerfile.agent` now pre-creates `/app/data` and `chown`s it to `appuser`, so the non-root user can write `data/memory.db` (resolved relative to WORKDIR `/app` by `agents/persona.py`).
  - A dedicated `ember-owl-data` named volume is mounted at `/app/data`, inheriting the image mountpoint ownership on first creation and persisting SQLite across restarts.
- Keep the persona memory volume separate from `workspace` so it is not visible to task agents.

Without these fixes the persona container booted but failed episodic/relationship memory init (`sqlite3.OperationalError: unable to open database file`), which silently removed it as a dispatch target — `persatrix chat ember-owl` would connect but get `Ember Owl did not respond`.

## Test plan
- [x] `docker compose build agent-ember-owl`
- [x] `docker compose up -d` on a host with no existing `persatrix_ember-owl-data` volume — verify the volume is created with `appuser:appuser` ownership and the container reaches `healthy`
- [x] `docker compose logs agent-ember-owl` shows memory migrations v1..v4 applied and tick scheduler active
- [x] `cli/target/release/persatrix chat ember-owl` round-trips a message (response visible in CLI; trace/log visible in Jaeger + Loki via the OTel Collector)
- [x] `docker compose down && docker compose up -d` — persona memory persists across restart
- [x] Existing task-agent services (`agent-planner`, `agent-coder`, `agent-reviewer`) still build and stay healthy