### PR TITLE
feat(v031): RFC 0034 PR 4 — history-fetcher review follow-ups

### DIFF
--- a/agents/channel_history_fetcher.py
+++ b/agents/channel_history_fetcher.py
@@ -13,11 +13,11 @@ The :class:`ChannelHistoryFetcher` :class:`typing.Protocol` is the seam:
 production code binds :class:`HttpChannelHistoryFetcher`, tests bind a
 duck-typed fake without inheritance ceremony.
 
-Contract (verbatim from the lifted catch-up helper): :meth:`fetch`
-returns the channel's message list on success, ``[]`` when the
-``messages`` field is absent or not a list, and ``None`` on any HTTP
-4xx/5xx or transport error (logged WARN). ``None`` means "best-effort
-failure already logged" — callers branch on it rather than catching an
+Contract: :meth:`fetch` returns the channel's message list on success,
+``[]`` when the response body is not a JSON object or its ``messages``
+field is absent / not a list, and ``None`` on any HTTP 4xx/5xx or
+transport error (logged WARN). ``None`` means "best-effort failure
+already logged" — callers branch on it rather than catching an
 exception, so the catch-up call site's ``if messages is None: continue``
 guard is unchanged.
 
@@ -76,10 +76,10 @@ class ChannelHistoryFetcher(Protocol):
 class HttpChannelHistoryFetcher:
     """Production :class:`ChannelHistoryFetcher` backed by ``aiohttp``.
 
-    The :meth:`fetch` body is the verbatim
-    ``GET /api/v1/channels/{id}/messages?limit=N`` request lifted from
-    the former ``agents.channel_catchup._fetch_channel_history`` helper —
-    same ``None``-on-error / list-on-success contract.
+    The :meth:`fetch` body issues the
+    ``GET /api/v1/channels/{id}/messages?limit=N`` request originally
+    lifted from the former ``agents.channel_catchup._fetch_channel_history``
+    helper — same ``None``-on-error / list-on-success contract.
 
     ``session``, ``orchestrator_url`` and ``timeout`` are resolved once
     at construction; :meth:`fetch` takes only the per-call ``channel_id``
@@ -116,18 +116,24 @@ class HttpChannelHistoryFetcher:
                 if resp.status >= 400:
                     body = await resp.text()
                     logger.warning(
-                        "channels: catch-up history %s returned HTTP %d: %s",
+                        "channels: history fetch %s returned HTTP %d: %s",
                         channel_id, resp.status, body[:256],
                     )
                     return None
                 data = await resp.json()
+            # Shape guard inside the request ``try``: a 2xx response whose
+            # JSON body is not an object (a bare array, string, number, or
+            # ``null``) must degrade to ``[]`` like a ``dict`` with an
+            # unusable ``messages`` field — not raise ``AttributeError`` on
+            # ``data.get`` and escape the "never raises across the seam"
+            # contract the conversation-window caller depends on.
+            messages = data.get("messages") if isinstance(data, dict) else None
         except Exception as exc:
             logger.warning(
-                "channels: catch-up history %s failed: %s",
+                "channels: history fetch %s failed: %s",
                 channel_id, exc,
             )
             return None
-        messages = data.get("messages")
         if not isinstance(messages, list):
             return []
         return messages

--- a/tests/unit/python/test_channel_history_fetcher.py
+++ b/tests/unit/python/test_channel_history_fetcher.py
@@ -14,11 +14,11 @@ Contract under test:
   never raises. The catch-up call site's ``if messages is None:
   continue`` guard depends on this exact contract.
 * A 2xx response whose JSON body is not an object (a bare array,
-  string, number, or ``null``) is a *known gap*: ``data.get`` runs
-  outside the request ``try``, so ``fetch`` raises ``AttributeError``
-  instead of degrading to ``[]``. Pinned under ``xfail`` by
-  :class:`TestHttpChannelHistoryFetcherTopLevelNonObjectBody`; RFC 0034
-  PR 4 closes it.
+  string, number, or ``null``) degrades to ``[]`` — RFC 0034 PR 4
+  moved the ``isinstance(data, dict)`` shape guard inside the request
+  ``try`` so an unusable body no longer raises ``AttributeError``
+  across the seam. Pinned by
+  :class:`TestHttpChannelHistoryFetcherTopLevelNonObjectBody`.
 * The default-constructed fetcher uses the 10s per-request timeout the
   catch-up path uses today.
 * A duck-typed fake satisfies the :class:`ChannelHistoryFetcher`
@@ -235,34 +235,22 @@ class TestHttpChannelHistoryFetcherMalformedPayload:
 
 class TestHttpChannelHistoryFetcherTopLevelNonObjectBody:
     """A 2xx response whose JSON body is *not* an object — a bare
