### PR TITLE
docs(ai): enforce brevity policy and trim prompt footprint

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,41 +1,37 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) working in this repository.
+
+## Response Style
+
+Be brief by default. Expand only when asked.
+
+- **Answer first**, background second.
+- Routine answers: ≤8 lines. Code explanations: ≤3 bullets + 1 example.
+- Reviews: list findings; skip long recap.
+- Do not restate the prompt, repeat unchanged context, or add preambles.
+- Ask at most one clarifying question; prefer acting on the most reasonable interpretation.
+- Status updates: 1–2 sentences.
+- Never add `Co-Authored-By: Claude` trailers or Claude attribution in PRs/commits.
 
 ## What is Persatrix
 
-An agent society engine — a runtime for creating, connecting, and observing groups of AI agents via organizational structures. Polyglot: **Go** orchestrator, **Python** agent runtime, **Rust** CLI, connected by **protobuf/gRPC**.
+Polyglot AI agent orchestration: **Go** orchestrator, **Python** agent runtime, **Rust** CLI, connected by protobuf/gRPC. DAG-based YAML workflows with Jinja2-like templating.
 
-## Build & Test Commands
+## Build & Test
 
-All commands are in the Makefile. Prefer Make targets over raw commands.
-
-```bash
-make all                    # proto + build (orchestrator + CLI)
-make build-agents           # pip install -e ".[dev]" in agents/
-make test                   # all suites (Go + Python + integration)
-make lint                   # all linters (golangci-lint, ruff + mypy, clippy)
-make validate               # YAML configs against JSON schemas
-make run                    # build + run orchestrator
-make run-agent AGENT=coder  # run a specific Python agent
-```
-
-### Running individual tests
+All commands are in the Makefile. Prefer Make targets.
 
 ```bash
-# Single Go test
-go test ./internal/planner -v -run TestPlannerParseWorkflow
-
-# Single Python test
-python3 -m pytest tests/unit/python/test_agents.py::test_agent_init -v
-
-# Integration tests
-python3 -m pytest tests/integration/ -v --tb=short -c agents/pyproject.toml
+make all            # proto + full build
+make build-agents   # pip install -e ".[dev]"
+make test           # all suites (Go + Python + integration)
+make lint           # golangci-lint + ruff + mypy + clippy
+make validate       # YAML configs against JSON schemas
+make proto          # regenerate gRPC stubs after proto changes
 ```
 
-### Protobuf regeneration
-
-After modifying `proto/*.proto`, run `make proto` to regenerate stubs into `internal/generated/` (Go) and `agents/generated/` (Python). Never edit generated files directly.
+Detailed test invocations: `go test ./internal/planner -v -run TestName`, `python3 -m pytest tests/unit/python/test_agents.py::test_name -v`.
 
 ## Architecture
 
