### PR TITLE
docs(instructions): adopt TDD from v0.3.0 onward

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -83,8 +83,6 @@ Per-language details are in `.github/instructions/`. Key rules:
 - **Rust:** `#[cfg(test)]` unit tests inline; `cli/tests/` for CLI integration tests; mock HTTP with `mockito`.
 - **Integration tests** (`tests/integration/`) are exempt — write them after the unit layer validates the pieces.
 
-Detailed test invocations: `go test ./internal/planner -v -run TestName`, `python3 -m pytest tests/unit/python/test_agents.py::test_name -v`.
-
 ## Terminology
 
 Use the canonical terms in [`docs/ai-glossary.md`](../docs/ai-glossary.md) by

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -69,6 +69,22 @@ Go: `go.uber.org/zap` structured logging; `testify` with `-race`; `fmt.Errorf("c
 Python: `X | None` types; `async def`; ruff line-length 100; `asyncio_mode = "auto"`; guard `loop.add_signal_handler()` on `sys.platform != "win32"`.  
 Rust: `clap` v4 derive; exhaustive `match` (no `_`); `tokio`.
 
+## TDD (from v0.3.0 onward)
+
+All new unit-level code follows Red-Green-Refactor:
+
+1. Write a failing test first. Confirm it fails before writing the implementation.
+2. Write the minimum implementation to make it pass. Then refactor.
+3. **Do not** write production code without a corresponding failing test (unit layer only).
+
+Per-language details are in `.github/instructions/`. Key rules:
+- **Go:** failing `_test.go` before `*.go`; table-driven tests; interface mocks in `internal/testutil/`.
+- **Python:** failing pytest in `tests/unit/python/` first; mock `LLMClient` at the boundary; no real network calls.
+- **Rust:** `#[cfg(test)]` unit tests inline; `cli/tests/` for CLI integration tests; mock HTTP with `mockito`.
+- **Integration tests** (`tests/integration/`) are exempt — write them after the unit layer validates the pieces.
+
+Detailed test invocations: `go test ./internal/planner -v -run TestName`, `python3 -m pytest tests/unit/python/test_agents.py::test_name -v`.
+
 ## Terminology
 
 Use the canonical terms in [`docs/ai-glossary.md`](../docs/ai-glossary.md) by

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,6 +58,20 @@ Language-specific rules live in the instruction files under `.github/instruction
 
 Key patterns: `@tool(name=..., permissions=[...])` auto-generates schemas; sub-agents inherit restricted permissions; three-tier memory (Episodic/Relationship/Working); optimization profiles in `config/optimization.yaml`.
 
+## TDD (from v0.3.0 onward)
+
+All new unit-level code follows Red-Green-Refactor:
+
+1. Write a failing test first. Confirm it fails before writing the implementation.
+2. Write the minimum implementation to make it pass. Then refactor.
+3. **Do not** write production code without a corresponding failing test (unit layer only).
+
+Per-language details are in `.github/instructions/`. Key rules:
+- **Go:** failing `_test.go` before `*.go`; table-driven tests; interface mocks in `internal/testutil/`.
+- **Python:** failing pytest in `tests/unit/python/` first; mock `LLMClient` at the boundary; no real network calls.
+- **Rust:** `#[cfg(test)]` unit tests inline; `cli/tests/` for CLI integration tests; mock HTTP with `mockito`.
+- **Integration tests** (`tests/integration/`) are exempt — write them after the unit layer validates the pieces.
+
 ## Project Layout (key paths)
 
 | Path | Purpose |

--- a/.github/instructions/go-orchestrator.instructions.md
+++ b/.github/instructions/go-orchestrator.instructions.md
@@ -11,3 +11,12 @@ description: "Go orchestrator conventions: zap logging, testify tests, deny-by-d
 - Many `internal/` packages are TODO stubs for v0.2/v0.3. Implement the stub when its phase is active; don't remove the placeholder.
 - gRPC services defined in `proto/task.proto` and `proto/agent_message.proto`. Run `make proto` after changing `.proto` files.
 - Entry point flags: `--config` (dir), `--port` (gRPC 9090), `--http-port` (REST 8080), `--env` (development|staging|production).
