### PR TITLE
feat(v031): RFC 0026 PR 5e — PR 4 review audit/chunking/edge cases

### DIFF
--- a/agents/memory/_facts_reinforce.py
+++ b/agents/memory/_facts_reinforce.py
@@ -21,13 +21,35 @@ the column write.
 from __future__ import annotations
 
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING
+
+from ._facts_audit import emit_audit as _emit_audit
 
 if TYPE_CHECKING:
     import aiosqlite
 
 __all__ = ["mark_recalled_for_agent"]
+
+
+# SQLite caps host parameters per prepared statement at
+# ``SQLITE_MAX_VARIABLE_NUMBER`` — 999 on builds older than v3.32,
+# 32 766 after.  The reinforcement UPDATE binds ``(timestamp,
+# agent_id, *ids)``, so the per-statement id budget is the cap minus
+# the two fixed binds.  900 stays clear of the conservative pre-3.32
+# limit with headroom and keeps each statement small.  Today's only
+# production caller (``memory_context._inject_memory_context``) passes
+# ≤40 ids — orders of magnitude below this — but the helper accepts an
+# arbitrary ``Iterable[str]`` and is reachable from the future RFC 0013
+# erasure backfill and RFC 0008 calibration paths.  (PR #342
+# second-pass review DR2-N-3.)
+_MAX_IDS_PER_UPDATE = 900
+
+
+def _chunked(ids: list[str], size: int) -> Iterator[list[str]]:
+    """Yield ``ids`` in contiguous slices of at most ``size`` elements."""
+    for start in range(0, len(ids), size):
+        yield ids[start : start + size]
 
 
 async def mark_recalled_for_agent(
@@ -59,16 +81,53 @@ async def mark_recalled_for_agent(
     ``COALESCE(..., 0)`` matters because the column starts ``NULL``
     and SQLite's ``MAX(NULL, x) = NULL``, which would silently no-op
     the first call.
+
+    IN-list chunking (PR #342 second-pass review DR2-N-3)
+    -----------------------------------------------------
+    The ``fact_id`` list is split into :data:`_MAX_IDS_PER_UPDATE`
+    chunks, one UPDATE per chunk, so an arbitrarily large id list
+    cannot breach SQLite's per-statement host-parameter cap.  All
+    chunks share a single trailing ``commit`` so the reinforcement
+    write lands atomically.
+
+    Audit emission (PR #342 second-pass review DR2-N-2)
+    ---------------------------------------------------
+    A non-empty call emits one ``fact.recalled`` RFC 0026 §G audit
+    record after commit, naming every requested ``fact_id`` — once
+    per call, not per id, so audit volume stays bounded.  Without it
+    the audit log was blind to reinforcement even though
+    MT-MEMORY-005 leg-failure analysis is one of the named consumers.
+
+    Commit cost (PR #342 second-pass review DR2-N-8)
+    ------------------------------------------------
+    ``FactStore`` exposes no transaction-scope manager, so every write
+    auto-commits — this helper included.  The reinforcement commit
+    therefore lands once per ``_inject_memory_context`` call, after the
+    facts section is staged in working memory but before the caller
+    builds the LLM prompt.  Reviewed against the MQ-12 per-turn-cost
+    budget: a single small UPDATE + commit is in the noise floor next
+    to the LLM round-trip that immediately follows, so no
+    ``FactStore.transaction()`` manager is introduced here — adding one
+    would be speculative.  Revisit only if a future trace shows the
+    commit on the hot path.
     """
     ids = list(fact_ids)
     if not ids:
         return
     timestamp = at if at is not None else time.time()
-    placeholders = ",".join("?" for _ in ids)
-    await db.execute(
-        f"UPDATE facts "  # noqa: S608 — placeholders are literal '?'.
-        f"SET last_recalled_at = MAX(COALESCE(last_recalled_at, 0), ?) "
-        f"WHERE agent_id = ? AND fact_id IN ({placeholders})",
-        (timestamp, agent_id, *ids),
-    )
+    for chunk in _chunked(ids, _MAX_IDS_PER_UPDATE):
+        placeholders = ",".join("?" for _ in chunk)
+        await db.execute(
+            f"UPDATE facts "  # noqa: S608 — placeholders are literal '?'.
+            f"SET last_recalled_at = MAX(COALESCE(last_recalled_at, 0), ?) "
+            f"WHERE agent_id = ? AND fact_id IN ({placeholders})",
+            (timestamp, agent_id, *chunk),
+        )
     await db.commit()
+
+    # RFC 0026 §G audit emission — after commit so the log cannot
+    # record a write that did not happen.  One record per call (the
+    # full id list rides as a field) keeps audit volume bounded.
+    _emit_audit(
+        "fact.recalled", agent_id=agent_id, fact_ids=ids, at=timestamp,
+    )

--- a/agents/persona_runtime/memory_budget.py
+++ b/agents/persona_runtime/memory_budget.py
@@ -146,33 +146,52 @@ MAX_NOTE_CONTENT_CHARS: int = 500
 # ─── Internal token helpers ────────────────────────────────
 
 
-def _count_tokens(text: str) -> int:
-    """Count tokens in *text* using tiktoken ``cl100k_base``, falling back to chars/4.
+def _encode_text(text: str) -> tuple[int, list[int] | None]:
+    """Encode *text* once, returning ``(token_count, token_ids)``.
 
-    Identical to the ``accurate=True`` path in :func:`~agents.memory.working.estimate_tokens`
-    but kept local to avoid an import that would create a circular dependency
-    once ``memory_context.py`` imports ``MemoryBudget`` in PR 2.
+    ``token_ids`` is the tiktoken ``cl100k_base`` token list when
+    tiktoken is available, and ``None`` in the chars/4 fallback.
+
+    DR2-N-6 (PR #342 second-pass review): :meth:`MemoryBudget.try_add`
+    caches the result of this single encode and threads ``token_ids``
+    into :func:`_truncate_to_token_limit`, so an oversized item's full
+    text is tokenised once per admission rather than re-encoded by the
+    counter and the truncator separately.
+
+    ``max(0, …)`` (not ``max(1, …)``) so empty input returns 0,
+    matching the tiktoken path (``enc.encode("") == []``).
     """
     try:
         import tiktoken  # type: ignore[import-untyped]
 
         enc = tiktoken.get_encoding("cl100k_base")
-        return len(enc.encode(text))
+        tokens = enc.encode(text)
+        return len(tokens), tokens
     except ImportError:
         logger.debug("tiktoken not available, using chars/4 token estimate")
     except Exception:
         logger.warning(
             "tiktoken encoding failed, falling back to chars/4", exc_info=True
         )
-    # ``max(0, …)`` (not ``max(1, …)``) so empty input returns 0, matching
-    # the tiktoken path (``enc.encode("") == []``).  ``try_add`` short-
-    # circuits on ``if not text:`` before reaching this helper, so no caller
-    # currently observes the difference, but the contracts now agree.
-    # (PR 6 — RFC 0017 PR 1 review finding 1.)
-    return max(0, len(text) // 4)
+    return max(0, len(text) // 4), None
 
 
-def _truncate_to_token_limit(text: str, token_limit: int) -> str:
+def _count_tokens(text: str) -> int:
+    """Count tokens in *text* using tiktoken ``cl100k_base``, falling back to chars/4.
+
+    Identical to the ``accurate=True`` path in :func:`~agents.memory.working.estimate_tokens`
+    but kept local to avoid an import that would create a circular dependency
+    once ``memory_context.py`` imports ``MemoryBudget`` in PR 2.
+
+    Thin wrapper over :func:`_encode_text` — callers that only need the
+    count (and not the token list) keep the original one-int signature.
+    """
+    return _encode_text(text)[0]
+
+
+def _truncate_to_token_limit(
+    text: str, token_limit: int, *, _token_ids: list[int] | None = None,
+) -> str:
     """Truncate *text* to fit within *token_limit* tokens, including the ellipsis ``…``.
 
     Uses tiktoken for exact token-boundary truncation when available.  Falls
@@ -180,6 +199,13 @@ def _truncate_to_token_limit(text: str, token_limit: int) -> str:
     on missing tiktoken.
 
     The ellipsis character ``…`` (U+2026) counts toward the token budget.
+
+    ``_token_ids`` (internal) — when the caller has already encoded
+    *text* (:meth:`MemoryBudget.try_add` does, on the oversized path),
+    it passes the token list here so the truncator decodes against it
+    instead of re-encoding the full text.  ``None`` means "encode
+    here", the behaviour every external caller and the chars/4
+    fallback rely on.  (PR #342 second-pass review DR2-N-6.)
     """
     ellipsis = "…"
 
@@ -190,7 +216,7 @@ def _truncate_to_token_limit(text: str, token_limit: int) -> str:
         import tiktoken  # type: ignore[import-untyped]
 
         enc = tiktoken.get_encoding("cl100k_base")
-        tokens = enc.encode(text)
+        tokens = enc.encode(text) if _token_ids is None else _token_ids
         if len(tokens) <= token_limit:
             return text
         ellipsis_tokens = len(enc.encode(ellipsis))
@@ -370,18 +396,21 @@ class MemoryBudget:
         if self._remaining <= 0:
             return None
 
-        count = _count_tokens(text)
+        count, token_ids = _encode_text(text)
         if count <= self._remaining:
             self._remaining -= count
             return text
 
-        # Item exceeds remaining budget; try a truncated form.
-        # Note: enc.encode() is invoked 3× for oversized items — once in
-        # _count_tokens(text) above, once inside _truncate_to_token_limit
-        # (encode + decode), and once in _count_tokens(truncated) below.
-        # Acceptable for typical memory-snippet sizes; profile here first
-        # if allocation becomes a hotspot.
-        truncated = _truncate_to_token_limit(text, self._remaining)
+        # Item exceeds remaining budget; try a truncated form.  The
+        # token list cached from the encode above is threaded into
+        # _truncate_to_token_limit so the full text is tokenised once,
+        # not re-encoded by the truncator (PR #342 second-pass review
+        # DR2-N-6).  The short truncated string is still counted below
+        # and the one-char ellipsis encoded inside the truncator —
+        # both cheap; only the full-text re-encode is eliminated.
+        truncated = _truncate_to_token_limit(
+            text, self._remaining, _token_ids=token_ids,
+        )
         truncated_count = _count_tokens(truncated)
         if truncated_count >= min_tokens:
             self._remaining -= truncated_count

--- a/agents/tests/test_inject_memory_context.py
+++ b/agents/tests/test_inject_memory_context.py
@@ -38,6 +38,12 @@ class _FakeEpisode:
 class _FakeNote:
     topic: str
     content: str
+    # RFC 0026 PR 4 wired ``record_admission(item_id=note.id)`` into the
+    # notes tier of ``_inject_memory_context``; this fake predates that
+    # and must carry an ``id`` or every admitted-note path raises
+    # ``AttributeError``.  Default keeps the existing keyword-only
+    # constructors (``_FakeNote(topic=…, content=…)``) working.
+    id: str = "note-fake"
 
 
 @dataclass

--- a/agents/tests/test_memory_budget.py
+++ b/agents/tests/test_memory_budget.py
@@ -330,3 +330,70 @@ class TestPR6Followups:
         result_small = budget.try_add(small, min_tokens=1)
         assert result_small == small
         assert budget.remaining < remaining_before
+
+
+# ─── PR #342 second-pass review DR2-N-6 ───────────────────────────────────────
+
+
+class TestEncodeOnceOnOversizedItem:
+    """DR2-N-6 — ``try_add`` tokenises the full item text only once.
+
+    The oversized path used to re-encode the full text: once in
+    ``_count_tokens(text)`` and again inside ``_truncate_to_token_limit``.
+    With PR 4's multi-block facts render a tight per-tier slice reaches
+    the oversized branch more often, so the redundant re-encode is now
+    worth removing.  ``try_add`` caches the token list off the first
+    encode and threads it into the truncator, which decodes against the
+    same list instead of re-encoding.
+    """
+
+    def test_oversized_item_encodes_full_text_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The long original text is passed to ``enc.encode`` exactly once.
+
+        Regression guard for the redundant re-encode: pre-fix this count
+        was 2 (counter + truncator).  The short truncated string and the
+        one-char ellipsis are still encoded separately — those are cheap
+        and out of scope; only the full-text re-encode is eliminated.
+        """
+        tiktoken = pytest.importorskip("tiktoken")
+
+        encoded_texts: list[str] = []
+        real_encode = tiktoken.Encoding.encode
+
+        def _spy(self, text, *args, **kwargs):  # type: ignore[no-untyped-def]
+            encoded_texts.append(text)
+            return real_encode(self, text, *args, **kwargs)
+
+        monkeypatch.setattr(tiktoken.Encoding, "encode", _spy)
+
+        budget = MemoryBudget(total_tokens=20)
+        long_text = "word " * 200  # far exceeds the 20-token budget
+        result = budget.try_add(long_text, min_tokens=1)
+
+        assert result is not None  # admitted in truncated form
+        assert result.endswith("…")
+        assert encoded_texts.count(long_text) == 1
+
+    def test_whole_fit_item_encodes_text_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An item that fits whole is also encoded only once (no truncation)."""
+        tiktoken = pytest.importorskip("tiktoken")
+
+        encoded_texts: list[str] = []
+        real_encode = tiktoken.Encoding.encode
+
+        def _spy(self, text, *args, **kwargs):  # type: ignore[no-untyped-def]
+            encoded_texts.append(text)
+            return real_encode(self, text, *args, **kwargs)
+
+        monkeypatch.setattr(tiktoken.Encoding, "encode", _spy)
+
+        budget = MemoryBudget(total_tokens=500)
+        text = "the quick brown fox jumps over the lazy dog"
+        result = budget.try_add(text)
+
+        assert result == text
+        assert encoded_texts.count(text) == 1

--- a/docs/rfcs/0026-declarative-facts-tier.md
+++ b/docs/rfcs/0026-declarative-facts-tier.md
@@ -161,7 +161,7 @@ Recall filters out superseded rows by default. This composes with reinforcement 
 
 ### G. Audit and provenance
 
-Every fact carries `source_interaction_id`. The [RFC 0009 AuditLogger](0009-security-sandboxing.md) records fact extraction events at `INFO` level; redaction policy follows the existing `RedactStruct` rules (no raw PII in audit metadata). A `superseded_by` write is also audited.
+Every fact carries `source_interaction_id`. The [RFC 0009 AuditLogger](0009-security-sandboxing.md) records fact extraction events at `INFO` level; redaction policy follows the existing `RedactStruct` rules (no raw PII in audit metadata). A `superseded_by` write is also audited. Use-based reinforcement (`mark_recalled`) emits one bounded `fact.recalled` audit record per call — naming every reinforced `fact_id` as a field rather than one record per id — so the audit log is not blind to which facts a turn reinforced. The reinforcement-audit event was added by PR 5e per [`docs/rfcs/0026-pr-plan.md` PR 5e §From PR 4 review — second-pass deferrals](0026-pr-plan.md#from-pr-4-review--second-pass-deferrals); the PR 4 implementation initially shipped the `last_recalled_at` write with no audit emission.
 
 ### H. Subject erasure (RFC 0013 traversal)
 

--- a/docs/rfcs/0026-pr-plan.md
+++ b/docs/rfcs/0026-pr-plan.md
@@ -990,102 +990,91 @@ commit):
 
 ##### From PR 4 review — second-pass deferrals
 
+**Shipped in PR 5e** — `feature/v031-rfc0026-followups-pr4`:
+
 Four nice-to-have findings from the second deep-review pass
-(PR #342) that did not block PR 4 merge and are tracked here
-for PR 5 to pick up.  Each is small in code surface but
-touches a different concern (audit, defense-in-depth bound,
-allocator amortisation, write-cost calibration), so they are
-sequenced individually rather than batched.
+(PR #342) that did not block PR 4 merge.  Each is small in
+code surface but touches a different concern (audit,
+defense-in-depth bound, allocator amortisation, write-cost
+calibration).  PR 5e is the storage-layer reinforcement slice
+and adds **no production behaviour change beyond the audit
+emission** — the chunk loop is inert on today's hot path
+(≤40 ids, one chunk) and the single-encode change is a pure
+allocator-internal optimisation.  The findings resolve as
+follows:
 
-- **DR2-N-2 — reinforcement writes are not audited.**
-  [`FactStore.store`](../../agents/memory/facts.py) and
-  `FactStore.supersede` both emit
-  `_emit_audit("fact.store", …)` /
-  `_emit_audit("fact.supersede", …)` via the RFC 0026 §G
-  audit hook.
+- **DR2-N-2 — reinforcement writes are now audited.**  Before
+  this slice [`FactStore.store`](../../agents/memory/facts.py)
+  and `FactStore.supersede` emitted `fact.store` /
+  `fact.supersede` via the RFC 0026 §G audit hook but
   [`FactStore.mark_recalled`](../../agents/memory/facts.py)
-  does not.  The audit log is therefore blind to which facts
-  were reinforced this turn, even though MT-MEMORY-005
-  leg-failure analysis is one of the two consumers PR 4
-  named.  The structured-log emission under
-  `PERSATRIX_MEMORY_PROVENANCE=1` partially fills this gap,
-  but it is env-gated and emits from the budget allocator,
-  not from the storage layer — so an audit-log reader has no
-  `FactStore`-level signal that reinforcement occurred.
-  PR 5 decision: either emit
-  `_emit_audit("fact.recalled", agent_id=…, fact_ids=ids,
-  at=timestamp)` once per call (not per fact_id — audit
-  volume stays bounded), or amend RFC 0026 §G to formally
-  exclude reinforcement events from the audit surface.  Pair
-  with a unit test in
-  [`tests/unit/python/test_fact_store_reinforcement.py`](../../tests/unit/python/test_fact_store_reinforcement.py)
-  that asserts a `fact.recalled` audit row lands after a
-  `mark_recalled` call (path #1), or with an inline note in
-  the `mark_recalled` docstring naming the audit-excluded
-  contract (path #2).
+  emitted nothing, leaving the audit log blind to which facts
+  a turn reinforced — even though MT-MEMORY-005 leg-failure
+  analysis is a named consumer.  The env-gated
+  `PERSATRIX_MEMORY_PROVENANCE` structured-log emission only
+  partially filled the gap (it fires from the budget
+  allocator, not the storage layer).  PR 5e takes **path #1**
+  of the two the plan offered:
+  [`_facts_reinforce.mark_recalled_for_agent`](../../agents/memory/_facts_reinforce.py)
+  emits one `_emit_audit("fact.recalled", agent_id=…,
+  fact_ids=ids, at=timestamp)` record per call — after commit,
+  carrying the whole id list as a field rather than one
+  record per id, so audit volume stays bounded.  RFC §G was
+  amended in the same PR to name the reinforcement event.
+  Pinned by `TestMarkRecalledAudit` in
+  [`test_fact_store_reinforcement.py`](../../tests/unit/python/test_fact_store_reinforcement.py)
+  — one record per non-empty call, the whole id list on that
+  one record, no record on an empty call.
 
-- **DR2-N-3 — `mark_recalled_for_agent` does not chunk the
-  IN-list.**  SQLite caps the parameter count per query at
+- **DR2-N-3 — `mark_recalled_for_agent` now chunks the
+  IN-list.**  SQLite caps host parameters per statement at
   `SQLITE_MAX_VARIABLE_NUMBER` (32 766 in v3.32+, 999 in
-  older builds).  Today the call site in
+  older builds).  The helper now splits its `fact_id` list
+  into `_MAX_IDS_PER_UPDATE` (900) chunks, one UPDATE per
+  chunk, sharing a single trailing `commit`; 900 stays clear
+  of the conservative pre-3.32 cap after the two fixed binds.
+  Today's call site in
   [`memory_context.py`](../../agents/persona_runtime/memory_context.py)
-  pulls IDs from `budget.admissions_by_tier("facts")`,
-  bounded by `FACTS_RECALL_LIMIT=20` × ≤2 seeds = 40 IDs —
-  orders of magnitude below either limit.  But the helper
-  accepts an arbitrary `Iterable[str]` and is callable from
-  other paths (RFC 0013 erasure backfill, RFC 0008
-  calibration); a single-line chunk loop
-  (`for chunk in chunks(ids, 900): …`) future-proofs the
-  API without affecting today's hot path.  PR 5 decision:
-  add the chunk loop to
-  [`_facts_reinforce.py`](../../agents/memory/_facts_reinforce.py)
-  and bump the docstring's "bounded by call-site" note to
-  "bounded by helper-internal chunking".  Pin with a unit
-  test that passes 1 500 IDs and asserts the call succeeds
-  on a sqlite build with the older 999-variable cap (or that
-  asserts the helper issues ≥2 UPDATE statements).
+  pulls ≤40 ids from `budget.admissions_by_tier("facts")` —
+  one chunk, inert — so this future-proofs the API for the
+  RFC 0013 erasure backfill and RFC 0008 calibration callers
+  that pass the helper an arbitrary `Iterable[str]`.  Pinned
+  by `TestMarkRecalledChunking`: a 1 503-id list issues ≥2
+  UPDATEs and still reinforces the real rows; a list one id
+  past the chunk boundary issues exactly two.
 
-- **DR2-N-6 — triple `enc.encode` re-cost on oversized
-  items.**  Pre-existing in
-  [`memory_budget.py`](../../agents/persona_runtime/memory_budget.py),
-  called out by the inline comment ("enc.encode() is invoked
-  3× for oversized items").  With PR 4's new admission
-  registry and the multi-block render, a tight budget can
-  amplify this — a 200-token per-tier slice with a fact line
-  that costs 60 tokens will see the oversized path on the
-  third or fourth item, multiplied across the per-block
-  fan-out.  Out of scope for PR 4 (the path existed before
-  this PR), but the multi-block render makes it more
-  reachable.  PR 5 decision: cache the token count off the
-  first `enc.encode(text)` call in `try_add` and pass it to
-  `_truncate_to_token_limit` so the truncation path can
-  decode against the same token list rather than re-encoding.
-  Pin with a benchmark / micro-bench under
-  `tests/bench/` (RFC 0017 §B notes the bench-suite seam) or
-  with an instrumented test that asserts `enc.encode` is
-  called at most once per `try_add`.
+- **DR2-N-6 — oversized budget items are now encoded once.**
+  [`MemoryBudget.try_add`](../../agents/persona_runtime/memory_budget.py)
+  used to tokenise an oversized item's full text twice — once
+  in `_count_tokens(text)` and again inside
+  `_truncate_to_token_limit` — the "enc.encode() invoked 3×"
+  the pre-fix inline comment flagged.  PR 4's multi-block
+  render makes the oversized path more reachable under a tight
+  per-tier slice.  PR 5e adds `_encode_text`, returning
+  `(count, token_ids)`; `try_add` caches that single encode
+  and threads `token_ids` into `_truncate_to_token_limit`,
+  which decodes against the same list instead of re-encoding.
+  `_count_tokens` is now a thin wrapper over `_encode_text`,
+  so its one-int signature and every external caller are
+  unchanged.  The short truncated string and the one-char
+  ellipsis are still encoded separately — cheap, out of scope.
+  Pinned by `TestEncodeOnceOnOversizedItem` in
+  [`test_memory_budget.py`](../../agents/tests/test_memory_budget.py),
+  which spies `tiktoken.Encoding.encode` and asserts the full
+  text is passed exactly once (pre-fix: twice).
 
-- **DR2-N-8 — `mark_recalled_for_agent` issues its own
-  `db.commit()` even when called inside an outer
-  transactional caller.**  `FactStore` does not currently
-  expose a transaction-scope manager, so all writes
-  auto-commit per call (`store`, `supersede`, `prune`,
-  `delete_by_subject` all commit before returning).  The
-  reinforcement write therefore commits at the very end of
-  every `_inject_memory_context` call — after the facts
-  section has been added to working memory but before the
-  caller builds the LLM prompt — a small write-amplification
-  cost the persona's hot path now pays.  Today's call-site
-  comment frames the failure as non-fatal because the section
-  is already staged in working memory (so the LLM call still
-  succeeds), but the write-cost is unmentioned.  PR 5 decision:
-  calibrate against the MQ-12
-  per-turn-cost budget; if the reinforcement commit shows
-  up in the trace, either batch it with a future facts-tier
-  write (RFC 0026 OQ #9 operator-seeded path is the most
-  natural pair) or expose an explicit
-  `FactStore.transaction()` context manager.  No-op if the
-  calibration shows the commit is in the noise floor.
+- **DR2-N-8 — reinforcement commit cost: no-op resolution.**
+  `FactStore` exposes no transaction-scope manager, so every
+  write auto-commits — the reinforcement UPDATE included, once
+  per `_inject_memory_context` call.  The plan asked for a
+  calibration against the MQ-12 per-turn-cost budget.  A
+  single small UPDATE + commit sits in the noise floor next to
+  the LLM round-trip that immediately follows, so PR 5e takes
+  the **documented no-op branch**: no `FactStore.transaction()`
+  manager is introduced — adding one would be speculative.
+  The reasoning is recorded in the `mark_recalled_for_agent`
+  docstring so a future trace that *does* surface the commit
+  on the hot path has a named revisit point.
 
 ##### From PR 4 review — third-pass deferrals
 
@@ -1131,7 +1120,7 @@ And the two zero-risk doc nits:
 The remaining four ride PR 5.
 
 - **DR3-L-3 — `mark_recalled` ``at=0.0`` and negative ``at``
-  edge cases are uncovered.**  The monotonicity clamp in
+  edge cases — shipped in PR 5e.**  The monotonicity clamp in
   [`_facts_reinforce.py`](../../agents/memory/_facts_reinforce.py)
   uses ``MAX(COALESCE(last_recalled_at, 0), ?)``; ``at=0.0``
   on a NULL column flips the column to 0.0 (a state change),
@@ -1141,14 +1130,15 @@ The remaining four ride PR 5.
   the contracts pinned at
   [`test_fact_store_reinforcement.py`](../../tests/unit/python/test_fact_store_reinforcement.py)
   `test_older_at_does_not_clobber_newer` / `test_first_call_sets_from_null` /
-  `test_equal_at_is_idempotent` leave a small gap where future SQL
-  evolution could regress silently.  PR 5 decision: parameterise
+  `test_equal_at_is_idempotent` left a small gap where future SQL
+  evolution could regress silently.  PR 5e parameterised
   `test_first_call_sets_from_null` over ``[1.0, 0.0]`` and
-  add a one-line ``at=-1.0`` no-op test against an already-
-  populated column.  Low priority — the gap is academic until
-  the OQ #9 operator-seeded-facts path or RFC 0013 erasure
-  backfill starts supplying ``at`` values from sources other
-  than ``time.time()``.
+  added `test_negative_at_is_noop_on_populated_column` — a
+  one-line ``at=-1.0`` no-op pin against an already-populated
+  column.  The gap was academic until the OQ #9
+  operator-seeded-facts path or RFC 0013 erasure backfill
+  starts supplying ``at`` values from sources other than
+  ``time.time()``; the pins close it ahead of those callers.
 
 - **DR3-L-4 — `"Known facts about self:"` header label may
   invite persona-inversion in the LLM's output.**  The header
@@ -1261,8 +1251,8 @@ Per [.github/copilot-instructions.md](../../.github/copilot-instructions.md) "St
 | 5a | Review follow-ups slice 1 — PR 1 review (symmetric latest-wins + nullability) | `feature/v031-rfc0026-followups-pr1` | ✅ Merged | [#344](https://github.com/mkhomutov/Persatrix/pull/344) | 2026-05-15 |
 | 5b | Review follow-ups slice 2 — PR 2 review (envelope parse observability) | `feature/v031-rfc0026-followups-pr2` | ✅ Merged | [#345](https://github.com/mkhomutov/Persatrix/pull/345) | 2026-05-15 |
 | 5c | Review follow-ups slice 3 — PR 3 review storage/render defensive fixes | `feature/v031-rfc0026-followups-pr3a` | ✅ Merged | [#346](https://github.com/mkhomutov/Persatrix/pull/346) | 2026-05-15 |
-| 5d | Review follow-ups slice 4 — PR 3 review tests + counter polish | `feature/v031-rfc0026-followups-pr3b` | 🔀 PR open | — | — |
-| 5e | Review follow-ups slice 5 — PR 4 review (audit, chunking, edge cases) | `feature/v031-rfc0026-followups-pr4` | ⬜ Not started | — | — |
+| 5d | Review follow-ups slice 4 — PR 3 review tests + counter polish | `feature/v031-rfc0026-followups-pr3b` | ✅ Merged | [#347](https://github.com/mkhomutov/Persatrix/pull/347) | 2026-05-15 |
+| 5e | Review follow-ups slice 5 — PR 4 review (audit, chunking, edge cases) | `feature/v031-rfc0026-followups-pr4` | 🔀 PR open | — | — |
 | 6 | RFC close | `feature/v031-rfc0026-close` | ⬜ Not started | — | — |
 
 ---

--- a/tests/unit/python/test_fact_store_reinforcement.py
+++ b/tests/unit/python/test_fact_store_reinforcement.py
@@ -32,14 +32,24 @@ Contracts pinned here:
   backwards step (NTP step-back, operator-supplied ``at`` from an
   older interaction) must not silently age the fact out by resetting
   the column to a stale timestamp.
+* A non-empty ``mark_recalled`` call emits **one** ``fact.recalled``
+  RFC 0026 §G audit record naming every requested ``fact_id`` — once
+  per call, not per id, so audit volume stays bounded (PR #342
+  second-pass review DR2-N-2).  An empty call emits nothing.
+* The reinforcement UPDATE **chunks** its ``fact_id`` IN-list so an
+  arbitrarily large id list cannot exceed SQLite's per-statement host
+  parameter cap (``SQLITE_MAX_VARIABLE_NUMBER`` — 999 on pre-3.32
+  builds) (PR #342 second-pass review DR2-N-3).
 """
 
 from __future__ import annotations
 
+import logging
 import time
+from typing import Any
 
 import pytest
-
+from agents.memory._facts_reinforce import mark_recalled_for_agent
 from agents.memory.facts import FactStore
 
 
@@ -163,17 +173,27 @@ class TestMarkRecalled:
         rows = await fact_store.recall(subject="bob")
         assert rows[0].last_recalled_at == 2500.0
 
+    @pytest.mark.parametrize("at_value", [1.0, 0.0])
     async def test_first_call_sets_from_null(
-        self, fact_store: FactStore,
+        self, fact_store: FactStore, at_value: float,
     ) -> None:
         """``last_recalled_at`` starts ``NULL``; the first
         :meth:`mark_recalled` must succeed regardless of how small
         ``at`` is — the ``MAX(COALESCE(existing, 0), supplied)`` shape
-        means a NULL existing value collapses to 0, so any positive
-        ``at`` (including small ones like ``1.0``) wins.  Regression
-        guard: a naive ``MAX(existing, supplied)`` without ``COALESCE``
-        would yield ``NULL`` on the first call under SQLite's NULL
-        propagation rules.
+        means a NULL existing value collapses to 0, so any
+        non-negative ``at`` wins.  Regression guard: a naive
+        ``MAX(existing, supplied)`` without ``COALESCE`` would yield
+        ``NULL`` on the first call under SQLite's NULL propagation
+        rules.
+
+        Parameterised over ``[1.0, 0.0]`` (PR #342 third-pass review
+        DR3-L-3): ``at=0.0`` is the boundary where the supplied value
+        ties the ``COALESCE`` floor — the column still flips from
+        ``NULL`` to ``0.0`` (a real state change), which the equality
+        assertion below pins.  ``time.time()`` is never 0 in
+        production; the case guards the OQ #9 operator-seeded path and
+        the future RFC 0013 erasure backfill, which may supply ``at``
+        from sources other than the wall clock.
         """
         fact_id = await fact_store.store(
             subject="bob",
@@ -182,9 +202,33 @@ class TestMarkRecalled:
             source_interaction_id="i1",
             asserted_at=1000.0,
         )
-        await fact_store.mark_recalled([fact_id], at=1.0)
+        await fact_store.mark_recalled([fact_id], at=at_value)
         rows = await fact_store.recall(subject="bob")
-        assert rows[0].last_recalled_at == 1.0
+        assert rows[0].last_recalled_at == at_value
+
+    async def test_negative_at_is_noop_on_populated_column(
+        self, fact_store: FactStore,
+    ) -> None:
+        """A negative ``at`` never clobbers a populated column
+        (PR #342 third-pass review DR3-L-3).
+
+        ``MAX(COALESCE(last_recalled_at, 0), -1.0)`` collapses to the
+        existing value for any non-negative column state, so the call
+        is a no-op.  Unreachable in production — ``time.time()`` is
+        monotone non-negative per process — but the case pins the
+        clamp so a future SQL evolution cannot silently regress it.
+        """
+        fact_id = await fact_store.store(
+            subject="bob",
+            predicate="prefers",
+            object="tea",
+            source_interaction_id="i1",
+            asserted_at=1000.0,
+        )
+        await fact_store.mark_recalled([fact_id], at=2500.0)
+        await fact_store.mark_recalled([fact_id], at=-1.0)
+        rows = await fact_store.recall(subject="bob")
+        assert rows[0].last_recalled_at == 2500.0
 
     async def test_does_not_touch_other_columns(
         self, fact_store: FactStore,
@@ -278,6 +322,177 @@ class TestMarkRecalled:
 
         other_rows = await other.recall(subject="bob")
         assert other_rows[0].last_recalled_at is None
+
+
+# ─── Audit emission (PR #342 second-pass review DR2-N-2) ─────
+
+
+def _audit_records(
+    caplog: pytest.LogCaptureFixture, event: str,
+) -> list[logging.LogRecord]:
+    """Return captured ``audit=True`` records whose event name is ``event``.
+
+    Mirrors the dual-surface lookup in
+    :mod:`tests.unit.python.test_fact_store_audit` — unit tests run
+    before :func:`configure_logging` builds the structlog chain, so the
+    event dict may land either as ``record.msg`` (structlog native) or
+    as ``record.msg`` string + attributes (stdlib bridge).
+    """
+    out: list[logging.LogRecord] = []
+    for rec in caplog.records:
+        if isinstance(rec.msg, dict):
+            if rec.msg.get("audit") is True and rec.msg.get("event") == event:
+                out.append(rec)
+        elif getattr(rec, "audit", None) is True and rec.msg == event:
+            out.append(rec)
+    return out
+
+
+def _field(rec: logging.LogRecord, key: str) -> Any:
+    """Read a structured field off a captured audit record (either surface)."""
+    if isinstance(rec.msg, dict):
+        return rec.msg.get(key)
+    return getattr(rec, key, None)
+
+
+class TestMarkRecalledAudit:
+    """DR2-N-2 — ``mark_recalled`` emits a bounded ``fact.recalled`` audit
+    record so the RFC 0026 §G audit log is not blind to reinforcement.
+
+    ``store`` / ``supersede`` already emit ``fact.store`` / ``fact.supersede``;
+    before this slice the reinforcement write left no audit signal, so an
+    MT-MEMORY-005 leg-failure analysis could not tell from the audit log
+    which facts were reinforced on a given turn.
+    """
+
+    async def test_emits_one_fact_recalled_record(
+        self, fact_store: FactStore, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        fact_id = await fact_store.store(
+            subject="bob",
+            predicate="prefers",
+            object="tea",
+            source_interaction_id="i1",
+            asserted_at=1000.0,
+        )
+        caplog.set_level(logging.INFO, logger="agents.memory.facts")
+        caplog.clear()
+        await fact_store.mark_recalled([fact_id], at=2500.0)
+
+        records = _audit_records(caplog, "fact.recalled")
+        assert len(records) == 1
+        rec = records[0]
+        assert _field(rec, "agent_id") == "test-agent"
+        assert list(_field(rec, "fact_ids")) == [fact_id]
+        assert _field(rec, "at") == 2500.0
+
+    async def test_one_record_per_call_not_per_fact(
+        self, fact_store: FactStore, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Audit volume is bounded — a multi-fact call emits a single
+        record carrying the whole id list, not one record per id.
+        """
+        ids = [
+            await fact_store.store(
+                subject=subject,
+                predicate="prefers",
+                object="tea",
+                source_interaction_id="i1",
+                asserted_at=1000.0,
+            )
+            for subject in ("bob", "alice", "carol")
+        ]
+        caplog.set_level(logging.INFO, logger="agents.memory.facts")
+        caplog.clear()
+        await fact_store.mark_recalled(ids, at=2500.0)
+
+        records = _audit_records(caplog, "fact.recalled")
+        assert len(records) == 1
+        assert sorted(_field(records[0], "fact_ids")) == sorted(ids)
+
+    async def test_empty_call_emits_no_record(
+        self, fact_store: FactStore, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.INFO, logger="agents.memory.facts")
+        caplog.clear()
+        await fact_store.mark_recalled([], at=2500.0)
+        assert _audit_records(caplog, "fact.recalled") == []
+
+
+# ─── IN-list chunking (PR #342 second-pass review DR2-N-3) ───
+
+
+class _ExecuteCountingConnection:
+    """Connection proxy that records every ``UPDATE facts`` statement.
+
+    Lets a test assert that :func:`mark_recalled_for_agent` splits a
+    large ``fact_id`` list across multiple UPDATE statements rather than
+    binding every id into one query (which would breach SQLite's
+    per-statement host-parameter cap on older builds).
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+        self.update_statements: list[str] = []
+
+    def execute(self, sql: str, parameters: Any = ()) -> Any:
+        if sql.strip().upper().startswith("UPDATE FACTS"):
+            self.update_statements.append(sql)
+        return self._inner.execute(sql, parameters)
+
+    def commit(self) -> Any:
+        return self._inner.commit()
+
+
+class TestMarkRecalledChunking:
+    """DR2-N-3 — the reinforcement UPDATE chunks its IN-list.
+
+    Today's call site is bounded (≤40 ids) but the helper accepts an
+    arbitrary iterable and is reachable from the future RFC 0013
+    erasure backfill and RFC 0008 calibration paths; chunking
+    future-proofs the API against ``SQLITE_MAX_VARIABLE_NUMBER``.
+    """
+
+    async def test_large_id_list_issues_multiple_updates(
+        self, fact_store: FactStore,
+    ) -> None:
+        live_ids = [
+            await fact_store.store(
+                subject=subject,
+                predicate="prefers",
+                object="tea",
+                source_interaction_id="i1",
+                asserted_at=1000.0,
+            )
+            for subject in ("bob", "alice", "carol")
+        ]
+        # Pad well past the conservative pre-3.32 cap (999) so the
+        # helper is forced to split into more than one statement.
+        id_list = live_ids + [f"pad-{n}" for n in range(1500)]
+
+        counting = _ExecuteCountingConnection(fact_store._ensure_db())
+        await mark_recalled_for_agent(
+            counting, "test-agent", id_list, at=2500.0,
+        )
+
+        assert len(counting.update_statements) >= 2
+        # The real facts still received the reinforcement write.
+        for subject in ("bob", "alice", "carol"):
+            rows = await fact_store.recall(subject=subject)
+            assert rows[0].last_recalled_at == 2500.0
+
+    async def test_chunk_boundary_count_is_exact(
+        self, fact_store: FactStore,
+    ) -> None:
+        """A list one id over a chunk boundary issues exactly two UPDATEs."""
+        from agents.memory._facts_reinforce import _MAX_IDS_PER_UPDATE
+
+        id_list = [f"pad-{n}" for n in range(_MAX_IDS_PER_UPDATE + 1)]
+        counting = _ExecuteCountingConnection(fact_store._ensure_db())
+        await mark_recalled_for_agent(
+            counting, "test-agent", id_list, at=2500.0,
+        )
+        assert len(counting.update_statements) == 2
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

RFC 0026 PR 5e — the fifth and final review-follow-up slice, applying the five PR 4 review findings deferred to PR 5 (the storage-layer reinforcement slice).

## Why

PR 4 ([#342](https://github.com/mkhomutov/Persatrix/pull/342)) shipped use-based reinforcement + retraction; its deep-review passes deferred five non-blocking findings to PR 5. PR 5 was sliced into 5a–5e; this is 5e, the last. PR 6 (RFC close) depends on all five slices merged.

## How

TDD throughout — each test written first, confirmed red, then implemented.

- **DR2-N-2 — reinforcement audit.** `mark_recalled_for_agent` emits one bounded `fact.recalled` RFC 0026 §G audit record per call (after commit, whole id list as a field — not one record per id, so audit volume stays bounded). RFC §G amended to name the event. Before this, the audit log was blind to which facts a turn reinforced.
- **DR2-N-3 — IN-list chunking.** The reinforcement UPDATE splits its `fact_id` list into 900-id chunks (one UPDATE each, single trailing commit) so an arbitrary id list cannot breach SQLite's per-statement host-parameter cap (`SQLITE_MAX_VARIABLE_NUMBER`, 999 on pre-3.32 builds). Inert on today's ≤40-id hot path; future-proofs the RFC 0013 erasure-backfill / RFC 0008 calibration callers.
- **DR2-N-6 — single-encode on oversized items.** New `_encode_text` returns `(count, token_ids)`; `MemoryBudget.try_add` caches that single encode and threads `token_ids` into `_truncate_to_token_limit`, eliminating the redundant full-text re-encode. `_count_tokens` is now a thin wrapper over it, signature unchanged.
- **DR2-N-8 — commit cost.** Reviewed against the MQ-12 per-turn-cost budget: a single small UPDATE+commit per `_inject_memory_context` sits in the noise floor next to the LLM round-trip that immediately follows. Documented no-op — no `FactStore.transaction()` manager added (would be speculative). Reasoning recorded in the helper docstring with a named revisit point.
- **DR3-L-3 — clamp edge cases.** `test_first_call_sets_from_null` parameterised over `[1.0, 0.0]`; added `test_negative_at_is_noop_on_populated_column` — pins the `MAX(COALESCE(...), ?)` monotonicity clamp so a future SQL change cannot regress it silently.

### Incidental fix

`agents/tests/test_inject_memory_context.py` — the `_FakeNote` test fake lacked an `id` attribute that PR 4's `record_admission(item_id=note.id)` wiring requires; 4 tests were red on the base branch (confirmed by stashing this branch's changes). Fixed here since this slice is the PR-4-review follow-up and already touches `agents/tests/`.

## Spec Reference

- RFC 0026 PR plan — §PR 5e, §From PR 4 review — second-pass deferrals
- RFC 0026 §F (reinforcement), §G (audit and provenance)

## Checklist

- [x] Tests pass — `tests/unit/python/` (1063), `agents/tests/` (207), integration facts suites; all green
- [x] Lint passes — `ruff check .` and `mypy .` clean
- [x] TDD: new tests written first and confirmed failing before implementation
- [x] No production behaviour change beyond the audit emission; chunk loop inert on the hot path
- [x] RFC 0026 §G + PR-plan Progress Overview updated