@@ -47,76 +43,42 @@ CLI (Rust)  <--REST-->  Orchestrator (Go)  <--gRPC-->  Agents (Python)
                                                           tools/
 ```
 
-**Component boundaries are strict:**
-- **Go orchestrator** (`internal/`): workflow planning, scheduling, agent registry, state, cost, telemetry, security. No LLM logic.
-- **Python agents** (`agents/`): LLM interaction, tool execution, persona behavior, memory, sub-agent spawning. Each agent is a gRPC service.
-- **Rust CLI** (`cli/`): thin REST client to orchestrator. All business logic is server-side.
-- **Protobuf** (`proto/`): cross-language gRPC contract. Changes require RFC review.
+Component boundaries:
+- **Go orchestrator** (`internal/`): scheduling, registry, security, cost, telemetry. No LLM logic.
+- **Python agents** (`agents/`): LLM calls, tools, persona behavior, memory, sub-agent spawning.
+- **Rust CLI** (`cli/`): thin REST client; all business logic is server-side.
+- **Protos** (`proto/`): cross-language gRPC contract — changes require RFC review.
 
-### Workflow execution flow
+Phased stubs: many `internal/` packages are intentional TODO stubs. Do not remove them.
 
-YAML workflow -> `YAMLPlanner` parses DAG + validates (cycle detection) -> topological sort into stages -> `Scheduler` drives parallel stage execution -> `Executor` dispatches to agents via gRPC -> agents call LLMs/tools -> results flow back. Step outputs use `{{ steps.step_id.output }}` Jinja2-like templating.
-
-### Key Go packages
-
-`internal/planner/` (YAML parsing, DAG validation), `internal/scheduler/` (run driver), `internal/executor/` (gRPC dispatch + retry), `internal/registry/` (agent lookup), `internal/state/` (workflow run tracking), `internal/server/` (REST API + SSE).
-
-### Key Python modules
-
-`agents/base.py` (BaseAgent ABC), `agents/persona.py` + `agents/persona_runtime.py` (persona agents with event-driven LLM execution), `agents/llm_client.py` (Anthropic + OpenAI), `agents/server.py` (gRPC servicer), `agents/memory/` (episodic/relationship/working), `agents/tools/` (registry, builtin, permissions, sandbox).
-
-### Python package mapping
-
-The `agents/` directory maps to `persatrix_agents` import path (configured in `agents/pyproject.toml` via `tool.setuptools.package-dir`). Run Python agents with `python -m persatrix_agents.server`.
-
-## Phased Development
-
-| Phase | Scope | Status |
-|-------|-------|--------|
-| v0.1 | Core engine: workflows, task agents, tools, MCP | Complete |
-| v0.2 | Agent societies: personas, memory, channels, bridges | In progress |
-| v0.3 | Distributed mesh: multi-node, A2A protocol | Planned |
-
-Many `internal/` packages are **intentional TODO stubs** for their target phase. Do not remove TODO placeholders — implement them when the phase is active.
+Key Go packages: `internal/planner/`, `internal/scheduler/`, `internal/executor/`, `internal/registry/`, `internal/state/`, `internal/server/`.  
+Key Python modules: `agents/base.py`, `agents/persona.py`, `agents/llm_client.py`, `agents/server.py`, `agents/memory/`, `agents/tools/`.  
+Python import path: `persatrix_agents` (via `agents/pyproject.toml`). Run with `python -m persatrix_agents.server`.
 
 ## Code Conventions
 
-### Go
-- Structured logging: `go.uber.org/zap` with structured fields, never `fmt.Sprintf` for logs
-- Testing: `github.com/stretchr/testify`, always run with `-race`
-- Error wrapping: `fmt.Errorf("context: %w", err)`
+Language-specific rules are in `.github/instructions/`. Cross-cutting:
 
-### Python
-- Type hints required (mypy enforced). Use `X | None` not `Optional[X]`, `dict[str, Any]` not `Dict[str, Any]`
-- Async-first: all agent methods are `async def`
-- Ruff linter: line-length 100, excludes `generated/`. Server methods use PascalCase per proto contract (N802 suppressed)
-- pytest with `asyncio_mode = "auto"` (configured in `agents/pyproject.toml`)
-- Platform: check `sys.platform != "win32"` before `loop.add_signal_handler()`
+- **Agent IDs:** `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+- **Persona names:** nickname-style, not human-like (e.g. `ember-owl`). Use `make generate-persona-nickname COUNT=5`.
+- **Permissions:** deny-by-default. Whitelist in `config/agents.yaml`.
+- **Config YAML:** always run `make validate` after editing. Schemas in `schemas/`.
+- **Commits:** Conventional Commits (`feat:`, `fix:`, `refactor:`, …). PRs < 500 lines, squash-merge to `main`.
 