-    array, string, number, or ``null`` — is a known gap in the lifted
-    contract.
+    array, string, number, or ``null`` — degrades to ``[]``.
 
-    ``HttpChannelHistoryFetcher.fetch`` reads ``data.get("messages")``
-    *outside* the ``try`` that wraps the request and ``resp.json()``. A
-    non-``dict`` ``data`` makes that attribute lookup raise
-    ``AttributeError``, which escapes ``fetch`` instead of degrading to
-    ``[]`` the way a ``dict`` with a bad ``messages`` field does (see
+    Before RFC 0034 PR 4, ``HttpChannelHistoryFetcher.fetch`` read
+    ``data.get("messages")`` *outside* the ``try`` that wraps the
+    request and ``resp.json()``. A non-``dict`` ``data`` made that
+    attribute lookup raise ``AttributeError``, which escaped ``fetch``
+    instead of degrading to ``[]`` the way a ``dict`` with a bad
+    ``messages`` field does (see
     :class:`TestHttpChannelHistoryFetcherMalformedPayload`).
 
-    PR 1 is a verbatim lift of ``_fetch_channel_history`` and changes
-    no behaviour, so the gap is preserved as-is. The *intended*
-    contract — a request that succeeds but carries an unusable body
-    degrades to ``[]`` and never raises across the seam — is asserted
-    here under ``xfail(strict=True)``: the test xfails today and will
-    xpass the moment the shape guard moves inside the ``try``, so
-    RFC 0034 PR 4 cannot close the gap without also removing this
-    marker. Tracked in ``docs/rfcs/0034-pr-plan.md`` PR 4,
-    "From PR 1 review".
+    PR 4 moved the ``isinstance(data, dict)`` shape guard inside the
+    ``try``: a request that succeeds but carries an unusable body now
+    degrades to ``[]`` and never raises across the seam — the contract
+    the RFC 0034 conversation-window caller depends on.
     """
 
-    @pytest.mark.xfail(
-        raises=AttributeError,
-        strict=True,
-        reason="known gap — data.get() runs outside the request try; "
-        "RFC 0034 PR 4 moves the shape guard inside so a non-object "
-        "2xx body degrades to [] instead of raising AttributeError",
-    )
     @pytest.mark.parametrize(
         "body",
         [
@@ -393,6 +381,52 @@ class TestHttpChannelHistoryFetcherFailures:
 
         assert messages is None
         assert any("failed" in rec.message for rec in caplog.records)
+
+    async def test_warn_messages_are_caller_agnostic(self, caplog):
+        """Both WARN strings name the *operation*, not a caller.
+
+        RFC 0034 PR 4: the fetcher serves the on-startup catch-up replay
+        *and* the persona conversation window, so the two WARN strings —
+        lifted from the catch-up helper as "catch-up history ..." —
+        misled an operator when a fetch failed on a live persona turn.
+        Both branches now use the caller-agnostic "history fetch"
+        prefix; this pins the rename against a silent regression.
+        """
+
+        def _assert_generic(label: str) -> None:
+            warns = [r.message for r in caplog.records]
+            assert warns, f"expected a {label} WARN"
+            assert all("catch-up" not in m for m in warns), \
+                f"WARN must not name a caller; got {warns!r}"
+            assert all("history fetch" in m for m in warns), \
+                f"expected the generic 'history fetch' prefix; got {warns!r}"
+
+        async def server_error(_request: web.Request) -> web.StreamResponse:
+            return web.Response(text="boom", status=503)
+
+        # HTTP-error branch (``resp.status >= 400``).
+        with caplog.at_level("WARNING", logger="agents.channel_history_fetcher"):
+            async with _serve(server_error) as base_url, \
+                    aiohttp.ClientSession() as session:
+                fetcher = HttpChannelHistoryFetcher(
+                    session=session, orchestrator_url=base_url,
+                )
+                assert await fetcher.fetch("c1", limit=20) is None
+        _assert_generic("HTTP-error")
+
+        caplog.clear()
+
+        # Transport-error branch (the bare ``except`` arm). Port 1 is
+        # privileged and unbound in the test env.
+        with caplog.at_level("WARNING", logger="agents.channel_history_fetcher"):
+            async with aiohttp.ClientSession() as session:
+                fetcher = HttpChannelHistoryFetcher(
+                    session=session,
+                    orchestrator_url="http://127.0.0.1:1",
+                    timeout=aiohttp.ClientTimeout(total=1.0),
+                )
+                assert await fetcher.fetch("c1", limit=20) is None
+        _assert_generic("transport-error")
 
 
 class TestHttpChannelHistoryFetcherTimeout:


### PR DESCRIPTION
## Summary

RFC 0034 Phase 1 **PR 4 of 5** — Review Follow-Ups ([0034-pr-plan.md §PR 4](docs/rfcs/0034-pr-plan.md)). Addresses the two findings recorded under *From PR 1 review*; PR 2 review recorded none, and the PR 3 review findings were all resolved within PR 3.

**Finding 1 — `fetch` could raise on a successful-but-malformed response.** `HttpChannelHistoryFetcher.fetch` read `data.get("messages")` *outside* the request `try`. A 2xx response whose JSON body is not an object (a bare array, string, number, or `null`) made that attribute lookup raise `AttributeError`, escaping `fetch` instead of degrading to `[]` the way a `dict` with a bad `messages` field does. The `isinstance(data, dict)` shape guard now lives inside the `try`, so an unusable body degrades to `[]` and never raises across the seam — the contract the RFC 0034 conversation-window caller depends on. The PR 1 test that pinned this gap under `xfail(strict=True)` (`TestHttpChannelHistoryFetcherTopLevelNonObjectBody`) loses its marker and now asserts the closed contract directly.

**Finding 2 — caller-specific WARN prefix.** Both `logger.warning` strings read `"channels: catch-up history …"`, wording lifted verbatim from the former catch-up helper. The fetcher now also serves the persona conversation window (PR 3), so a fetch failure on a live persona turn logged a misleading catch-up-flavoured message. Genericized to `"channels: history fetch …"`. No log-scraping alert or dashboard greps the old literal (verified repo-wide before renaming).

## TDD

- **RED** — removed the `xfail` marker (4 non-object-body cases then fail with `AttributeError`); added `test_warn_messages_are_caller_agnostic` (fails against the old `catch-up` prefix). 5 failing.
- **GREEN** — moved the shape guard inside the `try`; genericized both WARN strings. 25 passing.

## Test plan

- [x] `pytest tests/unit/python/test_channel_history_fetcher.py -q` — 25 passed (was 20 passed + 4 xfailed)
- [x] `pytest tests/unit/python/test_channel_catchup.py test_channel_catchup_followups.py -q` — catch-up regression suites pass unchanged
- [x] `pytest tests/unit/python/test_conversation_window*.py tests/integration/test_conversational_continuity.py -q` — downstream consumers green (PR 3 integration test included)
- [x] `ruff check` + `mypy agents/channel_history_fetcher.py` clean
- [x] `file_size.py --strict` clean (test file trimmed to 495 lines, under the 500-line cap)