### PR TITLE
fix(agent): include prompts in image and configure audit log path

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -3,12 +3,18 @@ FROM python:3.12-slim
 
 WORKDIR /app
 COPY agents/ agents/
+COPY prompts/ prompts/
 # Fallback config for standalone builds (without docker-compose).
 # In compose, ./config is bind-mounted at /app/config:ro and shadows this copy.
 COPY config/ config/
 # Non-editable install: -e is a dev pattern that complicates layer caching
 # and adds no value in containers where source is already copied.
-RUN pip install --no-cache-dir agents/
+RUN pip install --no-cache-dir agents/ && \
+    # RFC 0009 PR 1b: copy prompts into site-packages where the installed package
+    # looks for them. The package resolves prompts relative to
+    # Path(__file__).parent.parent, which resolves to site-packages in
+    # non-editable installations.
+    cp -r prompts /usr/local/lib/python3.12/site-packages/
 
 # Security: run as non-root to limit blast radius if agent code is compromised
 # (agents execute LLM-suggested actions and must be sandboxed).

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -13,8 +13,11 @@ RUN pip install --no-cache-dir agents/ && \
     # RFC 0009 PR 1b: copy prompts into site-packages where the installed package
     # looks for them. The package resolves prompts relative to
     # Path(__file__).parent.parent, which resolves to site-packages in
-    # non-editable installations.
-    cp -r prompts /usr/local/lib/python3.12/site-packages/
+    # non-editable installations. SITE_PKGS is resolved at build time via
+    # sysconfig so the path stays correct when the base image is updated to a
+    # newer Python minor version (avoids hardcoding "python3.12").
+    SITE_PKGS=$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))') && \
+    cp -r prompts "$SITE_PKGS/"
 
 # Security: run as non-root to limit blast radius if agent code is compromised
 # (agents execute LLM-suggested actions and must be sandboxed).

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -3,20 +3,23 @@ FROM python:3.12-slim
 
 WORKDIR /app
 COPY agents/ agents/
-COPY prompts/ prompts/
 # Fallback config for standalone builds (without docker-compose).
 # In compose, ./config is bind-mounted at /app/config:ro and shadows this copy.
 COPY config/ config/
 # Non-editable install: -e is a dev pattern that complicates layer caching
 # and adds no value in containers where source is already copied.
-RUN pip install --no-cache-dir agents/ && \
-    # RFC 0009 PR 1b: copy prompts into site-packages where the installed package
-    # looks for them. The package resolves prompts relative to
-    # Path(__file__).parent.parent, which resolves to site-packages in
-    # non-editable installations. SITE_PKGS is resolved at build time via
-    # sysconfig so the path stays correct when the base image is updated to a
-    # newer Python minor version (avoids hardcoding "python3.12").
-    SITE_PKGS=$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))') && \
+# Layer ordering: pip install is intentionally placed before COPY prompts/ so
+# that editing prompt files does not bust the pip cache and force a full
+# package re-download on every CI rebuild.
+RUN pip install --no-cache-dir agents/
+
+# RFC 0009 PR 1b: copy prompts into site-packages where the installed package
+# looks for them. The package resolves prompts relative to
+# Path(__file__).parent.parent, which resolves to site-packages/ in
+# non-editable container installs (not the repo root). Placed after pip install
+# to keep the pip layer cache hot across prompt-only edits.
+COPY prompts/ prompts/
+RUN SITE_PKGS=$(python -c 'import sysconfig; print(sysconfig.get_path("purelib"))') && \
     cp -r prompts "$SITE_PKGS/"
 
 # Security: run as non-root to limit blast radius if agent code is compromised

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ Internal RFCs are the engineering planning tool. They do not drive version numbe
 | [0006](docs/rfcs/0006-efficiency-execution-limits.md) | Efficiency & Execution Limits | v0.2.0 | ✅ Implemented |
 | [0007](docs/rfcs/0007-conditional-looped-workflow-control-flow.md) | Conditional & Looped Workflow Control Flow | v0.3.0 | 📋 Proposed |
 | [0008](docs/rfcs/0008-agent-memory-context-optimization.md) | Agent Memory & Context Optimization | v0.3.0 | 🚧 Implementing |
-| [0009](docs/rfcs/0009-security-sandboxing.md) | Agent Identity, Security & Sandboxing | v0.3.0 (Phases 1–2) + v0.4.0 (Phases 3–4) | 🚧 Implementing ([#233](https://github.com/mkhomutov/Persatrix/pull/233) open — PR 1 audit logger + secret redactor) |
+| [0009](docs/rfcs/0009-security-sandboxing.md) | Agent Identity, Security & Sandboxing | v0.3.0 (Phases 1–2) + v0.4.0 (Phases 3–4) | 🚧 Implementing ([#233](https://github.com/mkhomutov/Persatrix/pull/233) open — PR 1 audit logger + secret redactor; [#235](https://github.com/mkhomutov/Persatrix/pull/235) open — prep: prompts in agent image + audit path in compose) |
 | 0010 | Sub-Agent Spawning | v0.4.0 | Not yet written |
 | [0011](docs/rfcs/0011-channels-bridges.md) | Channels + Bridges | v0.3.0 (internal) + v0.5.0 (external) | 🚧 Implementing |
 | 0012 | Protocols + Organizations | v0.4.0 (partial) + v0.5.0 (remainder) | Not yet written |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,8 +48,12 @@ services:
       # relative path and the non-root container has no writable CWD,
       # so leaving it unset disables the entire log-service surface.
       - PERSATRIX_LOGBUFFER_DIR=/var/lib/persatrix/logs
-      # RFC 0009 PR 1b: set audit logger path to the mounted volume to avoid
-      # permission denied errors when creating data/logs relative to /.
+      # RFC 0009 PR 1b prep: declare audit logger path on the mounted volume.
+      # The orchestrator does not yet consume this variable — wiring lands in
+      # feature/v030-rfc0009-audit-wiring (PR 1b). Setting it here ensures the
+      # path is stable and on the writable orchestrator-data volume before the
+      # wiring PR merges, and avoids a permission-denied error when audit.jsonl
+      # would otherwise be created relative to / by a non-root appuser.
       - OBSERVABILITY_AUDIT_PATH=/var/lib/persatrix/audit.jsonl
     depends_on:
       - otel-collector

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,9 @@ services:
       # relative path and the non-root container has no writable CWD,
       # so leaving it unset disables the entire log-service surface.
       - PERSATRIX_LOGBUFFER_DIR=/var/lib/persatrix/logs
+      # RFC 0009 PR 1b: set audit logger path to the mounted volume to avoid
+      # permission denied errors when creating data/logs relative to /.
+      - OBSERVABILITY_AUDIT_PATH=/var/lib/persatrix/audit.jsonl
     depends_on:
       - otel-collector
     healthcheck:


### PR DESCRIPTION
## Summary
- copy `prompts/` into the agent image and into site-packages after install so prompt resolution works in non-editable container installs
- set `OBSERVABILITY_AUDIT_PATH=/var/lib/persatrix/audit.jsonl` in compose to avoid permission errors when audit logging writes under `/`

## Files changed
- Dockerfile.agent
- docker-compose.yaml

## Validation
- pre-commit checks passed during commit (`go fmt`, `ruff check`, `cargo fmt`, doc checks, file size checks)
