### PR TITLE
feat(v031): RFC 0026 PR 5d — PR 3 review tests + counter polish

### DIFF
--- a/agents/observability/_metrics_facts.py
+++ b/agents/observability/_metrics_facts.py
@@ -89,8 +89,9 @@ def register(inst: _Instruments, meter: Meter) -> None:
     # shipped per-turn tier provenance as the in-process
     # ``MemoryBudget.admissions_by_tier`` registry (read by the
     # reinforcement write), not an OTEL attribute join, so no sibling
-    # counter carries ``tier=`` yet; a reader should treat the
-    # attribute as a placeholder, not a live dimension, until a
+    # counter carries ``tier=`` yet.  ``tier`` is exported on every
+    # increment but is a constant, single-valued attribute — it
+    # carries no cardinality and has no join partner until a
     # dashboard promotes the registry to OTEL.
     inst.facts_injected = meter.create_counter(
         name="agent.facts.injected",

--- a/agents/observability/_metrics_facts.py
+++ b/agents/observability/_metrics_facts.py
@@ -84,15 +84,20 @@ def register(inst: _Instruments, meter: Meter) -> None:
     # RFC 0026 PR 3 — facts-tier admission counter.  Increments per
     # fact row admitted into the working-memory ``facts_context``
     # section by :func:`agents.persona_runtime.facts_section.render_facts_section`.
-    # ``tier="facts"`` is a low-cardinality dimension that lets a
-    # future provenance dashboard join this counter against the
-    # per-turn tier-provenance log RFC 0026 PR 4 emits.
+    # ``tier="facts"`` is a *constant* at v0.3.1 — single-valued, zero
+    # added cardinality — kept as a forward-compat seam.  RFC 0026 PR 4
+    # shipped per-turn tier provenance as the in-process
+    # ``MemoryBudget.admissions_by_tier`` registry (read by the
+    # reinforcement write), not an OTEL attribute join, so no sibling
+    # counter carries ``tier=`` yet; a reader should treat the
+    # attribute as a placeholder, not a live dimension, until a
+    # dashboard promotes the registry to OTEL.
     inst.facts_injected = meter.create_counter(
         name="agent.facts.injected",
         unit="{fact}",
         description=(
             "Declarative-fact rows admitted into the persona's "
             "working memory ``facts_context`` section (RFC 0026 PR 3). "
-            "Attributes: agent.id, tier."
+            "Attributes: agent.id; tier (constant \"facts\" at v0.3.1)."
         ),
     )

--- a/docs/rfcs/0026-pr-plan.md
+++ b/docs/rfcs/0026-pr-plan.md
@@ -680,130 +680,85 @@ render defensive fixes) and PR 5d (tests + counter polish):
   — four cases plus `test_source_interaction_id_traversal_not_canonicalised`,
   which proves the UUID column is not casefolded.
 
-**Remaining for PR 5d** — `feature/v031-rfc0026-followups-pr3b`:
+**Shipped in PR 5d** — `feature/v031-rfc0026-followups-pr3b`:
 