+
+## TDD (from v0.3.0 onward)
+
+- **Red-Green-Refactor:** Write a failing `_test.go` file before writing the implementation. Commit the failing test separately if it clarifies intent.
+- **Test file placement:** `internal/foo/bar_test.go` alongside `bar.go`. Use `package foo_test` (black-box) unless you must access unexported symbols.
+- **Stub implementation:** When activating a previously-stubbed package, write the test against the expected interface first, confirm it fails (`go test ./internal/... -run TestFoo`), then implement.
+- **Table-driven tests:** Prefer `[]struct{ name, input, want }` table tests for functions with multiple input cases.
+- **Mocks:** Use interface mocks in `internal/testutil/` rather than concrete types. Do not add real network/gRPC calls in unit tests.
+- **Integration tests** (`tests/integration/`) are exempt from strict TDD — write them to validate assembled pieces after unit tests pass.

--- a/.github/instructions/go-orchestrator.instructions.md
+++ b/.github/instructions/go-orchestrator.instructions.md
@@ -16,7 +16,7 @@ description: "Go orchestrator conventions: zap logging, testify tests, deny-by-d
 
 - **Red-Green-Refactor:** Write a failing `_test.go` file before writing the implementation. Commit the failing test separately if it clarifies intent.
 - **Test file placement:** `internal/foo/bar_test.go` alongside `bar.go`. Use `package foo_test` (black-box) unless you must access unexported symbols.
-- **Stub implementation:** When activating a previously-stubbed package, write the test against the expected interface first, confirm it fails (`go test ./internal/... -run TestFoo`), then implement.
+- **Stub implementation:** When activating a previously-stubbed package, write the test against the expected interface first, confirm it fails (`go test ./internal/... -run TestFoo`), then implement. Replace the stub body in-place — do not delete and recreate the package (preserves the placeholder convention from the bullet above).
 - **Table-driven tests:** Prefer `[]struct{ name, input, want }` table tests for functions with multiple input cases.
-- **Mocks:** Use interface mocks in `internal/testutil/` rather than concrete types. Do not add real network/gRPC calls in unit tests.
+- **Mocks:** Use interface mocks in `internal/testutil/` (create the package on first use) rather than concrete types. Do not add real network/gRPC calls in unit tests.
 - **Integration tests** (`tests/integration/`) are exempt from strict TDD — write them to validate assembled pieces after unit tests pass.

--- a/.github/instructions/python-agents.instructions.md
+++ b/.github/instructions/python-agents.instructions.md
@@ -10,6 +10,15 @@ description: "Python agent conventions: async-first, 3.11+ type hints, ruff lint
 - **Linting:** ruff configured in `pyproject.toml`. Run `make lint` or `cd agents && ruff check .`.
 - **Testing:** pytest with `asyncio_mode = "auto"`. Use `@pytest.fixture(autouse=True)` with `clear_registry()` for tool tests.
 - **Error handling:** Set `error_type` field to distinguish transient vs permanent failures. Raise `NotImplementedError` for stubs.
+
+## TDD (from v0.3.0 onward)
+
+- **Red-Green-Refactor:** Add a failing test in `tests/unit/python/` before writing implementation code. Run `pytest tests/unit/python/test_<module>.py -v` to confirm the red state.
+- **Test file naming:** `tests/unit/python/test_<module>.py` mirrors `agents/<module>.py`. Component tests that need agent fixtures go in `agents/tests/`.
+- **One assert per logical case:** Prefer separate test methods over multi-assert blocks; failures pinpoint the broken behaviour immediately.
+- **Mocking LLM calls:** Always mock `LLMClient` at the boundary (`unittest.mock.AsyncMock`). Never let a unit test make real LLM or network calls.
+- **Async tests:** Mark with `@pytest.mark.asyncio` (or rely on `asyncio_mode = "auto"`). Do not use `asyncio.run()` inside tests.
+- **Integration tests** (`tests/integration/`) are exempt from strict TDD — write them after the unit layer validates the pieces.
 - **Tool pattern:** `@tool(name=..., permissions=[...])` auto-generates parameter schemas from type hints.
 - **gRPC servicer methods use PascalCase** to match the proto contract (e.g. `ExecuteTask`, `HealthCheck`). `N802` is suppressed for these — see `[tool.ruff.lint.per-file-ignores]` in `agents/pyproject.toml`, the file-level `# ruff: noqa: N802` in `agents/server_servicers.py`, and inline `# noqa: N802` on test servicers. Do not rename them to snake_case or remove the suppressions.
 - **BaseAgent** is an ABC—subclass it and implement `handle(task: TaskInput) -> TaskOutput`.

