### PR TITLE
docs(release): post-release follow-up for v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Persatrix is BUSL-1.1 licensed with no warranty. Use at your own risk
 | Version | What you can do | Status |
 |---------|------------------|--------|
 | **v0.2.x** | Run persistent personas with memory, chat with them from a terminal, observe everything end-to-end with traces and metrics | ✅ Released |
-| **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 🚧 Release prep |
+| **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | ✅ Released |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
 | **v0.6.0** | Run agent societies across multiple nodes and networks | 📋 Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-05-12
-> **Current phase**: v0.3.0 (Agent Conversations — RFCs 0008, 0009 P1–2, 0011 internal, 0020, 0021 P1, 0022) — 🚧 Release prep
-> **Current milestone**: release-prep PR 3 + PR 4 bundled as [#328](https://github.com/mkhomutov/Persatrix/pull/328) — version bump to `0.3.0` (`agents/pyproject.toml` + `cli/Cargo.toml` + `cli/Cargo.lock` + two Python OTEL `service.version` constants), curated `[0.3.0]` CHANGELOG section regenerated via `git cliff` (Highlights + 12-row Upgrade Notes hand-curated; PR-list body produced by the tool to match the v0.2.x precedent), and final pre-tag verification (`make validate / lint / test / proto / sanitizer parity` green; Docker smoke test covering channels publish-and-await + chat-as-DM + Jaeger trace tree + Prometheus exemplar + rate-limit 429 + audit chain; MT-MEMORY-005 baseline rerun with canonical 11-min idle gaps — Leg 1 improvement vs PR 1, 3 ✓ / 2 ✗ overall). Three in-tree regression fixes bundled (`THIRD_PARTY_NOTICES.md` regen, `pytest-timeout` license exception, `.gitattributes` `eol=lf` pins for `agents/generated/**` + `internal/generated/**` + `Path.write_text(newline='\n')` on the inline `_pb2_grpc.py` rewrite). After #328 merges, tag procedure per [release-checklist §5](docs/v0.3.0-release-checklist.md#5-tag-and-github-release-procedure) fires. Earlier release-prep milestones: PR 0 plan + RFC 0008 OQ #12 calibration-window walk-back ([#312](https://github.com/mkhomutov/Persatrix/pull/312)); PR 1 manual-test execution report ([#314](https://github.com/mkhomutov/Persatrix/pull/314), 26 ✅ + 1 ⚠️ + 1 🔵 Baseline); PR 2 README + ROADMAP + guide callouts + diagram refresh + release checklist ([#315](https://github.com/mkhomutov/Persatrix/pull/315)).
+> **Last updated**: 2026-05-12 (v0.3.0 released — post-release document update: ROADMAP v0.3.0 section flipped to Complete, Version Map row flipped to Released, prep-plan PRs 0/1/2/3/4 marked merged, release checklist finalised, test-findings PR plan closed, v0.3.0-plan Phase 4/5 closed, manual-tests README Execution Reports table refreshed)
+> **Current phase**: v0.3.0 (Agent Conversations — RFCs 0008, 0009 P1–2, 0011 internal, 0020, 0021 P1, 0022) — ✅ Released
+> **Current milestone**: v0.3.0 released ([tag v0.3.0](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.0) pushed 2026-05-12, GitHub Release "Agent Conversations" published the same day); v0.3.x planning next (RFCs 0023 / 0024 / 0026 / 0029 sequenced per [v0.3.x-sequencing.md](docs/v0.3.x-sequencing.md); F-3 root-cause fix tracked in [RFC 0031](docs/rfcs/0031-per-session-namespacing-channels.md)).
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -19,7 +19,7 @@ A version is ready when a developer can do something meaningful they could not d
 | **v0.2.1** | Talk to a persona agent from your terminal — the agent remembers you and responds in character | ✅ Complete — released |
 | **v0.2.2** | Bounded, predictable per-event memory injection for persona agents — structural fix unblocking RFC 0008 | ✅ Complete — released |
 | **v0.2.3** | Observability Foundation — logs + traces + metrics + correlation shipped together: structured JSON logs across Go/Python/CLI on a versioned schema, working `persatrix logs` CLI (with `--follow` and server-side filters), end-to-end OpenTelemetry traces from REST handler to LLM call (with OTEL Gen-AI semantic conventions), OTLP metrics with exemplars, W3C Baggage propagation, and a tail-sampling Collector pipeline. Combined deliverable of RFCs 0018 + 0019. | ✅ Complete — released |
-| **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | 🚧 Release prep |
+| **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | ✅ Complete — released |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
 | **v0.6.0** | Run agent societies across multiple nodes and networks | 📋 Planned |
@@ -425,7 +425,7 @@ v0.2.2 complete
 
 ---
 
-## v0.3.0 — Agent Conversations
+## v0.3.0 — Agent Conversations ✅ Complete
 
 **What a user can do**: Give agents a shared channel and watch them talk, negotiate, and form opinions about each other over time.
 
@@ -923,6 +923,7 @@ v0.5.0 complete
 | [#325](https://github.com/mkhomutov/Persatrix/pull/325) | docs(rfcs): RFC 0031 — per-session namespacing for channels + persona memory | 0031 (RFC) | 2026-05-12 |
 | [#326](https://github.com/mkhomutov/Persatrix/pull/326) | docs(rfcs): YAML front-matter + auto-generated INDEX.md | cross-RFC docs | 2026-05-12 |
 | [#327](https://github.com/mkhomutov/Persatrix/pull/327) | feat(persona): reply-discretion + conversational-pacing prompt snippets | cross-RFC persona | 2026-05-12 |
+| [#328](https://github.com/mkhomutov/Persatrix/pull/328) | chore(release): v0.3.0 — version bump + curated changelog + PR 4 pre-tag verification | v0.3.0 release prep | 2026-05-12 |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -99,7 +99,8 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | v0.2.0 | [v0.2-execution-report.md](v0.2-execution-report.md) | ✅ Complete |
 | v0.2.1 | [v0.2.1-execution-report.md](v0.2.1-execution-report.md) | ✅ Complete |
 | v0.2.2 | [v0.2.2-execution-report.md](v0.2.2-execution-report.md) | ✅ Complete |
-| v0.2.1 | [v0.2.1-execution-report.md](v0.2.1-execution-report.md) | ✅ Complete |
+| v0.2.3 | [v0.2.3-execution-report.md](v0.2.3-execution-report.md) | ✅ Complete |
+| v0.3.0 | [v0.3.0-execution-report.md](v0.3.0-execution-report.md) | ✅ Complete |
 
 ---
 

--- a/docs/v0.3.0-plan.md
+++ b/docs/v0.3.0-plan.md
@@ -1,8 +1,9 @@
 # v0.3.0 Plan — Agent Conversations
 
-**Status**: 🚧 In progress (this is PR 0)
-**Target version**: v0.3.0 (RFCs 0008, 0009 P1–2, 0011 internal, 0020, 0021 P1)
+**Status**: ✅ Complete (v0.3.0 released 2026-05-12 — GitHub Release "Agent Conversations" published from tag `v0.3.0`)
+**Target version**: v0.3.0 (RFCs 0008, 0009 P1–2, 0011 internal, 0020, 0021 P1, 0022)
 **Created**: 2026-04-25
+**Completed**: 2026-05-12
 **Branch prefix**: `feature/v030-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -72,9 +73,9 @@ Update this table as each step PR merges. Flip **Status** and add the GitHub PR 
 | 5 | 2 | RFC 0009 P1–2 implementation (per [0009-pr-plan.md](rfcs/0009-pr-plan.md)) | `feature/v030-rfc0009-…` | ✅ Merged | PR 1 [#233](https://github.com/mkhomutov/Persatrix/pull/233), PR 1b [#234](https://github.com/mkhomutov/Persatrix/pull/234), PR 1c [#236](https://github.com/mkhomutov/Persatrix/pull/236), PR 2 [#244](https://github.com/mkhomutov/Persatrix/pull/244), PR 3 [#253](https://github.com/mkhomutov/Persatrix/pull/253); PR 4 (this PR) | 2026-05-09 |
 | 6 | 2 | RFC 0011 implementation (per [0011-pr-plan.md](rfcs/0011-pr-plan.md)) | `feature/v030-rfc0011-…` | ✅ Merged | PRs 1–8 — PR 1 [#231](https://github.com/mkhomutov/Persatrix/pull/231), PR 2 [#245](https://github.com/mkhomutov/Persatrix/pull/245), PR 3 [#246](https://github.com/mkhomutov/Persatrix/pull/246), PR 4 split (4a-i [#248](https://github.com/mkhomutov/Persatrix/pull/248), 4a-ii-α [#249](https://github.com/mkhomutov/Persatrix/pull/249), 4a-ii-β-1 [#250](https://github.com/mkhomutov/Persatrix/pull/250), 4a-ii-β-2 [#251](https://github.com/mkhomutov/Persatrix/pull/251), 4b [#252](https://github.com/mkhomutov/Persatrix/pull/252)), PR 5 [#263](https://github.com/mkhomutov/Persatrix/pull/263) + follow-ups [#264](https://github.com/mkhomutov/Persatrix/pull/264) / [#265](https://github.com/mkhomutov/Persatrix/pull/265), PR 6 [#302](https://github.com/mkhomutov/Persatrix/pull/302), PR 7 [#303](https://github.com/mkhomutov/Persatrix/pull/303), PR 8 [#304](https://github.com/mkhomutov/Persatrix/pull/304) | 2026-05-09 |
 | 7 | 2 | RFC 0007 implementation (per [0007-pr-plan.md](rfcs/0007-pr-plan.md)) | `feature/v040-rfc0007-…` | ⏭ Deferred to v0.4.0 (retargeted 2026-05-06 — see [ROADMAP §v0.4.0](../ROADMAP.md#v040--agent-organizations) for rationale; PR plan stays as scaffold for v0.4.0 use) | — | — |
-| 8 | 3 | v0.3.0 release-prep plan | `feature/v030-release-prep-plan` | 🔀 PR open | — | — |
-| 9 | 4 | v0.3.0 release-prep execution (MT report → docs → version bump → final) | `feature/v030-release-prep-…` | ⬜ | — | — |
-| 10 | 5 | v0.3.0 tag + post-release follow-up | `feature/v030-post-release` | ⬜ | — | — |
+| 8 | 3 | v0.3.0 release-prep plan | `feature/v030-release-prep-plan` | ✅ Merged | [#312](https://github.com/mkhomutov/Persatrix/pull/312) | 2026-05-10 |
+| 9 | 4 | v0.3.0 release-prep execution (MT report → docs → version bump → final) | `feature/v030-release-prep-…` | ✅ Merged | PR 1 [#314](https://github.com/mkhomutov/Persatrix/pull/314), PR 2 [#315](https://github.com/mkhomutov/Persatrix/pull/315), PR 3 + PR 4 bundled [#328](https://github.com/mkhomutov/Persatrix/pull/328) | 2026-05-12 |
+| 10 | 5 | v0.3.0 tag + post-release follow-up | `feature/v030-post-release` | 🔀 PR open | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred
 

--- a/docs/v0.3.0-release-checklist.md
+++ b/docs/v0.3.0-release-checklist.md
@@ -1,6 +1,6 @@
 # v0.3.0 Release Checklist
 
-> **Status**: 🚧 In progress — gates filled in as the release-prep PRs land. Tag procedure runs after PR 4 of the [release-prep plan](v0.3.0-release-prep-plan.md) merges.
+> **Status**: ✅ Released — all gates green in PR 3 + PR 4 bundled as [#328](https://github.com/mkhomutov/Persatrix/pull/328); tag `v0.3.0` pushed on `main` 2026-05-12 per §5 below; GitHub Release "Agent Conversations" published the same day.
 
 > v0.3.0 — "Agent Conversations" — ships the combined deliverable of RFCs 0008 (memory facade + per-step context allocation), 0009 Phases 1–2 (audit + redactor + rate-limit + sanitization), 0011 internal scope (channels + DMs + threads + chat-as-DM façade + on-startup catch-up), 0020 (interaction lifecycle: open → multi-turn → close → summarize), 0021 Phase 1 (now-anchor + relative-time rendering), and 0022 (persona prompt section templating).
 
@@ -14,24 +14,24 @@
 
 All gates run on a clean checkout of the release-candidate commit, executed by PR 4 of the release-prep plan.
 
-- [ ] `make test` is green on a clean checkout (Go + Python + integration; record per-suite pass counts in PR 4)
-- [ ] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
-- [ ] `make validate` passes for all config files (including `config/channels.yaml` and the RFC 0009 audit + RFC 0008 packaging additions)
-- [ ] Proto staleness check passes: `make proto` then `git diff --exit-code` (gRPC `AgentService` surface in sync with [`proto/task.proto`](../proto/task.proto) — `ChannelMessageEvent` + `ReceiveChannelMessage` from RFC 0011 PR 3)
-- [ ] `make check-licenses` is clean for Go, Python, and Rust (Python check run against the project `.venv`, not the user-wide interpreter)
-- [ ] `make notices` regenerated and diffed: v0.3.0 channels-side new deps (Python aiohttp client, Go `internal/channels` packages, Rust CLI channel subcommands). Diff committed to [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) in PR 4
-- [ ] `make generate-sanitizer-patterns-check` passes — RFC 0009 PR 3 Go ↔ Python pattern parity gate
-- [ ] **MT-MEMORY-005 baseline** rerun on the docker-composed orchestrator at the release-candidate tip — per-leg outcome (Legs 1–5) recorded in [`docs/manual-tests/v0.3.0-execution-report.md`](manual-tests/v0.3.0-execution-report.md) as a baseline measurement (not a pass/fail gate)
-- [ ] Docker smoke test — channels surface is the v0.3.0 headline; sub-items:
-  - [ ] `make docker-build && make docker-up` brings up all nine services healthy
-  - [ ] Group-channel publish-and-await: `persatrix channel send --as <agent-A> <id> "ping"` produces an `<agent-B>` reply within the publish-and-await window
-  - [ ] DM round-trip: `POST /api/v1/agents/<agent>/chat` from `curl` → confirm chat-as-DM persona reply (JSON contract `chatResponse` shape preserved)
-  - [ ] `persatrix channel history <id>` returns the full ordered transcript including the agent reply
-  - [ ] `persatrix channel watch <id>` prints chronological lines, deduplicates across polls, and emits exactly one `FULL_PAGE_WARNING_TEXT` after a burst (suppressed on first poll)
-  - [ ] `GET /api/v1/cost/summary` shows channel-publish + dispatch line items
-  - [ ] Jaeger search by tag `persatrix.workflow_id=<your-workflow>` returns a connected trace tree spanning `channel.publish` → `channel.dispatch` → persona-runtime LLM call across `persatrix-server` + `persatrix-agent`
-  - [ ] A Prometheus histogram exemplar on the channel-publish span produces a `trace_id` that resolves in Jaeger
-  - [ ] Hit a known rate-limit overage to confirm 429 + `Retry-After` and the `rate_limit.violated` audit event
+- [x] `make test` is green on a clean checkout (Go + Python + integration; per-suite pass counts recorded in [#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
+- [x] `make validate` passes for all config files (including `config/channels.yaml` and the RFC 0009 audit + RFC 0008 packaging additions)
+- [x] Proto staleness check passes: `make proto` then `git diff --exit-code` (gRPC `AgentService` surface in sync with [`proto/task.proto`](../proto/task.proto) — `ChannelMessageEvent` + `ReceiveChannelMessage` from RFC 0011 PR 3)
+- [x] `make check-licenses` is clean for Go, Python, and Rust (Python check run against the project `.venv`, not the user-wide interpreter; `pytest-timeout` carries an `--exception` per [#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] `make notices` regenerated and diffed: v0.3.0 channels-side new deps (Python aiohttp client, Go `internal/channels` packages, Rust CLI channel subcommands). Diff committed to [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md) in [#328](https://github.com/mkhomutov/Persatrix/pull/328)
+- [x] `make generate-sanitizer-patterns-check` passes — RFC 0009 PR 3 Go ↔ Python pattern parity gate
+- [x] **MT-MEMORY-005 baseline** rerun on the docker-composed orchestrator at the release-candidate tip — per-leg outcome (Legs 1–5) recorded in [`docs/manual-tests/v0.3.0-execution-report.md`](manual-tests/v0.3.0-execution-report.md) as a baseline measurement (Leg 1 improvement vs PR 1, 3 ✓ / 2 ✗ overall)
+- [x] Docker smoke test — channels surface is the v0.3.0 headline; sub-items:
+  - [x] `make docker-build && make docker-up` brings up all nine services healthy
+  - [x] Group-channel publish-and-await: `persatrix channel send --as <agent-A> <id> "ping"` produces an `<agent-B>` reply within the publish-and-await window
+  - [x] DM round-trip: `POST /api/v1/agents/<agent>/chat` from `curl` → confirm chat-as-DM persona reply (JSON contract `chatResponse` shape preserved)
+  - [x] `persatrix channel history <id>` returns the full ordered transcript including the agent reply
+  - [x] `persatrix channel watch <id>` prints chronological lines, deduplicates across polls, and emits exactly one `FULL_PAGE_WARNING_TEXT` after a burst (suppressed on first poll)
+  - [x] `GET /api/v1/cost/summary` shows channel-publish + dispatch line items
+  - [x] Jaeger search by tag `persatrix.workflow_id=<your-workflow>` returns a connected trace tree spanning `channel.publish` → `channel.dispatch` → persona-runtime LLM call across `persatrix-server` + `persatrix-agent`
+  - [x] A Prometheus histogram exemplar on the channel-publish span produces a `trace_id` that resolves in Jaeger
+  - [x] Hit a known rate-limit overage to confirm 429 + `Retry-After` and the `rate_limit.violated` audit event
 
 > The live evidence captured during PR 1's MT execution report ([`docs/manual-tests/v0.3.0-execution-report.md`](manual-tests/v0.3.0-execution-report.md)) is the baseline for the Docker smoke-test row. PR 4 reruns the channels + chat-as-DM + Jaeger paths on the post-version-bump tip to certify the release-candidate commit.
 
@@ -50,11 +50,11 @@ Before tagging, all shipped components must declare `0.3.0` consistently.
 
 Checklist (filled in by release-prep plan PR 3):
 
-- [ ] `agents/pyproject.toml` updated to `0.3.0` (PR 3)
-- [ ] `cli/Cargo.toml` updated to `0.3.0` (PR 3)
-- [ ] `cli/Cargo.lock` regenerated and committed (PR 3)
-- [ ] `make all` builds successfully with the new versions (verified on PR 3; re-verified on the PR 4 candidate)
-- [ ] No docs or examples still describe v0.3.0 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist all flipped in PR 4)
+- [x] `agents/pyproject.toml` updated to `0.3.0` ([#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] `cli/Cargo.toml` updated to `0.3.0` ([#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] `cli/Cargo.lock` regenerated and committed ([#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] `make all` builds successfully with the new versions (verified on the bundled PR 3 + PR 4 in [#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] No docs or examples still describe v0.3.0 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist all flipped in the post-release follow-up PR)
 
 ---
 
@@ -64,10 +64,10 @@ The release changelog must preserve the curated `[0.2.3]`, `[0.2.2]`, `[0.2.1]`,
 
 Checklist:
 
-- [ ] `CHANGELOG.md` contains a `[0.3.0]` section (PR 3)
-- [ ] The existing curated `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
-- [ ] The seeded operator-visible text from the `[Unreleased]` section is preserved verbatim, moved under an Upgrade Notes subsection (see §3.1 below)
-- [ ] The `[0.3.0]` section includes:
+- [x] `CHANGELOG.md` contains a `[0.3.0]` section ([#328](https://github.com/mkhomutov/Persatrix/pull/328))
+- [x] The existing curated `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
+- [x] The seeded operator-visible text from the `[Unreleased]` section is preserved verbatim, moved under an Upgrade Notes subsection (see §3.1 below)
+- [x] The `[0.3.0]` section includes:
   - **Highlights**: internal channels with DMs/groups/threads, `persatrix channel` CLI, chat-as-DM façade, interaction-bounded episodic memory, persona temporal awareness Phase 1, per-step context-budget allocation via `MemoryFacade`, security hardening Phases 1–2, externally inspectable persona prompt sections
   - **Features**: RFC 0008 PRs 1–6 (#218–#225, #227–#228, plus the close-out PR), RFC 0009 PRs 1/1b/1c/2/3/4 (#233, #234, #236, #244, #253, #306), RFC 0011 internal-scope PRs 1–8 (#231, #245, #246, #248–#252, #263–#265, #302–#304), RFC 0020 PRs 1–7 (#214–#216, #229, #262, #266→#301, #305), RFC 0021 P1 PRs 1–3 + follow-up (#256, #260, #261, #267), RFC 0022
   - **Bug fixes**: ISSUE-0001 through ISSUE-0050 closures, channels response-gate cascade fix (release-prep PR 1), `.gitattributes` LF pin for Windows checkouts (release-prep PR 1)
@@ -152,7 +152,7 @@ Checklist:
 - [x] `MT-COST-002` accepted-with-known-gap is carried forward with the same deferral rationale (no budget-enforcement changes in v0.3.0)
 - [x] `MT-LOGS-001` Step 4 (seal-on-completion warm-load gap) remains footnoted as an RFC 0018 PR 7 follow-up
 - [x] `MT-MEMORY-005` Leg 1 fail is documented as the canonical dementia-gap signature motivating [RFC 0026 facts tier](rfcs/0026-declarative-facts-tier.md) (v0.3.1) — not a v0.3.0 regression
-- [ ] Release-prep PR 4 reruns the headline channels + chat-as-DM + Jaeger paths on the post-version-bump release-candidate tip and appends the evidence to the execution report
+- [x] Release-prep PR 4 reruns the headline channels + chat-as-DM + Jaeger paths on the post-version-bump release-candidate tip and appends the evidence to the execution report (bundled into [#328](https://github.com/mkhomutov/Persatrix/pull/328))
 
 ---
 
@@ -169,10 +169,10 @@ git push origin v0.3.0
 
 GitHub Release checklist (post-merge manual steps after PR 4 merges):
 
-- [ ] Create the GitHub Release from tag `v0.3.0`
-- [ ] Use the curated `[0.3.0]` changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body — link the MT-MEMORY-005 baseline pointer to [RFC 0026](rfcs/0026-declarative-facts-tier.md) as the v0.3.1 fix path
+- [x] Create the GitHub Release from tag `v0.3.0`
+- [x] Use the curated `[0.3.0]` changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body — link the MT-MEMORY-005 baseline pointer to [RFC 0026](rfcs/0026-declarative-facts-tier.md) as the v0.3.1 fix path
 - [ ] Attach binaries or container references if produced for this release
 
 ---
@@ -235,25 +235,25 @@ These items remain intentionally incomplete and should be described as deferred 
 Single-page go/no-go gate. All items must be checked before tagging.
 
 ```text
-[ ] make test is green on a clean checkout
-[ ] make lint is clean
-[ ] make validate passes (incl. config/channels.yaml + audit + packaging configs)
-[ ] make proto then git diff --exit-code shows no generated drift
-[ ] make check-licenses passes
-[ ] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
-[ ] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
-[ ] agents/pyproject.toml updated to 0.3.0
-[ ] cli/Cargo.toml updated to 0.3.0
-[ ] cli/Cargo.lock regenerated and committed
-[ ] make all builds successfully
-[ ] CHANGELOG.md contains a curated [0.3.0] section with upgrade notes
-[ ] Existing [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
+[x] make test is green on a clean checkout
+[x] make lint is clean
+[x] make validate passes (incl. config/channels.yaml + audit + packaging configs)
+[x] make proto then git diff --exit-code shows no generated drift
+[x] make check-licenses passes
+[x] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
+[x] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
+[x] agents/pyproject.toml updated to 0.3.0
+[x] cli/Cargo.toml updated to 0.3.0
+[x] cli/Cargo.lock regenerated and committed
+[x] make all builds successfully
+[x] CHANGELOG.md contains a curated [0.3.0] section with upgrade notes
+[x] Existing [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
 [x] All 28 manual tests recorded in docs/manual-tests/v0.3.0-execution-report.md (release-prep PR 1)
 [x] No unresolved Fail in manual tests
 [x] MT-MEMORY-005 baseline measurement recorded with per-leg notes (Leg 1 fail documented as the v0.3.1 RFC 0026 motivator)
-[ ] MT-MEMORY-005 baseline rerun on the post-version-bump release-candidate tip (release-prep PR 4)
-[ ] Known gaps documented for release notes (§6 above)
-[ ] Docker smoke test passes (channels publish-and-await + chat-as-DM + Jaeger trace tree + Prometheus exemplar click-through + cost summary + rate-limit overage)
-[ ] git tag v0.3.0 created and pushed (post-merge manual step)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (post-merge manual step)
+[x] MT-MEMORY-005 baseline rerun on the post-version-bump release-candidate tip (bundled into #328)
+[x] Known gaps documented for release notes (§6 above)
+[x] Docker smoke test passes (channels publish-and-await + chat-as-DM + Jaeger trace tree + Prometheus exemplar click-through + cost summary + rate-limit overage)
+[x] git tag v0.3.0 created and pushed (2026-05-12)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (2026-05-12 — "Agent Conversations")
 ```

--- a/docs/v0.3.0-release-prep-plan.md
+++ b/docs/v0.3.0-release-prep-plan.md
@@ -1,8 +1,9 @@
 # v0.3.0 Release Preparation Plan
 
-**Status**: 🔀 PR open (this is PR 0)
+**Status**: ✅ Complete (all 5 PRs merged; PR 3 + PR 4 bundled as [#328](https://github.com/mkhomutov/Persatrix/pull/328); `v0.3.0` tag pushed 2026-05-12, GitHub Release "Agent Conversations" published the same day)
 **Target version**: v0.3.0 (Agent Conversations — RFCs 0008, 0009 P1–2, 0011 internal, 0020, 0021 P1, 0022)
 **Created**: 2026-05-10
+**Completed**: 2026-05-12
 **Branch prefix**: `feature/v030-release-prep-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -33,11 +34,11 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 
 | PR | Track | Title | Branch | Status | GitHub PR | Merged |
 |----|-------|-------|--------|--------|-----------|--------|
-| 0 | — | v0.3.0 release prep plan (this document) | `feature/v030-release-prep-plan` | 🔀 PR open | — | — |
-| 1 | A | Manual test execution report (v0.3.0 surface) | `feature/v030-release-prep-mt-exec` | ⬜ | — | — |
-| 2 | A | README + ROADMAP + persona/channels guide refresh + diagram pass + release checklist | `feature/v030-release-prep-docs` | ⬜ | — | — |
-| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v030-release-prep-version-bump` | ⬜ | — | — |
-| 4 | B | Final pre-tag verification & release notes | `feature/v030-release-prep-final` | ⬜ | — | — |
+| 0 | — | v0.3.0 release prep plan (this document) | `feature/v030-release-prep-plan` | ✅ Merged | [#312](https://github.com/mkhomutov/Persatrix/pull/312) | 2026-05-10 |
+| 1 | A | Manual test execution report (v0.3.0 surface) | `feature/v030-release-prep-mt-exec` | ✅ Merged | [#314](https://github.com/mkhomutov/Persatrix/pull/314) | 2026-05-10 |
+| 2 | A | README + ROADMAP + persona/channels guide refresh + diagram pass + release checklist | `feature/v030-release-prep-docs` | ✅ Merged | [#315](https://github.com/mkhomutov/Persatrix/pull/315) | 2026-05-10 |
+| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v030-release-prep-version-bump` | ✅ Merged | [#328](https://github.com/mkhomutov/Persatrix/pull/328) (bundled with PR 4) | 2026-05-12 |
+| 4 | B | Final pre-tag verification & release notes | `feature/v030-release-prep-final` | ✅ Merged | [#328](https://github.com/mkhomutov/Persatrix/pull/328) (bundled with PR 3) | 2026-05-12 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 

--- a/docs/v0.3.0-test-findings-pr-plan.md
+++ b/docs/v0.3.0-test-findings-pr-plan.md
@@ -5,7 +5,7 @@
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
 
-> **Status**: Draft. Further PRs may be appended as testing continues to surface additional defects.
+> **Status**: ✅ Complete — all 6 PRs merged before the v0.3.0 tag. PR 1 [#318](https://github.com/mkhomutov/Persatrix/pull/318), PR 2 [#319](https://github.com/mkhomutov/Persatrix/pull/319), PR 3 [#321](https://github.com/mkhomutov/Persatrix/pull/321), PR 4 [#322](https://github.com/mkhomutov/Persatrix/pull/322), PR 5 [#323](https://github.com/mkhomutov/Persatrix/pull/323), PR 6 [#324](https://github.com/mkhomutov/Persatrix/pull/324). F-3 root-cause fix (per-session memory namespacing) carried forward as [RFC 0031](rfcs/0031-per-session-namespacing-channels.md); Future-PRs list below is the v0.3.x carry-over backlog.
 
 ---
 


### PR DESCRIPTION
## Summary

Doc-only sweep that mirrors [#192](https://github.com/mkhomutov/Persatrix/pull/192) (v0.2.3) for v0.3.0. The `v0.3.0` tag was pushed on `main` 2026-05-12 and the GitHub Release "Agent Conversations" was published the same day, but several docs still described v0.3.0 as in-progress work. This PR closes that gap.

- **README.md**: roadmap row v0.3.0 → ✅ Released
- **ROADMAP.md**: "Last updated" refreshed; "Current phase" → ✅ Released; "Current milestone" trimmed to a short post-tag note pointing at [v0.3.x-sequencing.md](docs/v0.3.x-sequencing.md) and [RFC 0031](docs/rfcs/0031-per-session-namespacing-channels.md); Version Map row v0.3.0 → ✅ Complete — released; §v0.3.0 section header → ✅ Complete; #328 appended to Merged PR History
- **docs/v0.3.0-release-prep-plan.md**: top Status → ✅ Complete; Completed: 2026-05-12; all five PRs marked ✅ Merged (PR 0 #312 / PR 1 #314 / PR 2 #315 / PR 3 + PR 4 bundled as #328)
- **docs/v0.3.0-release-checklist.md**: top Status → ✅ Released; every §1 pre-release-verification gate, §2 version-alignment gate, §3 changelog gate, §4 PR 4 rerun row, §5 GitHub Release procedure item, and §7 summary-checklist gate ticked. "Attach binaries" row intentionally left unchecked (none produced) — matches the v0.2.3 precedent
- **docs/v0.3.0-plan.md**: top Status → ✅ Complete; Master Progress Overview rows 8 + 9 → ✅ Merged with PR links; row 10 (this PR) → 🔀 PR open
- **docs/v0.3.0-test-findings-pr-plan.md**: top Status → ✅ Complete with the six test-findings PRs rolled up (#318/#319/#321/#322/#323/#324); F-3 root-cause carried forward as RFC 0031
- **docs/manual-tests/README.md**: Execution Reports table — replace duplicate v0.2.1 row with v0.2.3, add v0.3.0 row, both ✅ Complete

No code changes. No tests affected.

## Test plan

- [x] \`make validate\` passes
- [x] \`python3 scripts/checks/doc_links.py\` passes (2500 links across 219 files)
- [x] \`python3 scripts/checks/file_size.py\` passes
- [x] Pre-commit hooks: filemap, go fmt, ruff, cargo fmt, doc links, doc status, file size — 7/7 passed
- [x] Tag \`v0.3.0\` verified present on remote (\`git ls-remote --tags origin\`)
- [x] GitHub Release "Agent Conversations" verified published (\`gh release view v0.3.0\`)