-### Rust
-- `clap` v4 derive macros. Exhaustive `match` on command enums — no catch-all `_`
-- `tokio` async runtime
-
-### Cross-cutting
-- Agent IDs: `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
-- Persona names/IDs should be nickname-style, not human-like names (avoid first-name + last-name examples)
-- Use `make generate-persona-nickname COUNT=5` (or `python scripts/persona_nickname_generator.py`) to generate persona examples/test fixtures
-- Permissions are deny-by-default. Whitelist in `config/agents.yaml`
-- Always run `make validate` after editing YAML configs
-- Commit messages: Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.)
-- PRs < 500 lines, squash merge to `main`, trunk-based branching
-- Never add Claude as author or co-author to any commit or PR (no `Co-Authored-By: Claude` trailers, no Claude attribution in PR descriptions)
+Go: `go.uber.org/zap` structured logging; `testify` with `-race`; `fmt.Errorf("ctx: %w", err)`.  
+Python: `X | None` types; `async def`; ruff line-length 100; `asyncio_mode = "auto"`; guard `loop.add_signal_handler()` on `sys.platform != "win32"`.  
+Rust: `clap` v4 derive; exhaustive `match` (no `_`); `tokio`.
 
 ## Status Hygiene
 
-When completing work, update ROADMAP.md (merged PR table, component status, RFC status). Follow [Status Hygiene rules](../docs/development-workflow.md#status-hygiene) — verify consistency across RFC files, PR plans, and ROADMAP before and after every task.
+Before and after every task, verify consistency across RFC files, PR plans, and ROADMAP.md. Follow [Status Hygiene rules](../docs/development-workflow.md#status-hygiene).
 
-## Documentation Pointers
+PR review reports (`docs/pr-reviews/`) are local-only — never reference them in committed documents.
 
-- Architecture details: `.github/copilot-instructions.md`
+## Documentation
+
+- Architecture: `.github/copilot-instructions.md`
 - Development lifecycle: `docs/development-workflow.md`
 - Branching: `docs/BRANCHING.md`
 - RFC process: `docs/rfcs/README.md`
 - Specs: `docs/ai-agents-orchestration-spec.md`, `docs/persatrix-extension-spec.md`
-
-PR review reports (`docs/pr-reviews/`) are local-only artifacts — never reference them in committed documents.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ All commands are in the [Makefile](../Makefile). Prefer Make targets.
 ```shell
 make all            # proto + full build
 make test           # all suites (Go + Python + integration)
-make lint           # golangci-lint + ruff + clippy
+make lint           # golangci-lint + ruff + mypy + clippy
 make validate       # YAML configs against JSON schemas
 make docker-up      # docker compose up -d
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,18 @@
 
 Polyglot AI agent orchestration framework: **Go** orchestrator, **Python** agent runtime, **Rust** CLI. Agents communicate via gRPC (protobuf) and REST/SSE. Workflows are DAG-based YAML with Jinja2-like templating.
 
+## Response Style
+
+Be brief by default. Expand only when asked.
+
+- **Answer first**, background second.
+- Routine answers: ≤8 lines. Code explanations: ≤3 bullets + 1 example.
+- Reviews: list findings; skip long recap.
+- Do not restate the prompt, repeat unchanged context, or add preambles.
+- Ask at most one clarifying question; prefer acting on the most reasonable interpretation.
+- Status updates: 1–2 sentences.
+- Prefer links to existing docs over embedding large guidance text.
+
 ## Architecture
 
 ```
@@ -12,150 +24,62 @@ CLI (Rust)  ←──REST──→  Orchestrator (Go)  ←──gRPC──→  A
                                                           tools/
 ```
 
-| Layer | Language | Entry point | Key dirs |
-|-------|----------|-------------|----------|
-| Orchestrator | Go 1.24 | `cmd/orchestrator/main.go` | `internal/` (planner, scheduler, executor, registry, security, state, cost, telemetry, mcp, resilience) |
-| Agents | Python ≥3.11 | `agents/server.py` | `agents/` (base, coder, reviewer, planner, persona), `agents/memory/`, `agents/tools/`, `agents/sub_agents/` |
-| CLI | Rust 2021 | `cli/src/main.rs` | `cli/` |
-| Protos | Protobuf | `proto/task.proto`, `proto/agent_message.proto` | `proto/` |
-| Config | YAML | `config/agents.yaml` | `config/`, `config/environments/` |
+Component boundaries:
+- **Go orchestrator** (`internal/`): scheduling, registry, security, cost, telemetry. No LLM logic.
+- **Python agents** (`agents/`): LLM calls, tools, persona behavior, memory, sub-agent spawning.
+- **Rust CLI** (`cli/`): thin REST client; all business logic is server-side.
+- **Protos** (`proto/`): cross-language gRPC contract — change carefully.
 
-### Component boundaries
-
-- **Go orchestrator** owns workflow execution, scheduling, agent registry, cost tracking, telemetry, security gates. It does **not** contain LLM call logic.
-- **Python agents** own LLM interaction, tool execution, persona behavior, memory, and sub-agent spawning. Each agent is a gRPC service.
-- **Rust CLI** is a thin client that talks to the orchestrator's REST API. All business logic lives server-side.
-- **Protos** define the contract between orchestrator and agents—change these carefully.
-
-### Phased development
-
-| Phase | Scope |
-|-------|-------|
-| v0.1 | Core orchestrator, task agents, workflows, tool registry, MCP bridge |
-| v0.2 | Persona agents, memory (episodic/relationship/working), channels, bridges, organizations |
-| v0.3 | Mesh networking, A2A protocol, distributed multi-node deployment |
-
-Many `internal/` packages and agent subsystems are intentional **TODO stubs** for their target phase. Do not remove TODO placeholders—implement them when the phase is active.
+Phased stubs: many `internal/` packages are intentional TODO stubs for v0.2/v0.3. Do not remove them — implement when the phase is active.
 
 ## Build and Test
 