--- a/.github/instructions/python-agents.instructions.md
+++ b/.github/instructions/python-agents.instructions.md
@@ -10,6 +10,13 @@ description: "Python agent conventions: async-first, 3.11+ type hints, ruff lint
 - **Linting:** ruff configured in `pyproject.toml`. Run `make lint` or `cd agents && ruff check .`.
 - **Testing:** pytest with `asyncio_mode = "auto"`. Use `@pytest.fixture(autouse=True)` with `clear_registry()` for tool tests.
 - **Error handling:** Set `error_type` field to distinguish transient vs permanent failures. Raise `NotImplementedError` for stubs.
+- **Tool pattern:** `@tool(name=..., permissions=[...])` auto-generates parameter schemas from type hints.
+- **gRPC servicer methods use PascalCase** to match the proto contract (e.g. `ExecuteTask`, `HealthCheck`). `N802` is suppressed for these — see `[tool.ruff.lint.per-file-ignores]` in `agents/pyproject.toml`, the file-level `# ruff: noqa: N802` in `agents/server_servicers.py`, and inline `# noqa: N802` on test servicers. Do not rename them to snake_case or remove the suppressions.
+- **BaseAgent** is an ABC—subclass it and implement `handle(task: TaskInput) -> TaskOutput`.
+- **PersonaAgent** extends BaseAgent with `on_event()` and `on_tick()` for event-driven autonomy (v0.2+).
+- **Sub-agents** are ephemeral: spawned by parent agents via `orchestrator_client.spawn_sub_agent()` with inherited permissions.
+- **Platform awareness:** Guard `loop.add_signal_handler()` with `sys.platform != "win32"`.
+- **Dataclasses:** Use `field(default_factory=...)` for mutable defaults.
 
 ## TDD (from v0.3.0 onward)
 
@@ -19,10 +26,3 @@ description: "Python agent conventions: async-first, 3.11+ type hints, ruff lint
 - **Mocking LLM calls:** Always mock `LLMClient` at the boundary (`unittest.mock.AsyncMock`). Never let a unit test make real LLM or network calls.
 - **Async tests:** Mark with `@pytest.mark.asyncio` (or rely on `asyncio_mode = "auto"`). Do not use `asyncio.run()` inside tests.
 - **Integration tests** (`tests/integration/`) are exempt from strict TDD — write them after the unit layer validates the pieces.
-- **Tool pattern:** `@tool(name=..., permissions=[...])` auto-generates parameter schemas from type hints.
-- **gRPC servicer methods use PascalCase** to match the proto contract (e.g. `ExecuteTask`, `HealthCheck`). `N802` is suppressed for these — see `[tool.ruff.lint.per-file-ignores]` in `agents/pyproject.toml`, the file-level `# ruff: noqa: N802` in `agents/server_servicers.py`, and inline `# noqa: N802` on test servicers. Do not rename them to snake_case or remove the suppressions.
-- **BaseAgent** is an ABC—subclass it and implement `handle(task: TaskInput) -> TaskOutput`.
-- **PersonaAgent** extends BaseAgent with `on_event()` and `on_tick()` for event-driven autonomy (v0.2+).
-- **Sub-agents** are ephemeral: spawned by parent agents via `orchestrator_client.spawn_sub_agent()` with inherited permissions.
-- **Platform awareness:** Guard `loop.add_signal_handler()` with `sys.platform != "win32"`.
-- **Dataclasses:** Use `field(default_factory=...)` for mutable defaults.

--- a/.github/instructions/rust-cli.instructions.md
+++ b/.github/instructions/rust-cli.instructions.md
@@ -14,8 +14,8 @@ description: "Rust CLI conventions: clap v4 derive, exhaustive match, tokio asyn
 
 ## TDD (from v0.3.0 onward)
 