-- **`agent.facts.injected` overcount when the section is dropped on
-  header admission failure.** PR 3 increments the
-  `agent.facts.injected` counter inside the per-item budget loop in
-  [`render_facts_section`](../../agents/persona_runtime/facts_section.py),
-  but the section is only added to working memory if the
-  `"Known facts about {subject}:\n"` header *also* admits — and the
-  header `try_add` runs **after** the loop.  When the per-item
-  passes drain the budget to `<= MIN_TOKENS_FACTS` and the header
-  subsequently fails admission, the function returns `None`, no
-  section reaches the prompt, but the counter has already ticked
-  once per admitted item — silently violating the docstring
-  contract ("counter reflects what reached the prompt, not what
-  the recall layer returned") inherited from PR #260 review M-1.
-  Latent today because the relationship + channel_history tiers
-  rarely leave the global allocator close enough to its floor for
-  the header pass to fail.  Two implementation options to pick in
-  PR 5 review:
-  1. **Reserve the header tokens up-front.** Move the header
-     `try_add` to *before* the per-item loop; if the header itself
-     cannot be admitted, return `None` immediately with no
-     counter writes and no items consumed.  Aligns the
-     cost-attribution order with the read order of the rendered
-     section.  Cost: the per-tier soft-slice
-     (`facts_budget_tokens`) accounting becomes slightly
-     trickier — the header eats a slice the items had counted on.
-  2. **Defer the counter writes until after `add_section`
-     succeeds.** Keep a local pre-add tally inside the function
-     and emit one `facts_injected.add(N, ...)` call after the
-     header lands.  Keeps the per-item ordering as-is; trades one
-     batched `add(N)` for N individual `add(1)` calls (no
-     observable behaviour change for OpenTelemetry counter
-     semantics).  Pairs naturally with PR 4's tier-provenance
-     instrumentation since it already needs to record admitted
-     items in a structured shape.
-  Test pin should pre-fill `MemoryBudget` so the loop admits N
-  fact lines but leaves no room for the header, then assert
-  `counter_total(reader, "agent.facts.injected") == 0` *and*
-  `get_section("facts_context") is None`.
+PR 5d is a test-hardening + counter-polish slice — it adds three
+regression pins and one comment fix, with **no production behaviour
+change** (`facts_section.py` is untouched).  The PR 3-review items
+deferred here resolve as follows:
 
-- **`self.*` subject seed — extend `_subject_seeds` to include
-  `"self"`.** PR 2's extractor can write `subject="self"` rows
-  for the OQ #10 introspection predicates
-  (`self.has_preference`, `self.holds_value`, `self.committed_to`,
-  `self.has_attribute`); PR 3's `_subject_seeds` derives seeds
-  only from `event.sender_id`, so introspective facts are
-  write-only until the seed list grows.  The seam in
-  [`facts_section.py`](../../agents/persona_runtime/facts_section.py)
-  is narrow (a one-line append in `_subject_seeds`), but the
-  feature sequences naturally with PR 4's reinforcement /
-  retraction work because the `last_recalled_at` write must fire
-  on `"self"` rows too for the MT-MEMORY-005 Leg 5
-  (self-consistency) outcome to flip green.  Per the PR 4 scope
-  table below, this PR formally moves "self-subject seed" into
-  PR 4 acceptance.  Pinned by an explicit test that stores a
-  `self.has_preference` row and asserts it admits at the next
-  event with the same agent.
+- **`agent.facts.injected` overcount on header drop — regression
+  pinned.**  PR 3 ticked the counter inside the per-item budget loop
+  in [`render_facts_section`](../../agents/persona_runtime/facts_section.py),
+  before the per-subject header's `try_add`; a subsequently dropped
+  header returned `None` with the counter already ticked once per
+  admitted item — violating the PR #260 review M-1 contract ("the
+  counter reflects what reached the prompt, not what the recall layer
+  returned").  The *fix* already landed in **PR 4**: the M-1
+  phantom-reinforcement guard moved both the registry
+  `record_admission` **and** the `facts_injected` telemetry write
+  into the post-header `pending` commit loop — effectively option (2)
+  of the two the plan offered (defer the counter writes until the
+  header admits).  PR 5d adds the regression pin that fix lacked:
+  `TestNoCounterOvercountOnHeaderDrop.test_facts_injected_counter_zero_when_header_dropped`
+  in [`test_facts_section.py`](../../tests/unit/python/test_facts_section.py)
+  initialises an in-memory OTEL reader, drives the same tight-budget
+  header-drop path as `TestNoPhantomReinforcementOnHeaderDrop`, and
+  asserts `counter_total(reader, "agent.facts.injected") == 0` with
+  `section is None`.  Verified to bite by mutation (counter write
+  re-added to the per-item loop → red).
 
-- **`tier="facts"` counter attribute is a constant in PR 3.**
-  Every `agent.facts.injected` increment carries the same
-  `tier="facts"` value — the dimension adds zero cardinality at
-  Phase 1.  The justification at
-  [`agents/observability/_metrics_facts.py`](../../agents/observability/_metrics_facts.py)
-  is forward-compat with PR 4's per-turn tier-provenance
-  dashboard, which adds `tier=` to the other tier counters
-  (`agent.episodic.retrieved`, `agent.notes.injected`, …) so they
-  all join on the same attribute key.  PR 5 picks one:
-  1. **Add a one-line comment naming PR 4 as the consumer** so a
-     future operator reading the metric definition does not
-     assume the attribute is alive.  Keeps the forward-compat
-     surface intact at zero behaviour cost.
-  2. **Drop the attribute until PR 4 emits the second value.**
-     Cleaner Phase-1 surface; PR 4 re-adds the attribute when
-     it acquires meaningful cardinality.  Risk: dashboards
-     written against `tier="facts"` between PR 3 and PR 4 break
-     when the attribute reappears with a different lineage.
-  Default in absence of operator demand: option (1).
+- **`self.*` subject seed — already shipped in PR 4.**  PR 4's M-2
+  finding made `_subject_seeds` return `[SELF_SUBJECT, sender]` for
+  sender-bearing events, so introspective `self.*` rows admit at
+  recall time.  No residual code work for PR 5d; the sender-less
+  short-circuit it introduced is pinned by the negative-path test
+  below.
 
-- **Negative-path test coverage in
-  [`tests/integration/test_facts_recall.py`](../../tests/integration/test_facts_recall.py).**
-  PR 3 ships 9 tests (post-M-2 fold-in), covering the happy
-  paths and the dementia-core leg, but three negative-path
-  branches are unpinned:
-  1. **`fact_store.recall` raises.** `recall_facts_for_event`
-     catches `Exception`, logs `WARNING`, and returns `[]` —
-     the log-and-continue idiom that parallels the relationship
-     and episodic tiers.  Both tiers have explicit negative-path
-     tests; the facts tier does not.  Add a test with
-     `AsyncMock(side_effect=RuntimeError(...))` and assert the
-     section is absent and the dementia-core invariant on other
-     events is unaffected.
-  2. **TICK / orchestrator event with no sender.**
-     `_subject_seeds` returns `[]` when `event.sender_id` is
-     `None` / empty / whitespace-only; `recall_facts_for_event`
-     short-circuits.  Pin with an explicit `sender_id=None`
-     event.
-  3. **Header-dropped case** (pairs with the M-1 follow-up
-     above) — also pins the counter-overcount regression.
+- **`tier="facts"` counter attribute — comment polished (option
+  (1)).**  The attribute is a single-valued constant at v0.3.1 (zero
+  added cardinality).  PR 4 shipped per-turn tier provenance as the
+  in-process `MemoryBudget.admissions_by_tier` registry, **not** as
+  an OTEL attribute join — no sibling counter (`agent.episodic.*`,
+  `agent.notes.*`) carries `tier=`.  The registration comment in
+  [`_metrics_facts.py`](../../agents/observability/_metrics_facts.py)
+  is updated to state the attribute is a forward-compat placeholder
+  and to name the registry as PR 4's actual provenance surface, so a
+  future operator does not assume the dimension is live.  Option (2)
+  (drop the attribute) was rejected: the description string already
+  documents `tier`, and dropping then re-adding it risks the
+  dashboard-lineage break the plan flagged.
 
-- **`TestTierOrdering` asserts `add_section` call order, not the
-  rendered prompt order.** The test wraps `add_section` and
-  asserts the call sequence is `relationship → facts → notes`.
-  That validates the allocate-loop's insertion order, but the
-  actual prompt order is determined by
-  `WorkingMemory.build_context`'s stable sort by `priority`
-  (descending).  Today facts (7), channel_history (7), and
-  episodic (7) share priority and Python's stable sort breaks
-  ties on insertion order, so the test invariant matches the
-  prompt output by happy coincidence.  If a future PR nudges
-  `FACTS_SECTION_PRIORITY` to 6, the existing test still passes
-  but the prompt order silently flips facts below notes — a
-  regression the dementia-core leg would catch only on the
-  Mira-style follow-up where notes prose displaces a fact.
-  Either:
-  1. **Assert against `_working_memory.build_context()` output**
-     so the priority sort is exercised end-to-end.
-  2. **Add a second test that snapshots `build_context()`** and
-     pins the rendered tier order at the prompt boundary; keep
-     the existing `add_section` test as a separate insertion-
-     order pin.
-  Default: option (2) — the two contracts (allocate order vs
-  render order) are distinct and worth pinning separately so a
-  future regression report points at the right layer.
+- **Negative-path test coverage.**  Of the three branches the plan
+  enumerated: (1) **`fact_store.recall` raises** — already pinned by
+  PR 5c's
+  `TestRecallFactsForEventSignature.test_helper_logs_agent_id_from_store_on_failure`
+  (`AsyncMock(side_effect=RuntimeError(...))`, asserts `[]` + WARNING
+  log); (2) **sender-less event** — PR 5d adds
+  `TestRecallFactsForEventNoSenderShortCircuit.test_no_sender_event_skips_recall_entirely`,
+  a helper-level pin that `recall_facts_for_event` issues zero
+  `FactStore.recall` round-trips for a `sender_id=None` event
+  (complements the `_subject_seeds`-level
+  `TestSubjectSeedsSenderlessShortCircuit` and the integration-level
+  `TestTickEventDoesNotQueryFactStore`); (3) **header-dropped case**
+  — satisfied jointly by PR 4's `TestNoPhantomReinforcementOnHeaderDrop`
+  (registry side) and PR 5d's counter pin above (telemetry side).
+
+- **`TestTierOrdering` render-order pin (option (2)).**  The existing
+  `test_facts_admitted_before_notes_section_added` asserts the
+  `add_section` *call* order, which matches the rendered prompt only
+  by stable-sort coincidence — facts / channel_history / episodic all
+  share priority 7.  PR 5d adds
+  `test_facts_rendered_between_relationship_and_notes` in
+  [`test_facts_recall.py`](../../tests/integration/test_facts_recall.py),
+  which snapshots `WorkingMemory.build_context()` and pins the
+  rendered boundary `relationship_context` (8) → `facts_context` (7)
+  → `recent_notes` (6).  The shared three-tier setup is extracted to
+  a `_seed_three_tier_mixin` helper so both pins read off one
+  fixture; the existing `add_section` test is kept as the distinct
+  insertion-order pin.  Verified to bite by mutation
+  (`FACTS_SECTION_PRIORITY` nudged to 5 → render-order pin red while
+  the insertion-order pin stays green).
 
 ##### From PR 4 review
 
@@ -1305,8 +1260,8 @@ Per [.github/copilot-instructions.md](../../.github/copilot-instructions.md) "St
 | 4 | Reinforcement + retraction + tier provenance + MT update | `feature/v031-rfc0026-reinforcement-retraction` | ✅ Merged | [#342](https://github.com/mkhomutov/Persatrix/pull/342) | 2026-05-15 |
 | 5a | Review follow-ups slice 1 — PR 1 review (symmetric latest-wins + nullability) | `feature/v031-rfc0026-followups-pr1` | ✅ Merged | [#344](https://github.com/mkhomutov/Persatrix/pull/344) | 2026-05-15 |
 | 5b | Review follow-ups slice 2 — PR 2 review (envelope parse observability) | `feature/v031-rfc0026-followups-pr2` | ✅ Merged | [#345](https://github.com/mkhomutov/Persatrix/pull/345) | 2026-05-15 |
-| 5c | Review follow-ups slice 3 — PR 3 review storage/render defensive fixes | `feature/v031-rfc0026-followups-pr3a` | 🔀 PR open | — | — |
-| 5d | Review follow-ups slice 4 — PR 3 review tests + counter polish | `feature/v031-rfc0026-followups-pr3b` | ⬜ Not started | — | — |
+| 5c | Review follow-ups slice 3 — PR 3 review storage/render defensive fixes | `feature/v031-rfc0026-followups-pr3a` | ✅ Merged | [#346](https://github.com/mkhomutov/Persatrix/pull/346) | 2026-05-15 |
+| 5d | Review follow-ups slice 4 — PR 3 review tests + counter polish | `feature/v031-rfc0026-followups-pr3b` | 🔀 PR open | — | — |
 | 5e | Review follow-ups slice 5 — PR 4 review (audit, chunking, edge cases) | `feature/v031-rfc0026-followups-pr4` | ⬜ Not started | — | — |
 | 6 | RFC close | `feature/v031-rfc0026-close` | ⬜ Not started | — | — |
 

--- a/tests/_otel_test_helpers.py
+++ b/tests/_otel_test_helpers.py
@@ -1,9 +1,11 @@
 """Shared OTel test helpers.
 
-One implementation of the OTel-counter assertion shape every metric
-test in the repo had been re-deriving inline.  Lives at the top of
-``tests/`` so unit and integration suites can both import it via
-``conftest.py``'s ``sys.path`` insertion.
+Single implementations of the two shapes metric tests across the repo
+had been re-deriving inline: the OTel-counter assertion walk
+(:func:`counter_total`) and the in-memory meter bootstrap
+(:func:`build_meter`).  Lives at the top of ``tests/`` so unit and
+integration suites can both import it via ``conftest.py``'s
+``sys.path`` insertion.
 
 History: PR 298 (RFC 0020 PR 6 slice 4) was about to land a third
 copy of ``_counter_total`` in
@@ -11,13 +13,40 @@ copy of ``_counter_total`` in
 flagged the duplication; this module collapses that copy plus the two
 pre-existing ones in ``test_interaction_tracker`` and
 ``test_summarize_close_helpers`` into a single source of truth.
+
+PR 347 (RFC 0026 PR 5d) review N1 hoisted ``build_meter`` here for the
+same reason — the ``init_metrics(reader=InMemoryMetricReader())``
+bootstrap was duplicated verbatim across the facts-tier metric
+suites.  Other test files still carry a local ``_build_meter``; they
+collapse onto this one as they are next touched.
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-__all__ = ["counter_total"]
+__all__ = ["build_meter", "counter_total"]
+
+
+def build_meter() -> tuple[Any, Any]:
+    """Bootstrap OTel metrics against a fresh in-memory reader.
+
+    Returns ``(reader, metrics_mod)``.  Counters are dead until
+    ``init_metrics`` has run — ``try_get_instruments`` returns
+    ``None`` until then — so a metric test calls this in setup and
+    reads the result back through :func:`counter_total`.
+
+    Teardown is the caller's: wrap the test body in ``try / finally:
+    await metrics_mod.shutdown()`` so the global provider is nulled
+    and metrics state does not leak into later tests.
+    """
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # noqa: PLC0415
+
+    from agents.observability import metrics as metrics_mod  # noqa: PLC0415
+
+    reader = InMemoryMetricReader()
+    metrics_mod.init_metrics(reader=reader)
+    return reader, metrics_mod
 
 
 def counter_total(reader: Any, name: str) -> int:

--- a/tests/integration/test_facts_recall.py
+++ b/tests/integration/test_facts_recall.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from _otel_test_helpers import counter_total
+from _otel_test_helpers import build_meter, counter_total
 
 from agents.memory.episodic import EpisodicMemory
 from agents.memory.facts import FactStore
@@ -135,16 +135,6 @@ def _make_event(
     event.payload = {"content": content}
     event.timestamp = 0.0
     return event
-
-
-def _build_meter() -> Any:
-    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # noqa: PLC0415
-
-    from agents.observability import metrics as metrics_mod  # noqa: PLC0415
-
-    reader = InMemoryMetricReader()
-    metrics_mod.init_metrics(reader=reader)
-    return reader, metrics_mod
 
 
 # ─── 1. Subject-indexed recall round-trip ───────────────────
@@ -306,7 +296,7 @@ class TestConfigDisable:
             source_interaction_id="i1", asserted_at=time.time(),
         )
 
-        reader, metrics_mod = _build_meter()
+        reader, metrics_mod = build_meter()
         try:
             mixin = _wire_mixin(
                 fact_store=fact_store, episodic=empty_episodic,
@@ -375,7 +365,7 @@ class TestInjectionCounter:
             source_interaction_id="i2", asserted_at=ts + 1,
         )
 
-        reader, metrics_mod = _build_meter()
+        reader, metrics_mod = build_meter()
         try:
             mixin = _wire_mixin(
                 fact_store=fact_store, episodic=empty_episodic,

--- a/tests/integration/test_facts_recall.py
+++ b/tests/integration/test_facts_recall.py
@@ -1,30 +1,21 @@
-"""RFC 0026 PR 3 — FactStore.recall wired into the MemoryBudget allocator.
+"""RFC 0026 — FactStore.recall wired into the MemoryBudget allocator.
 
-Pins the PR 3 deliverables called out in
-:doc:`docs/rfcs/0026-pr-plan.md` §PR 3: the facts tier slots between
-relationship and notes in the canonical cross-RFC priority order, calls
-:meth:`agents.memory.facts.FactStore.recall` for each of ``(sender,
-*mentioned_entities)``, and routes admitted rows through
+Pins the facts tier's recall + admission contracts: the tier slots
+between relationship and notes in the canonical cross-RFC priority
+order, recalls per derived subject, and routes admitted rows through
 :class:`agents.persona_runtime.memory_budget.MemoryBudget` with a
-per-tier floor.  The dementia-test core (fact in turn N injected at turn
-N+1 *without* the subject string appearing in the query) is the
-load-bearing leg of MT-MEMORY-005 and pinned here.
+per-tier floor.  The dementia-test core — a fact stored at interaction
+N injected at N+1 *without* the subject string appearing in the query
+— is the load-bearing leg of MT-MEMORY-005 and pinned here.
 
 Contracts asserted:
 
-* Subject-indexed recall round-trip on a fresh DB.
-* Dementia-test core: a fact stored at interaction N is injected at
-  N+1 even when the next event's natural-language query does not
-  mention the subject string (the dementia test that fails today is
-  the one where ``query`` is a follow-up question that does not name
-  the entity).
-* Tier ordering: facts admitted before notes when the budget is tight.
-* ``memory.facts.enabled: false`` skips the tier entirely; no
-  ``agent.facts.injected`` increment.
-* RFC 0017's 1500-token allocator cap still holds with the facts tier
-  wired in.
-* Per-tier header tokens are charged against the budget (PR 3 review
-  precedent — the prepended header is not free).
+* Subject-indexed recall round-trip; dementia-test core injection.
+* Tier ordering — both the ``add_section`` call sequence and the
+  ``build_context`` priority-sorted render order (PR 5d).
+* ``memory.facts.enabled: false`` skips the tier; no counter tick.
+* RFC 0017's 1500-token allocator cap holds with the tier wired in.
+* Per-tier header tokens are charged against the budget.
 """
 
 from __future__ import annotations
@@ -219,38 +210,42 @@ class TestDementiaCore:
 # ─── 3. Tier ordering: facts before notes ──────────────────
 
 
+async def _seed_three_tier_mixin(
+    fact_store: FactStore, episodic: EpisodicMemory,
+) -> _ConcreteMemoryMixin:
+    """Seed one fact + one note + a relationship summary and wire a
+    mixin so the relationship / facts / notes tiers all admit — shared
+    setup for the two tier-ordering pins below.
+    """
+    await fact_store.store(
+        subject="bob", predicate="prefers", object="tea",
+        source_interaction_id="i1", asserted_at=time.time(),
+    )
+    await episodic.store_note(
+        topic="rollout", content="bob asked about rollout planning",
+    )
+    rel = _FakeRelSummary(
+        other_participant_id="bob", other_participant_type="user",
+        interaction_count=3, trust_score=0.6,
+        notes="bob is detail-focused",
+        last_interaction_at=time.time() - 60,
+        first_interaction_at=time.time() - 3600,
+    )
+    return _wire_mixin(
+        fact_store=fact_store, episodic=episodic, rel=rel,
+        format_query="rollout",
+    )
+
+
 class TestTierOrdering:
     async def test_facts_admitted_before_notes_section_added(
         self, fact_store: FactStore, empty_episodic: EpisodicMemory,
     ) -> None:
-        """The five-tier order matches RFC 0027 §F end-state:
-        relationship → channel_history → facts → episodic → notes.
-
-        Pinned via the ``add_section`` call sequence; the facts
-        section must be added between relationship_context and
-        recent_notes.
+        """Insertion-order pin: ``add_section`` is called for the facts
+        section between ``relationship_context`` and ``recent_notes``.
+        The rendered prompt order is pinned separately below.
         """
-        await fact_store.store(
-            subject="bob", predicate="prefers", object="tea",
-            source_interaction_id="i1", asserted_at=time.time(),
-        )
-        await empty_episodic.store_note(
-            topic="rollout", content="bob asked about rollout planning",
-        )
-
-        rel = _FakeRelSummary(
-            other_participant_id="bob",
-            other_participant_type="user",
-            interaction_count=3,
-            trust_score=0.6,
-            notes="bob is detail-focused",
-            last_interaction_at=time.time() - 60,
-            first_interaction_at=time.time() - 3600,
-        )
-        mixin = _wire_mixin(
-            fact_store=fact_store, episodic=empty_episodic, rel=rel,
-            format_query="rollout",
-        )
+        mixin = await _seed_three_tier_mixin(fact_store, empty_episodic)
 
         order: list[str] = []
         real_add = mixin._working_memory.add_section
@@ -261,18 +256,41 @@ class TestTierOrdering:
 
         mixin._working_memory.add_section = _record  # type: ignore[assignment]
 
-        event = _make_event(sender_id="bob", content="rollout")
-        await mixin._inject_memory_context(event)
+        await mixin._inject_memory_context(
+            _make_event(sender_id="bob", content="rollout"),
+        )
 
-        # The facts section must sit between relationship_context and recent_notes.
-        assert "facts_context" in order
-        assert "relationship_context" in order
-        assert "recent_notes" in order
         rel_idx = order.index("relationship_context")
         facts_idx = order.index("facts_context")
         notes_idx = order.index("recent_notes")
+        assert rel_idx < facts_idx < notes_idx, f"tier order drifted: {order}"
+
+    async def test_facts_rendered_between_relationship_and_notes(
+        self, fact_store: FactStore, empty_episodic: EpisodicMemory,
+    ) -> None:
+        """Render-order pin (PR 5d).  The insertion-order test above
+        pins the ``add_section`` call sequence; the prompt the LLM sees
+        is ``build_context``'s priority-sorted output.  ``facts``
+        (priority 7) ties with ``channel_history`` / ``episodic``, so
+        the insertion pin matches the prompt only by stable-sort
+        coincidence — a ``FACTS_SECTION_PRIORITY`` nudge would leave it
+        green while flipping the prompt.  Pins the rendered boundary:
+        relationship (8) → facts (7) → notes (6).
+        """
+        mixin = await _seed_three_tier_mixin(fact_store, empty_episodic)
+        await mixin._inject_memory_context(
+            _make_event(sender_id="bob", content="rollout"),
+        )
+
+        rendered = [
+            entry["role"]
+            for entry in mixin._working_memory.build_context()
+        ]
+        rel_idx = rendered.index("relationship_context")
+        facts_idx = rendered.index("facts_context")
+        notes_idx = rendered.index("recent_notes")
         assert rel_idx < facts_idx < notes_idx, (
-            f"tier order drifted: {order}"
+            f"rendered tier order drifted: {rendered}"
         )
 
 

--- a/tests/unit/python/test_facts_section.py
+++ b/tests/unit/python/test_facts_section.py
@@ -1,48 +1,50 @@
 """Unit tests for :mod:`agents.persona_runtime.facts_section` — the
-seed-derivation + section-render contracts that compose with the
-declarative-fact tier's reinforcement write.
+seed-derivation, section-render, and telemetry contracts that compose
+with the declarative-fact tier's reinforcement write.
 
-Two contracts pinned here:
+Contracts pinned here:
 
-* :func:`_subject_seeds` short-circuit on sender-less events
-  (TICK, orchestrator-internal) — the PR 4 cut briefly broke this by
-  always seeding ``["self"]`` even when ``event.sender_id`` was empty,
-  defeating the PR-5 empty-context cost guard and unconditionally
-  issuing ``fact_store.recall(subject="self")`` on every TICK.  The
-  PR #342 review M-2 finding reverted the change to gate the
-  self-seed on a non-empty sender, preserving MT-MEMORY-005 Leg 5
-  (user-facing self-consistency always carries a sender) while
-  honoring the sender-less short-circuit.
+* :func:`_subject_seeds` short-circuits on sender-less events (TICK,
+  orchestrator-internal); :func:`recall_facts_for_event` honours that
+  short-circuit one layer up — no DB round-trip for a sender-less
+  event (PR #342 review M-2; PR 5d helper-level pin).
+* :func:`render_facts_section`'s phantom-reinforcement guard — admitted
+  fact_ids reach the :class:`MemoryBudget` registry only after the
+  per-subject header admits, so a dropped header strands nothing
+  (PR #342 review M-1).  The ``agent.facts.injected`` counter mirrors
+  the guard: zero ticks when the header is dropped (PR 5d).
 
-* :func:`render_facts_section` phantom-reinforcement guard — the PR
-  4 cut briefly registered admitted fact_ids on the
-  :class:`MemoryBudget` registry inside the per-item loop, *before*
-  the per-subject header was admitted; when the header was dropped
-  (budget remainder below the truncation floor) the items stayed on
-  the registry and the downstream
-  :meth:`agents.memory.facts.FactStore.mark_recalled` write fired on
-  rows the LLM never saw.  The PR #342 review M-1 finding staged
-  the admissions per-block and committed them only after the header
-  admitted.
-
-Both classes use direct calls against the module under test rather
-than going through ``_inject_memory_context`` — the contracts are
-local to ``facts_section.py`` and the unit-level surface is
-narrower (no FactStore lifecycle, no full mixin wiring) than the
-integration pin in
-:mod:`tests.integration.test_facts_reinforcement`.  The integration
-counterpart (``TestTickEventDoesNotQueryFactStore``) is intentionally
-kept in the integration file so the cost contract is also pinned
-end-to-end at the mixin boundary.
+These use direct calls against the module under test rather than
+``_inject_memory_context`` — the contracts are local to
+``facts_section.py`` and need no FactStore lifecycle or mixin wiring.
+The integration counterpart ``TestTickEventDoesNotQueryFactStore``
+pins the cost contract end-to-end at the mixin boundary.
 """
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
+from _otel_test_helpers import counter_total
+
 pytestmark = pytest.mark.asyncio
+
+
+def _build_meter() -> tuple[Any, Any]:
+    """Initialise OTel metrics against an in-memory reader so the
+    ``agent.facts.injected`` counter is live (``try_get_instruments``
+    returns ``None`` until ``init_metrics`` runs) and assertable.
+    """
+    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # noqa: PLC0415
+
+    from agents.observability import metrics as metrics_mod  # noqa: PLC0415
+
+    reader = InMemoryMetricReader()
+    metrics_mod.init_metrics(reader=reader)
+    return reader, metrics_mod
 
 
 # ─── _subject_seeds short-circuit (PR #342 review M-2) ─────
@@ -127,6 +129,41 @@ class TestSubjectSeedsSenderlessShortCircuit:
         event = MagicMock()
         event.sender_id = "self"
         assert _subject_seeds(event) == [SELF_SUBJECT]
+
+
+# ─── recall_facts_for_event no-sender short-circuit (PR 5d) ─
+
+
+class TestRecallFactsForEventNoSenderShortCircuit:
+    """``recall_facts_for_event`` returns ``[]`` and issues **zero**
+    ``FactStore.recall`` round-trips for a sender-less event.
+
+    ``TestSubjectSeedsSenderlessShortCircuit`` above pins the
+    short-circuit at the ``_subject_seeds`` boundary; this pins it one
+    layer up — the ``if not seeds: return []`` guard inside
+    :func:`recall_facts_for_event` — so the DB-cost guard cannot
+    regress for a caller reaching the helper outside the mixin.
+    """
+
+    async def test_no_sender_event_skips_recall_entirely(self) -> None:
+        from unittest.mock import AsyncMock  # noqa: PLC0415
+
+        from agents.persona_runtime.facts_section import (  # noqa: PLC0415
+            recall_facts_for_event,
+        )
+
+        fact_store = MagicMock()
+        fact_store.agent_id = "dementia-agent"
+        fact_store.recall = AsyncMock(return_value=[])
+
+        event = MagicMock()
+        event.sender_id = None
+
+        result = await recall_facts_for_event(fact_store, event)
+
+        assert result == []
+        # Cost guard: a sender-less event must not pay a DB round-trip.
+        fact_store.recall.assert_not_called()
 
 
 # ─── render_facts_section phantom-reinforcement guard (M-1) ─
@@ -296,6 +333,72 @@ class TestNoPhantomReinforcementOnHeaderDrop:
         # whether siblings admit.
         assert section is None
         assert budget.admissions_by_tier("facts") == []
+
+
+# ─── facts.injected not overcounted on header drop (PR 5d) ─
+
+
+class TestNoCounterOvercountOnHeaderDrop:
+    """``agent.facts.injected`` must count prompt-side admissions only —
+    zero increments when the per-subject header is dropped.
+
+    Sibling to :class:`TestNoPhantomReinforcementOnHeaderDrop`: that
+    class pins the *admission registry* side of the header-drop guard
+    (no phantom ``last_recalled_at`` write); this pins the *telemetry*
+    side.  PR 3 ticked the counter inside the per-item budget loop,
+    *before* the header ``try_add`` — a dropped header then returned
+    ``None`` with the counter already ticked, breaking the PR #260
+    review M-1 contract.  PR 4's M-1 fix moved the counter write into
+    the post-header ``pending`` commit loop; this is the regression
+    pin that fix lacked.
+    """
+
+    async def test_facts_injected_counter_zero_when_header_dropped(
+        self,
+    ) -> None:
+        """An 8-token budget admits the 4-token fact line but cannot
+        fit the header, so the block is dropped and the section is
+        ``None`` — same sizing as ``TestNoPhantomReinforcementOnHeaderDrop``.
+        """
+        from agents.memory.facts import Fact  # noqa: PLC0415
+        from agents.persona_runtime.facts_section import (  # noqa: PLC0415
+            render_facts_section,
+        )
+        from agents.persona_runtime.memory_budget import (  # noqa: PLC0415
+            MemoryBudget,
+        )
+
+        budget = MemoryBudget(total_tokens=8)
+        facts = [
+            Fact(
+                fact_id="overcount-fact-1",
+                agent_id="dementia-agent",
+                subject="bob",
+                predicate="prefers",
+                object="tea",
+                certainty=1.0,
+                source_interaction_id="i1",
+                asserted_at=1000.0,
+                last_recalled_at=None,
+                superseded_by=None,
+                session_id="legacy",
+            ),
+        ]
+
+        reader, metrics_mod = _build_meter()
+        try:
+            section = render_facts_section(
+                facts, budget, facts_budget_tokens=200,
+            )
+            # Header dropped → block dropped → no section, and the
+            # counter must not have ticked for the discarded item.
+            assert section is None
+            assert counter_total(reader, "agent.facts.injected") == 0, (
+                "agent.facts.injected ticked for a fact whose block "
+                "was dropped on header-admission failure (PR #260 M-1)."
+            )
+        finally:
+            await metrics_mod.shutdown()
 
 
 # ─── self-first emit order under tight slice (PR #342 third-pass M-2) ─

--- a/tests/unit/python/test_facts_section.py
+++ b/tests/unit/python/test_facts_section.py
@@ -23,28 +23,13 @@ pins the cost contract end-to-end at the mixin boundary.
 
 from __future__ import annotations
 
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
 
-from _otel_test_helpers import counter_total
+from _otel_test_helpers import build_meter, counter_total
 
 pytestmark = pytest.mark.asyncio
-
-
-def _build_meter() -> tuple[Any, Any]:
-    """Initialise OTel metrics against an in-memory reader so the
-    ``agent.facts.injected`` counter is live (``try_get_instruments``
-    returns ``None`` until ``init_metrics`` runs) and assertable.
-    """
-    from opentelemetry.sdk.metrics.export import InMemoryMetricReader  # noqa: PLC0415
-
-    from agents.observability import metrics as metrics_mod  # noqa: PLC0415
-
-    reader = InMemoryMetricReader()
-    metrics_mod.init_metrics(reader=reader)
-    return reader, metrics_mod
 
 
 # ─── _subject_seeds short-circuit (PR #342 review M-2) ─────
@@ -385,7 +370,7 @@ class TestNoCounterOvercountOnHeaderDrop:
             ),
         ]
 
-        reader, metrics_mod = _build_meter()
+        reader, metrics_mod = build_meter()
         try:
             section = render_facts_section(
                 facts, budget, facts_budget_tokens=200,


### PR DESCRIPTION
## Summary

RFC 0026 PR 5, slice 4 of 5 (per `docs/rfcs/0026-pr-plan.md` §PR 5). A test-hardening + counter-polish slice — **no production behaviour change** (`facts_section.py` is untouched; the underlying fixes landed in PR 4). Closes the test-coverage and `tier="facts"` items deferred from the PR 3 review.

- **Counter-overcount regression pin** — `TestNoCounterOvercountOnHeaderDrop` asserts `agent.facts.injected` stays at 0 when a per-subject header is dropped. Telemetry-side sibling of PR 4's phantom-reinforcement registry guard (`TestNoPhantomReinforcementOnHeaderDrop`).
- **Sender-less negative-path pin** — `TestRecallFactsForEventNoSenderShortCircuit` pins that `recall_facts_for_event` issues zero `FactStore.recall` round-trips for a `sender_id=None` event.
- **Rendered tier-order pin** — `TestTierOrdering.test_facts_rendered_between_relationship_and_notes` snapshots `WorkingMemory.build_context()` to pin the rendered prompt order (`relationship` > `facts` > `notes`), which the existing `add_section` insertion-order test matched only by stable-sort coincidence (facts/channel_history/episodic share priority 7). Shared three-tier setup extracted to a `_seed_three_tier_mixin` helper.
- **Counter comment polish** — the `agent.facts.injected` registration comment now states `tier="facts"` is a single-valued constant and names PR 4's in-process `MemoryBudget.admissions_by_tier` registry as the actual tier-provenance surface (PR 4 did not add `tier=` to sibling OTEL counters).

Each pin was mutation-verified: reintroducing the PR 3 bug shape — counter write back in the per-item loop, `_subject_seeds` seeding `["self"]` for sender-less events, `FACTS_SECTION_PRIORITY` nudged to 5 — turns the corresponding test red while leaving siblings green.

Also corrects the PR 5c row in the plan's Progress Overview, which #346 left as `PR open`.

## Test plan

- [x] `pytest tests/unit/python/test_facts_section.py tests/integration/test_facts_recall.py tests/integration/test_facts_reinforcement.py tests/unit/python/test_facts_section_defensive.py` — 39 passed
- [x] `python scripts/checks/file_size.py --strict` — all files within limits (both touched test files land under the 500-line cap)
- [x] `ruff check` on changed files — clean
- [x] Pre-commit hooks — 7/7 passed (filemap, go fmt, ruff, cargo fmt, doc links, doc status, file size)