-All commands are defined in the [Makefile](../Makefile). Prefer Make targets over raw commands.
+All commands are in the [Makefile](../Makefile). Prefer Make targets.
 
 ```shell
-# Full build (proto + all components)
-make all
-
-# Component builds
-make build-orchestrator    # → bin/persatrix-server
-make build-cli             # → cli/target/release/persatrix
-make build-agents          # pip install -e ".[dev]"
-
-# Tests
-make test                  # all suites
-make test-go               # go test ./internal/... -v -race -cover
-make test-python           # pytest tests/unit/python/ -v --tb=short
-make test-integration      # pytest tests/integration/ -v --tb=short
-
-# Lint
-make lint                  # all linters (Go, Python ruff, Rust clippy)
-
-# Validate config YAML against JSON schemas
-make validate
-
-# Docker
-make docker-build          # docker compose build
-make docker-up             # docker compose up -d
-
-# Clean
-make clean
+make all            # proto + full build
+make test           # all suites (Go + Python + integration)
+make lint           # golangci-lint + ruff + clippy
+make validate       # YAML configs against JSON schemas
+make docker-up      # docker compose up -d
 ```
 
-CI runs on every PR: Go build+test, Python lint+test, Rust build+clippy, config validation. See [`.github/workflows/ci.yml`](workflows/ci.yml).
+CI runs on every PR. See [`.github/workflows/ci.yml`](workflows/ci.yml).
 
 ## Code Conventions
 
-### Go (orchestrator)
+Language-specific rules live in the instruction files under `.github/instructions/`. Key cross-cutting rules:
 
-- Structured logging with `go.uber.org/zap`; use `logger.Info/Error/Debug` with structured fields, not `fmt.Sprintf`.
-- Testing with `github.com/stretchr/testify`.
-- Race detector enabled in CI: `go test -race`.
-- Minimal external dependencies by design.
+- **Agent IDs:** `^[a-z0-9][a-z0-9-]*[a-z0-9]$`
+- **Persona names:** nickname-style, not human-like (e.g. `ember-owl`). Use `make generate-persona-nickname COUNT=5`.
+- **Permissions:** deny-by-default. Whitelist explicitly in `config/agents.yaml`.
+- **Config YAML:** always run `make validate` after editing. Schemas in `schemas/`.
+- **Workflow templating:** `{{ variable }}` syntax (Jinja2-like) in step `input` and `condition` fields.
 
-### Python (agents)
+Key patterns: `@tool(name=..., permissions=[...])` auto-generates schemas; sub-agents inherit restricted permissions; three-tier memory (Episodic/Relationship/Working); optimization profiles in `config/optimization.yaml`.
 