-- **Red-Green-Refactor:** Write a failing `#[test]` (or `#[tokio::test]`) before implementing the function. Confirm the red state with `cargo test -p persatrix-cli`.
+- **Red-Green-Refactor:** Write a failing `#[test]` (or `#[tokio::test]`) before implementing the function. Confirm the red state with `cargo test -p persatrix` (the package name in [`cli/Cargo.toml`](../../cli/Cargo.toml)) or simply `cargo test` from `cli/`.
 - **Unit test placement:** Inline `#[cfg(test)] mod tests { ... }` at the bottom of the source file being tested.
-- **Integration tests:** Place in `cli/tests/` as separate `.rs` files. These test CLI argument parsing and output formatting end-to-end without a live server (use a mock HTTP server or `mockito`).
-- **HTTP calls:** Mock the orchestrator REST API in unit tests — do not make real network calls. Inject the base URL via the `--server` flag or a test helper that binds `mockito`.
+- **Integration tests:** Place in `cli/tests/` (create the directory on first use) as separate `.rs` files. These test CLI argument parsing and output formatting end-to-end without a live server (use a mock HTTP server or `mockito`).
+- **HTTP calls:** Mock the orchestrator REST API in unit tests — do not make real network calls. Inject the base URL via the `--server` flag or a test helper that binds `mockito`. `mockito` is not currently declared in `cli/Cargo.toml`; add `mockito = "1"` to `[dev-dependencies]` on first use (matches the lazy-add pattern called out in that file's comments).
 - **New commands:** Before adding a `Command` variant, write at least one test that asserts the expected output format; implement until it passes.

--- a/.github/instructions/rust-cli.instructions.md
+++ b/.github/instructions/rust-cli.instructions.md
@@ -11,3 +11,11 @@ description: "Rust CLI conventions: clap v4 derive, exhaustive match, tokio asyn
 - **Thin client:** CLI is a REST client to the orchestrator at `--server` (default `http://localhost:8080`). All business logic lives server-side.
 - **Output:** `tabled` for tables, `indicatif` for progress bars, `colored` for terminal colors.
 - **YAML:** `serde_yml` (maintained successor to `serde_yaml`).
+
+## TDD (from v0.3.0 onward)
+
+- **Red-Green-Refactor:** Write a failing `#[test]` (or `#[tokio::test]`) before implementing the function. Confirm the red state with `cargo test -p persatrix-cli`.
+- **Unit test placement:** Inline `#[cfg(test)] mod tests { ... }` at the bottom of the source file being tested.
+- **Integration tests:** Place in `cli/tests/` as separate `.rs` files. These test CLI argument parsing and output formatting end-to-end without a live server (use a mock HTTP server or `mockito`).
+- **HTTP calls:** Mock the orchestrator REST API in unit tests — do not make real network calls. Inject the base URL via the `--server` flag or a test helper that binds `mockito`.
+- **New commands:** Before adding a `Command` variant, write at least one test that asserts the expected output format; implement until it passes.


### PR DESCRIPTION
## Summary

Adds a `## TDD` section to the three language-specific instruction files so that all new code written from v0.3.0 onward follows a Red-Green-Refactor cycle.

## Changes

| File | What was added |
|---|---|
| `go-orchestrator.instructions.md` | TDD section: failing `_test.go` first, table-driven tests, interface mocks in `internal/testutil/`, stub-activation workflow |
| `python-agents.instructions.md` | TDD section: failing pytest first, file naming convention, LLM mock strategy, async test rules |
| `rust-cli.instructions.md` | TDD section: `#[cfg(test)]` placement, integration test location, HTTP mock strategy, new-command checklist |
| `yaml-config.instructions.md` | **Unchanged** — schema-validated config has no unit-testable logic |

## Why not earlier?

The existing ~70 unit tests were written post-hoc. This PR codifies TDD as a **forward-looking** rule starting with v0.3.0 work — it does not require retrofitting existing tests.

## Integration tests exemption

Integration tests (`tests/integration/`) are explicitly exempt from the red-first rule. They validate assembled pieces after the unit layer passes and often require a running stack.