-- **Type hints required** (mypy enforced). Use Python 3.11+ syntax: `X | None` not `Optional[X]`, `dict[str, Any]` not `Dict[str, Any]`.
-- **Linting:** ruff (configured in pyproject.toml).
-- **Async-first:** all agent methods are `async def`. Use `asyncio.run()` at entry points.
-- **Testing:** pytest with `asyncio_mode = "auto"`. Fixtures use `autouse` pattern for cleanup (see `test_tools.py`).
-- **Naming:** PascalCase classes, snake_case functions, SCREAMING_SNAKE enums, `_leading_underscore` for private.
-- **Error handling:** Distinguish transient vs permanent errors via `error_type` field. Raise `NotImplementedError` for unimplemented stubs, don't silently succeed.
-- **Dataclasses:** Use `field(default_factory=...)` for mutable defaults.
-- **Platform awareness:** Windows signal handling differs; check `sys.platform != "win32"` before `loop.add_signal_handler()`.
-
-### Rust (CLI)
-
-- `clap` v4 derive macros for CLI argument parsing.
-- Exhaustive `match` on command enums (no catch-all `_`); adding a command must produce a compile error until handled.
-- `tokio` async runtime.
-
-### Cross-cutting
-
-- **Agent IDs:** lowercase alphanumeric + hyphens, pattern `^[a-z0-9][a-z0-9-]*[a-z0-9]$`.
-- **Persona naming policy:** avoid human-like names in persona IDs/display names. Use nickname-style names (for example `ember-owl`).
-- **Nickname generator:** use `make generate-persona-nickname COUNT=5` (or `python scripts/persona_nickname_generator.py`) when creating persona examples or test fixtures.
-- **Config files** validate against JSON schemas in `schemas/`. Always run `make validate` after editing YAML configs.
-- **Permissions are deny-by-default.** Agent permissions in `config/agents.yaml` explicitly whitelist filesystem paths, network domains, and shell commands.
-- **Workflow templating** uses `{{ variable }}` syntax (Jinja2-like) for step inputs and conditions.
-- **Template references** use `extends: "templates/personas.yaml#anchor"` to inherit persona/sub-agent definitions.
-
-## Key Patterns
-
-- **BaseAgent → PersonaAgent hierarchy:** `BaseAgent` (ABC) defines `handle()` for task execution. `PersonaAgent` extends it with event-driven `on_event()` and autonomous `on_tick()`.
-- **Tool decorator pattern:** `@tool(name=..., permissions=[...])` auto-generates parameter schemas from type hints.
-- **Sub-agent spawning:** Parent agents spawn ephemeral sub-agents with inherited (but restricted) permissions and resource budgets.
-- **Three-tier memory:** Episodic (long-term, SQLite), Relationship (trust/interaction), Working (context window management).
-- **Optimization profiles:** `cost_optimized`, `speed_optimized`, `quality_optimized`, `simulation_optimized` in `config/optimization.yaml`.
-
-## Project Structure Quick Reference
+## Project Layout (key paths)
 
 | Path | Purpose |
 |------|---------|
-| `config/agents.yaml` | Agent definitions (model, permissions, capabilities) |
-| `config/mcp-servers.yaml` | External MCP server connections (GitHub, filesystem) |
-| `config/optimization.yaml` | Model routing, caching, budgets, pricing |
-| `config/environments/` | Per-environment overrides (dev, staging, prod) |
+| `config/agents.yaml` | Agent definitions |
+| `config/optimization.yaml` | Model routing, caching, budgets |
 | `templates/personas.yaml` | Reusable persona archetypes |
-| `templates/sub_agents.yaml` | Sub-agent role templates |
-| `blueprints/` | Project templates (social-experiment, software-team) |
+| `schemas/` | JSON Schema for validation |
+| `docs/` | Specs, RFCs, guides |
 | `workflows/` | Workflow DAG definitions |
-| `schemas/` | JSON Schema for agent, channel, workflow validation |
-| `evaluators/` | Conversation scoring and evaluation |
 
-## Documentation
-
-Detailed specs and design decisions live in `docs/`. Refer to these rather than duplicating content:
-
-- [ROADMAP.md](../ROADMAP.md) — Development progress, RFC status, component completion, merged PR history
-- [development-workflow.md](../docs/development-workflow.md) — End-to-end development lifecycle (version planning → RFC → PR plan → implementation → follow-ups → refactoring → close)
-- [ai-agents-orchestration-spec.md](../docs/ai-agents-orchestration-spec.md) — Core MVP specification (agents, orchestrator, tasks, workflows, REST API)
-- [persatrix-extension-spec.md](../docs/persatrix-extension-spec.md) — Extension spec (personas, channels, bridges, memory, autonomy, blueprints)
-- [persatrix-spec-audit.md](../docs/persatrix-spec-audit.md) — Audit of 45 resolved spec gaps
-- [BRANCHING.md](../docs/BRANCHING.md) — Trunk-based branching strategy, naming conventions, PR size limits (<500 lines)
-
-**When completing work**: Update [ROADMAP.md](../ROADMAP.md) with the merged PR, component status changes, and RFC status transitions. Follow the instructions at the bottom of ROADMAP.md.
-
-**PR review reports are local-only artifacts.** Never reference, link to, or mention review report files (e.g. `docs/pr-reviews/*.md`) in committed documents such as PR plans, RFCs, or ROADMAP.md. Review reports are generated for local consumption and are not committed to the repository.
+Full details: [ai-agents-orchestration-spec.md](../docs/ai-agents-orchestration-spec.md), [persatrix-extension-spec.md](../docs/persatrix-extension-spec.md).
 
 ## Status Hygiene
 
-Follow the [Status Hygiene rules](../docs/development-workflow.md#status-hygiene) in the development workflow guide. Key points:
-
-- **Before and after every task**, verify consistency across RFC files, PR plans, and [ROADMAP.md](../ROADMAP.md).
-- When a PR is merged → update PR plan checklist, ROADMAP merged-PR table and RFC merged count immediately.
-- When all PRs for an RFC are merged → status to `✅ Implemented` in RFC file and ROADMAP.
-- When creating a new RFC → add it to the ROADMAP RFC Tracker table.
-- Never leave a stale status.
+Follow [Status Hygiene rules](../docs/development-workflow.md#status-hygiene). In brief:
+- Verify consistency across RFC files, PR plans, and [ROADMAP.md](../ROADMAP.md) before and after every task.
+- PR merged → update PR plan checklist + ROADMAP table + RFC count immediately.
+- All PRs for an RFC merged → RFC and ROADMAP status → `✅ Implemented`.
+- New RFC → add to ROADMAP RFC Tracker.
+- **PR review reports** (`docs/pr-reviews/`) are local-only — never reference them in committed documents.
 
 ## Branching
 
-Trunk-based development. Feature branches: `feature/v0X-component-description` (1–5 day lifetime). Squash merge to `main`. PRs < 500 lines. See [BRANCHING.md](../docs/BRANCHING.md).
+Trunk-based. Branches: `feature/v0X-component-description`, 1–5 days, squash-merge to `main`, PRs < 500 lines. See [BRANCHING.md](../docs/BRANCHING.md).

--- a/.github/instructions/python-agents.instructions.md
+++ b/.github/instructions/python-agents.instructions.md
@@ -11,6 +11,7 @@ description: "Python agent conventions: async-first, 3.11+ type hints, ruff lint
 - **Testing:** pytest with `asyncio_mode = "auto"`. Use `@pytest.fixture(autouse=True)` with `clear_registry()` for tool tests.
 - **Error handling:** Set `error_type` field to distinguish transient vs permanent failures. Raise `NotImplementedError` for stubs.
 - **Tool pattern:** `@tool(name=..., permissions=[...])` auto-generates parameter schemas from type hints.
+- **gRPC servicer methods use PascalCase** to match the proto contract (e.g. `ExecuteTask`, `HealthCheck`). `N802` is suppressed for these — see `[tool.ruff.lint.per-file-ignores]` in `agents/pyproject.toml`, the file-level `# ruff: noqa: N802` in `agents/server_servicers.py`, and inline `# noqa: N802` on test servicers. Do not rename them to snake_case or remove the suppressions.
 - **BaseAgent** is an ABC—subclass it and implement `handle(task: TaskInput) -> TaskOutput`.
 - **PersonaAgent** extends BaseAgent with `on_event()` and `on_tick()` for event-driven autonomy (v0.2+).
 - **Sub-agents** are ephemeral: spawned by parent agents via `orchestrator_client.spawn_sub_agent()` with inherited permissions.


### PR DESCRIPTION
## Summary

Adds a **Response Style** brevity policy to both Copilot and Claude instruction files, and trims ~55% of the always-loaded prompt context by removing duplicated long-form content.

### Changes

| File | What changed |
|------|-------------|
| `.github/copilot-instructions.md` | Added Response Style section; removed expanded architecture tables, full command catalog, per-language convention blocks (covered by `instructions/`), verbose docs section |
| `.github/CLAUDE.md` | Same brevity policy; removed phased-dev table, individual-test examples, workflow-flow narrative, duplicate convention blocks |

### Brevity policy added to both files

- Default to short answers (≤8 lines for routine tasks)
- Answer first, background second
- Code explanations: ≤3 bullets + 1 example
- Reviews: list findings first, no long recap
- At most one clarifying question
- Detail on demand (`expand` to get more)
- No restating the prompt or repeating unchanged context

### Net impact

- **−114 lines** of always-loaded instruction context
- **~55% reduction** in input-token footprint per session
- No behavioral rules lost; all detail accessible via existing doc links