### PR TITLE
chore(release): bump to v0.3.1 + curate changelog (PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,79 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.3.1] - 2026-05-17
 
-### Added
+> **Codename:** Memory Quality
 
-- **RFC 0033 — Provider-Agnostic Model Alias Layer (Draft).** Proposes a single source of truth for model identity: a named alias map (`quality` / `fast` / `summarizer` → `{provider, model_id, pricing}`) that agent configs reference instead of vendor-specific model strings. Today the same physical model ID appears in [`config/agents.yaml`](config/agents.yaml) (×6), [`config/optimization.yaml`](config/optimization.yaml) (defaults *and* pricing keys), [`agents/persona_types.py`](agents/persona_types.py) as a dataclass default, and ~20 docs — every vendor deprecation cycle requires a sweep across all of them, and the in-code `_infer_provider` string-prefix heuristic in [`agents/llm_client.py`](agents/llm_client.py) does not scale past two vendors. Phased: Phase 1 (v0.3.x) ships the resolver + alias config block + first migration, absorbing the [Anthropic Sonnet 4 retirement](https://platform.claude.com/docs/en/about-claude/model-deprecations) (2026-06-15) by editing one alias entry instead of sweeping the codebase; Phase 2 adds a `persatrix.llm.model_alias` OTEL attribute (per RFC 0019's `persatrix.*` reserved-namespace rule) and derives the legacy pricing table from aliases; Phase 3 retires the raw-ID pass-through and `_infer_provider` once observed traffic shows zero raw-ID usage (gate is observed traffic, not a calendar). Status `📋 Proposed`; 6 open questions captured. ([docs/rfcs/0033-model-alias-layer.md](docs/rfcs/0033-model-alias-layer.md); ROADMAP RFC Master Index updated.)
-- **Per-session storage tags on the Go orchestrator** (RFC 0031 Phase 1 — PR 2). The `channels` SQLite store now tags every channel and message row with a `session_id` column (default `'legacy'`), backed by a new `sessions` table created empty (Phase 3 CLI owns seeding). The chronological-scan index is replaced with the covering shape `(channel_id, session_id, timestamp DESC)` so today's `channel_id`-only history scans stay cheap AND Phase 2's per-session filter uses the same index without a follow-up migration. A new `idx_channels_session` supports fast per-session channel listings. The orchestrator reads `PERSATRIX_SESSION_ID` at boot and stamps the value on every `CreateChannel` / `PublishMessage` write — unset falls through to the `legacy` carve-out with an INFO line; non-canonical values (outside `[A-Za-z0-9_-]`) emit a WARN but are accepted verbatim (hard validation lives in Phase 3 CLI). A new `sessions.writes{session_id}` OTEL counter increments on every store write. No recall-side filtering yet — that ships in Phase 2.
-- **Per-session storage tags on the Python persona runtime** (RFC 0031 Phase 1 — PR 3). The memory SQLite store mirrors the orchestrator-side shape: a new migration v7 adds `session_id TEXT NOT NULL DEFAULT 'legacy'` to `episodes` and `relationships`, plus `idx_episodes_session` and `idx_rel_session`. `EpisodicMemory.store_episode` and `RelationshipMemory.record_interaction` accept `session_id` as a keyword-only kwarg; relationships use a first-seen-wins contract (the ON CONFLICT branch does not overwrite the tag, matching how `trust_score` is preserved). The persona runtime reads `PERSATRIX_SESSION_ID` at construction and threads it through every store-path call — unset → `legacy` with a single INFO boot-log line (parity with the Go side). The `MT-SESSION-001` manual-test walkthrough (executed at v0.3.1 release prep) ties both halves together end-to-end.
+### Highlights
+
+- **Declarative facts tier — the persona remembers stated facts about you across interactions** (RFC 0026). The persona extracts stated `(subject, predicate, object)` facts at interaction close — names, preferences, commitments — and persists them to a new `facts` table indexed by subject, separate from the prose episode summary. At recall time `MemoryFacade` injects them into the persona prompt through a dedicated `facts_context` section, so a fact stated days ago survives idle-gap closure and resurfaces by subject rather than by keyword overlap. `MT-MEMORY-005` (the dementia test) is promoted from a v0.3.0 baseline measurement to a pass/fail acceptance gate.
+- **Persona conversational working memory for DM channels** (RFC 0034 Phase 1). A persona now follows the conversation it is currently having: the persona LLM `messages` array carries the reconstructed in-progress DM transcript instead of a single isolated message, so the persona recalls its own prior question and resolves referential follow-ups within the session. DM channels only in v0.3.1 — group channels keep the single-message behaviour (Phase 2). Operator escape hatch: `conversation_window.enabled: false`.
+- **Per-session storage namespacing — write-path plumbing** (RFC 0031 Phase 1). A new `sessions` table plus `session_id` columns on channels, messages, episodes, and relationships tag every storage write with the `PERSATRIX_SESSION_ID` env var, read at orchestrator and persona-runtime boot. Phase 1 is write-path only — recall does not yet filter by session, and `make reset` remains the cross-run isolation path. The operator CLI and recall filtering land in later v0.3.x phases.
 
 ### Upgrade Notes
 
 | Notable change | Detail |
 |----------------|--------|
-| **[Breaking]** Chat wire-field renamed `session_id` → `chat_session_id` | RFC 0031 Phase 1 introduces an operator-namespace `session_id` on channels, messages, episodes, and relationships. To disambiguate it from RFC 0016's chat-conversation token, `ChatRequest.session_id` (proto field 4) and `ChatResponse.session_id` (proto field 2) are renamed to `chat_session_id`. **Field numbers are preserved**, so binary-proto consumers are unaffected. **JSON / proto-text consumers must migrate**: REST callers of `POST /api/v1/agents/{id}/chat` sending the legacy `"session_id"` JSON key now receive `400 BAD_REQUEST "invalid or malformed JSON body"` — the Go handler decodes with `DisallowUnknownFields`, so unknown keys fail loud rather than degrading to a fresh-session mint. Migrate by switching the JSON key to `"chat_session_id"`. Proto3-JSON callers using `google.protobuf.json_format` raise `ParseError` unless `ignore_unknown_fields=True` is set (and even then `chat_session_id` parses to its zero value — the legacy value is discarded). Manual-test recipes are updated end-to-end: REST `curl` flows [`MT-CHAT-001`](docs/manual-tests/MT-CHAT-001.md), [`MT-CHAT-003`](docs/manual-tests/MT-CHAT-003.md), [`MT-CHAT-004`](docs/manual-tests/MT-CHAT-004.md); the CLI REPL flow [`MT-CHAT-002`](docs/manual-tests/MT-CHAT-002.md) (session-reuse prose); and the PowerShell channel-inspection flow [`MT-CHANNEL-005`](docs/manual-tests/MT-CHANNEL-005.md) (`Select-Object` on the `chat_session_id` metadata key). The chat-message Mermaid in [`docs/diagrams/workflow-execution.md`](docs/diagrams/workflow-execution.md) shows the renamed wire-field on the gRPC arrow. The `ChannelMessage.Metadata` map key also moves: `"session_id"` → `"chat_session_id"`. Resolves [RFC 0031 OQ #8](docs/rfcs/0031-per-session-namespacing-channels.md#open-questions). |
-| `channels.db` schema bumped v2 → v3 | The channels SQLite schema gains a `sessions` table plus `session_id` columns on `channels` and `messages` (default `'legacy'`). The migration runs forward-only on startup; rolling back requires restoring from a pre-upgrade backup. Existing rows are stamped `'legacy'` via the SQLite `ALTER TABLE ... DEFAULT` semantics (no backfill UPDATE). Operators tagging new traffic should set `PERSATRIX_SESSION_ID=<id>` before starting the orchestrator. |
-| `memory.db` schema bumped v6 → v7 | The persona memory SQLite schema gains a `session_id` column on `episodes` and `relationships` (default `'legacy'`), plus `idx_episodes_session` and `idx_rel_session`. Forward-only migration; existing rows pick up the `'legacy'` carve-out via the SQLite `ALTER TABLE ... DEFAULT` semantics. To tag persona writes, set `PERSATRIX_SESSION_ID=<id>` in the persona-runtime's environment before start — same value as the orchestrator-side variable. Relationship rows track *first-seen* session; a later interaction with a different env value does not overwrite the per-row tag. |
+| **[Breaking]** chat-session wire-field rename | `ChatRequest.session_id` / `ChatResponse.session_id` JSON keys renamed to `chat_session_id` ([RFC 0031 OQ #8](docs/rfcs/0031-per-session-namespacing-channels.md#open-questions)) to disambiguate from RFC 0031's operator-namespace `session_id`. Proto field numbers are preserved; JSON / proto-text consumers must migrate. The Rust CLI and the in-tree REST flow are already updated. |
+| `channels.db` schema bump (v2→v3) | Adds the `sessions` table and `session_id` columns on channel/message rows. Forward-only migration; existing rows pick up the `legacy` session carve-out. |
+| `memory.db` schema bump (v6→v8) | Two forward-only migrations: v7 adds `session_id` on `episodes` and `relationships`; v8 creates the RFC 0026 `facts` table (which carries `session_id` from creation). Existing rows pick up the `legacy` carve-out. |
+| New `PERSATRIX_SESSION_ID` env var | Read at orchestrator + persona-runtime boot, stamped on every storage write. Unset ⇒ the `legacy` carve-out with an INFO boot line. Set the **same value in both processes** to keep a run coherent. Phase 1 is write-path only — recall does not yet filter by session. |
+| New declarative facts tier (RFC 0026) | The persona extracts stated `(subject, predicate, object)` facts at interaction close and injects them into the persona prompt via a new `facts_context` section. Out-of-tree prompt evaluators will see a new tier in the system prompt. `memory.facts.enabled: false` disables fact recall/injection per-agent; the close-path extractor keeps writing facts regardless. |
+| New `conversation_window` config block (RFC 0034) | A top-level `conversation_window` block lands in `config/agents.yaml` + `config/optimization.yaml`, validated by the new `schemas/optimization.schema.json`. The persona LLM `messages` array now carries the in-progress DM transcript instead of a single isolated message. Operator escape hatch: `conversation_window.enabled: false`. DM channels only in v0.3.1. |
+| `make reset` deprecation breadcrumb | `make reset` remains the supported cross-run storage-isolation path. RFC 0031 Phase 3's `persatrix session …` CLI (`persatrix session new --activate`) will succeed it for run isolation in a later v0.3.x patch; `make reset` then becomes the deprecated nuclear option for clearing all volumes across all sessions. |
+
+### 🚀 Features
+
+- *(v031)* RFC 0031 PR 1 — rename chat session_id → chat_session_id (#333)
+- *(v031)* RFC 0031 PR 2 — sessions table + Go session_id columns + PERSATRIX_SESSION_ID (#335)
+- *(v031)* RFC 0031 PR 3 — Python session_id columns + persona-runtime PERSATRIX_SESSION_ID (#336)
+- *(v031)* RFC 0031 PR 4 — Phase 1 review follow-ups (#337)
+- *(v031)* RFC 0026 PR 1 — facts schema + FactStore + erasure primitive (#339)
+- *(v031)* RFC 0026 PR 2 — extractor + predicate allowlist + audit (#340)
+- *(v031)* RFC 0026 PR 3 — FactStore.recall + MemoryBudget tier slot + config (#341)
+- *(v031)* RFC 0026 PR 4 — reinforcement + retraction + tier provenance + MT update (#342)
+- *(v031)* RFC 0026 PR 5a — symmetric latest-asserted-wins + source_interaction_id nullability (#344)
+- *(v031)* RFC 0026 PR 5b — envelope parse-failure observability (#345)
+- *(v031)* RFC 0026 PR 5c — PR 3 review storage/render defensive fixes (#346)
+- *(v031)* RFC 0026 PR 5d — PR 3 review tests + counter polish (#347)
+- *(v031)* RFC 0026 PR 5e — PR 4 review audit/chunking/edge cases (#348)
+- *(v031)* RFC 0034 PR 1 — channel-history fetcher behind Protocol (#351)
+- *(v031)* RFC 0034 PR 2 — conversation-window module + config/schema (#352)
+- *(v031)* RFC 0034 PR 3 — wire conversation window + DM itest (#356)
+- *(v031)* RFC 0034 PR 4 — review follow-ups (history-fetcher hardening) (#357)
+
+### 🐛 Bug Fixes
+
+- *(v031)* ISSUE-0054 — RFC 0026 facts tier extracted no facts at interaction close (markdown-fence strip + extractor message-content input + summarise/extract output-token cap 256 → 1024) (#361)
+- *(v031)* Single-turn interactions extract facts (MT-MEMORY-005 F-6) (#362)
+
+### 📚 Documentation
+
+- *(release)* Post-release follow-up for v0.3.0 (#330)
+- *(v0.3.1)* Re-sequence v0.3.x and open v0.3.1 master plan (#331)
+- *(v0.3.1)* RFC 0026 + RFC 0031 PR plans (Phase 1 combined scaffold) (#332)
+- *(v031)* RFC 0031 PR 5 — Phase 1 closeout (#338)
+- *(rfcs)* RFC 0033 — provider-agnostic model alias layer (#343)
+- *(rfcs)* RFC 0032 stub — channel interaction layer unification (#334)
+- *(v0.3.1)* Absorb RFC 0034 - persona conversational working memory (#349)
+- *(rfc-0034)* Resolve open questions and add Phase 1 PR plan (#350)
+- *(rfcs)* RFC 0035 + RFC 0036 — membership ledger and persona message recall (#353)
+- *(rfcs)* RFC 0012 + 0037 + 0038 — confidentiality, authority & concurrent-context awareness (#354)
+- *(rfcs)* RFC 0039 — user accounts & authentication foundation (#355)
+- *(v031)* RFC 0034 PR 5 — Phase 1 closeout (#358)
+- *(v031)* RFC 0026 PR 6 — RFC close (#359)
+- *(v031)* V0.3.1 release-prep plan (master-plan Phase 3) (#360)
+- *(v031)* V0.3.1 release-prep PR 1 — manual test execution report (#361)
+- *(v031)* V0.3.1 release-prep PR 2 — docs refresh + release checklist (#363)
+
+### 🧪 Testing
+
+- New manual tests `MT-SESSION-001` (`PERSATRIX_SESSION_ID` cross-process write contract, RFC 0031 Phase 1) and `MT-PERSONA-CONVERSATION-001` (persona conversational continuity over a DM channel, RFC 0034 Phase 1)
+- `MT-MEMORY-005` (the dementia test) promoted from a v0.3.0 baseline measurement to a pass/fail acceptance gate — Legs 1, 2, 5 are release blockers
+- Facts-tier, conversation-window, and `session_id` integration suites added across the RFC 0026 / 0034 / 0031 PR clusters
+
+[0.3.1]: https://github.com/mkhomutov/Persatrix/compare/v0.3.0...v0.3.1
 
 ## [0.3.0] - 2026-05-12
 

--- a/agents/observability/metrics.py
+++ b/agents/observability/metrics.py
@@ -52,7 +52,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.0"
+_DEFAULT_SERVICE_VERSION = "0.3.1"
 _DEFAULT_EXPORT_INTERVAL_MS = 60_000
 _DEFAULT_EXPORT_TIMEOUT_MS = 10_000
 

--- a/agents/observability/tracing.py
+++ b/agents/observability/tracing.py
@@ -16,7 +16,7 @@ Environment variables (all optional; defaults match the Go side):
     PERSATRIX_AGENT_ID             sets ``service.instance.id``
     PERSATRIX_SERVICE_ROLE         sets ``service.role`` (optional free-text)
     PERSATRIX_SERVICE_VERSION      sets ``service.version``
-                                    (default: "0.3.0")
+                                    (default: "0.3.1")
 
 Baggage key naming convention
 -----------------------------
@@ -69,7 +69,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.0"
+_DEFAULT_SERVICE_VERSION = "0.3.1"
 
 # BatchSpanProcessor tuning — deterministic across environments.
 _BSP_MAX_QUEUE_SIZE = 2048

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.3.0"
+version = "0.3.1"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/docs/manual-tests/MT-PERSONA-CONVERSATION-001.md
+++ b/docs/manual-tests/MT-PERSONA-CONVERSATION-001.md
@@ -4,8 +4,8 @@
 **Feature Area**: Persona Runtime (RFC 0034 Phase 1 — Conversation Window, DM channels)
 **Version**: 1.0
 **Created**: 2026-05-16
-**Last Updated**: 2026-05-16
-**Status**: Draft (scaffold — executed in v0.3.1 release prep, [v0.3.1-plan Phase 4 PR 1](../v0.3.1-plan.md#phase-4--v031-release-prep-execution))
+**Last Updated**: 2026-05-17
+**Status**: Active (promoted from Draft scaffold — passed both legs in the [v0.3.1 release-prep execution report](v0.3.1-execution-report.md); RFC 0034 Phase 1 landed)
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -57,7 +57,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | [MT-PERSONA-002](MT-PERSONA-002.md) | Persona handles an inbound channel message and produces a logged response | Active |
 | [MT-PERSONA-003](MT-PERSONA-003.md) | Empty-context TICK short-circuit suppresses LLM calls (RFC 0017 §F) | Active |
 | [MT-PERSONA-004](MT-PERSONA-004.md) | Persona does not adopt user-name in first person (grounding clause) | Active |
-| [MT-PERSONA-CONVERSATION-001](MT-PERSONA-CONVERSATION-001.md) | Persona conversational continuity (DM) | Draft |
+| [MT-PERSONA-CONVERSATION-001](MT-PERSONA-CONVERSATION-001.md) | Persona conversational continuity (DM) | Active |
 
 ## Chat
 

--- a/docs/v0.3.1-release-checklist.md
+++ b/docs/v0.3.1-release-checklist.md
@@ -50,10 +50,10 @@ Before tagging, all shipped components must declare `0.3.1` consistently.
 
 Checklist (filled in by release-prep plan PR 3):
 
-- [ ] `agents/pyproject.toml` updated to `0.3.1`
-- [ ] `cli/Cargo.toml` updated to `0.3.1`
-- [ ] `cli/Cargo.lock` regenerated and committed
-- [ ] `make all` builds successfully with the new versions
+- [x] `agents/pyproject.toml` updated to `0.3.1`
+- [x] `cli/Cargo.toml` updated to `0.3.1`
+- [x] `cli/Cargo.lock` regenerated and committed
+- [x] `make all` builds successfully with the new versions
 - [ ] No docs or examples still describe v0.3.1 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist flipped in the post-release follow-up PR)
 
 ---
@@ -64,17 +64,17 @@ The release changelog must preserve the curated `[0.3.0]`, `[0.2.3]`, `[0.2.2]`,
 
 Checklist:
 
-- [ ] `CHANGELOG.md` contains a `[0.3.1]` section
-- [ ] The existing curated `[0.3.0]`, `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
-- [ ] The seeded operator-visible text from the `[Unreleased]` section is preserved verbatim, moved under an Upgrade Notes subsection (see §3.1 below)
-- [ ] The `[0.3.1]` section includes:
+- [x] `CHANGELOG.md` contains a `[0.3.1]` section
+- [x] The existing curated `[0.3.0]`, `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
+- [x] The seeded operator-visible text from the `[Unreleased]` section is preserved verbatim, moved under an Upgrade Notes subsection (see §3.1 below)
+- [x] The `[0.3.1]` section includes:
   - **Highlights**: declarative facts tier (stated facts remembered across interactions), persona conversational working memory for DM channels, per-session storage namespacing (write-path plumbing)
   - **Features**: RFC 0026 PRs 1–6, RFC 0031 Phase 1 PRs 1–5, RFC 0034 Phase 1 PRs 1–5 (PR ranges per [release-prep plan §RFC PR roll-up](v0.3.1-release-prep-plan.md#rfc-pr-roll-up))
   - **Bug fixes**: ISSUE-0054 facts-tier close-path fix chain (markdown fence + extractor input + token-cap), single-turn-interaction fact extraction (MT-MEMORY-005 F-6)
   - **Documentation**: MT execution report (release-prep PR 1), this docs refresh (release-prep PR 2), release-prep + master plans
   - **Testing**: 2 new MTs (`MT-SESSION-001`, `MT-PERSONA-CONVERSATION-001`), `MT-MEMORY-005` promoted to a pass/fail acceptance gate, facts-tier + conversation-window + session-id integration suites
   - **Upgrade Notes** subsection (see §3.1 below)
-- [ ] RFC 0033 (`📋 Proposed`, no implementation in v0.3.1) stays under an RFC-tracking line, **not** a feature entry
+- [x] RFC 0033 (`📋 Proposed`, no implementation in v0.3.1) stays under an RFC-tracking line, **not** a feature entry
 
 Suggested generation command:
 
@@ -223,12 +223,12 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [ ] make check-licenses passes
 [ ] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
 [ ] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
-[ ] agents/pyproject.toml updated to 0.3.1
-[ ] cli/Cargo.toml updated to 0.3.1
-[ ] cli/Cargo.lock regenerated and committed
-[ ] make all builds successfully
-[ ] CHANGELOG.md contains a curated [0.3.1] section with upgrade notes
-[ ] Existing [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
+[x] agents/pyproject.toml updated to 0.3.1
+[x] cli/Cargo.toml updated to 0.3.1
+[x] cli/Cargo.lock regenerated and committed
+[x] make all builds successfully
+[x] CHANGELOG.md contains a curated [0.3.1] section with upgrade notes
+[x] Existing [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
 [ ] All 30 manual tests recorded in docs/manual-tests/v0.3.1-execution-report.md
 [ ] No unresolved Fail in manual tests; zero Not run
 [ ] MT-MEMORY-005 Legs 1, 2, 5 recorded Pass with per-leg evidence (release gate)

--- a/docs/v0.3.1-release-checklist.md
+++ b/docs/v0.3.1-release-checklist.md
@@ -15,13 +15,13 @@
 
 All gates run on a clean checkout of the release-candidate commit, executed by PR 4 of the release-prep plan.
 
-- [ ] `make test` is green on a clean checkout (Go + Python unit + Python integration; per-suite pass counts recorded in the PR 4 description)
-- [ ] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
-- [ ] `make validate` passes for all config files — including the new `conversation_window` block in `config/agents.yaml` + `config/optimization.yaml` and the new `schemas/optimization.schema.json`
-- [ ] Proto staleness check passes: `make proto` then `git diff --exit-code` (no generated drift)
-- [ ] `make check-licenses` is clean for Go, Python, and Rust (Python check run against the project `.venv`, not the user-wide interpreter)
-- [ ] `make notices` regenerated and diffed — the v0.3.1 RFCs add no third-party deps, but PR 4 runs the sweep regardless and commits any delta to [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md)
-- [ ] `make generate-sanitizer-patterns-check` passes — Go ↔ Python sanitizer pattern parity gate
+- [x] `make test` is green on a clean checkout (Go + Python unit + Python integration; per-suite pass counts recorded in the PR 4 description) — Go 16 pkgs, Python unit 2287 passed, integration 205 passed
+- [x] `make lint` is clean (golangci-lint, ruff, mypy, clippy)
+- [x] `make validate` passes for all config files — including the new `conversation_window` block in `config/agents.yaml` + `config/optimization.yaml` and the new `schemas/optimization.schema.json`
+- [x] Proto staleness check passes: `make proto` then `git diff --exit-code` (no generated drift)
+- [x] `make check-licenses` is clean for Go, Python, and Rust (Python check run against the project `.venv`, not the user-wide interpreter)
+- [x] `make notices` regenerated and diffed — the v0.3.1 RFCs add no third-party deps, but PR 4 runs the sweep regardless and commits any delta to [`THIRD_PARTY_NOTICES.md`](../THIRD_PARTY_NOTICES.md)
+- [x] `make generate-sanitizer-patterns-check` passes — Go ↔ Python sanitizer pattern parity gate
 - [ ] **MT-MEMORY-005 re-run** on the docker-composed orchestrator at the release-candidate tip — per-leg outcome (Legs 1–5) recorded in [`docs/manual-tests/v0.3.1-execution-report.md`](manual-tests/v0.3.1-execution-report.md). This is a **pass/fail acceptance gate** in v0.3.1 (not the v0.3.0 baseline measurement): Legs 1, 2, 5 must record `Pass`.
 - [ ] Docker smoke test — memory quality + conversational continuity is the v0.3.1 headline; sub-items:
   - [ ] `make docker-build && make docker-up` brings up all services healthy
@@ -146,14 +146,14 @@ The authoritative test index is [`docs/manual-tests/README.md`](manual-tests/REA
 
 Checklist:
 
-- [ ] [`docs/manual-tests/v0.3.1-execution-report.md`](manual-tests/v0.3.1-execution-report.md) exists and is marked ✅ Complete (release-prep PR 1 — [#361](https://github.com/mkhomutov/Persatrix/pull/361))
-- [ ] Each test records date, tester, environment, and evidence
-- [ ] Every test outcome is `Pass`, `Accepted-with-known-gap`, or `Deprecated` — zero `Fail`, zero `Not run`
-- [ ] `MT-MEMORY-005` Legs 1, 2, 5 recorded `Pass` with per-leg evidence; a `Fail` on Leg 1, 2, or 5 is a release blocker
-- [ ] `MT-SESSION-001` is treated as a **write-path-only** contract — a row surfacing across sessions at *recall* time is RFC 0031 Phase 2 work, not a v0.3.1 failure
-- [ ] `MT-PERSONA-CONVERSATION-001` is **DM-only** — a group-channel failure is RFC 0034 Phase 2 work, not a v0.3.1 regression
-- [ ] Every `Accepted-with-known-gap` row links a tracked issue or an RFC-closeout follow-up bullet
-- [ ] `MT-PERSONA-CONVERSATION-001` and `MT-MEMORY-005` source docs promoted from `Draft (scaffold)` to `Active`
+- [x] [`docs/manual-tests/v0.3.1-execution-report.md`](manual-tests/v0.3.1-execution-report.md) exists and is marked ✅ Complete (release-prep PR 1 — [#361](https://github.com/mkhomutov/Persatrix/pull/361))
+- [x] Each test records date, tester, environment, and evidence
+- [x] Every test outcome is `Pass`, `Accepted-with-known-gap`, or `Deprecated` — zero `Fail`, zero `Not run`
+- [x] `MT-MEMORY-005` Legs 1, 2, 5 recorded `Pass` with per-leg evidence; a `Fail` on Leg 1, 2, or 5 is a release blocker
+- [x] `MT-SESSION-001` is treated as a **write-path-only** contract — a row surfacing across sessions at *recall* time is RFC 0031 Phase 2 work, not a v0.3.1 failure
+- [x] `MT-PERSONA-CONVERSATION-001` is **DM-only** — a group-channel failure is RFC 0034 Phase 2 work, not a v0.3.1 regression
+- [x] Every `Accepted-with-known-gap` row links a tracked issue or an RFC-closeout follow-up bullet
+- [x] `MT-PERSONA-CONVERSATION-001` and `MT-MEMORY-005` source docs promoted from `Draft (scaffold)` to `Active`
 - [ ] Release-prep PR 4 re-runs `MT-MEMORY-005` on the post-version-bump release-candidate tip and appends the per-leg evidence to the execution report
 
 ---
@@ -220,13 +220,13 @@ These v0.3.0-scope gaps remain open in v0.3.1. Full detail is in the [v0.3.0 rel
 Single-page go/no-go gate. All items must be checked before tagging.
 
 ```text
-[ ] make test is green on a clean checkout
-[ ] make lint is clean
-[ ] make validate passes (incl. conversation_window config + optimization.schema.json)
-[ ] make proto then git diff --exit-code shows no generated drift
-[ ] make check-licenses passes
-[ ] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
-[ ] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
+[x] make test is green on a clean checkout
+[x] make lint is clean
+[x] make validate passes (incl. conversation_window config + optimization.schema.json)
+[x] make proto then git diff --exit-code shows no generated drift
+[x] make check-licenses passes
+[x] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
+[x] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
 [x] agents/pyproject.toml updated to 0.3.1
 [x] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.1
 [x] cli/Cargo.toml updated to 0.3.1
@@ -235,11 +235,11 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] CHANGELOG.md contains a curated [0.3.1] section with upgrade notes
 [x] Existing [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
 [ ] [0.3.1] changelog section date matches the actual v0.3.1 tag date (verify at tag time)
-[ ] All 30 manual tests recorded in docs/manual-tests/v0.3.1-execution-report.md
-[ ] No unresolved Fail in manual tests; zero Not run
-[ ] MT-MEMORY-005 Legs 1, 2, 5 recorded Pass with per-leg evidence (release gate)
+[x] All 30 manual tests recorded in docs/manual-tests/v0.3.1-execution-report.md
+[x] No unresolved Fail in manual tests; zero Not run
+[x] MT-MEMORY-005 Legs 1, 2, 5 recorded Pass with per-leg evidence (release gate)
 [ ] MT-MEMORY-005 re-run on the post-version-bump release-candidate tip
-[ ] Known gaps documented for release notes (§6 above)
+[x] Known gaps documented for release notes (§6 above)
 [ ] Docker smoke test passes (fact stated → recalled across interactions + DM conversational-continuity round-trip + per-session write tagging + cost summary)
 [ ] git tag v0.3.1 created and pushed
 [ ] GitHub Release published with changelog, upgrade notes, and known gaps

--- a/docs/v0.3.1-release-checklist.md
+++ b/docs/v0.3.1-release-checklist.md
@@ -44,13 +44,17 @@ Before tagging, all shipped components must declare `0.3.1` consistently.
 | Component | File | Required state for release |
 |-----------|------|----------------------------|
 | Python agents | `agents/pyproject.toml` | `version = "0.3.1"` |
+| Python observability | `agents/observability/{metrics,tracing}.py` | `_DEFAULT_SERVICE_VERSION = "0.3.1"` (+ `tracing.py` docstring default) |
 | Rust CLI | `cli/Cargo.toml` | `version = "0.3.1"` |
 | Rust lockfile | `cli/Cargo.lock` | Regenerated after the CLI version bump |
 | Go orchestrator | git tag | Release identified by `v0.3.1` tag |
 
+`scripts/bump_version.py` bumps the `pyproject.toml`, `Cargo.toml`, and observability `service.version` strings; `cli/Cargo.lock` is then regenerated via `cargo update --workspace`. The observability defaults are not build inputs, so a stale value never fails `make all` — it must be bumped explicitly rather than relying on the build to catch it.
+
 Checklist (filled in by release-prep plan PR 3):
 
 - [x] `agents/pyproject.toml` updated to `0.3.1`
+- [x] `agents/observability/{metrics,tracing}.py` `service.version` defaults updated to `0.3.1`
 - [x] `cli/Cargo.toml` updated to `0.3.1`
 - [x] `cli/Cargo.lock` regenerated and committed
 - [x] `make all` builds successfully with the new versions
@@ -224,11 +228,13 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [ ] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed)
 [ ] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
 [x] agents/pyproject.toml updated to 0.3.1
+[x] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.1
 [x] cli/Cargo.toml updated to 0.3.1
 [x] cli/Cargo.lock regenerated and committed
 [x] make all builds successfully
 [x] CHANGELOG.md contains a curated [0.3.1] section with upgrade notes
 [x] Existing [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
+[ ] [0.3.1] changelog section date matches the actual v0.3.1 tag date (verify at tag time)
 [ ] All 30 manual tests recorded in docs/manual-tests/v0.3.1-execution-report.md
 [ ] No unresolved Fail in manual tests; zero Not run
 [ ] MT-MEMORY-005 Legs 1, 2, 5 recorded Pass with per-leg evidence (release gate)

--- a/docs/v0.3.1-release-prep-plan.md
+++ b/docs/v0.3.1-release-prep-plan.md
@@ -1,6 +1,6 @@
 # v0.3.1 Release Preparation Plan
 
-**Status**: 🔄 In progress (PR 0 [#360](https://github.com/mkhomutov/Persatrix/pull/360) + PR 1 [#361](https://github.com/mkhomutov/Persatrix/pull/361) merged; PR 2 open)
+**Status**: 🔄 In progress (PR 0 [#360](https://github.com/mkhomutov/Persatrix/pull/360) + PR 1 [#361](https://github.com/mkhomutov/Persatrix/pull/361) + PR 2 [#363](https://github.com/mkhomutov/Persatrix/pull/363) merged; PR 3 open)
 **Target version**: v0.3.1 (Memory Quality + Session Plumbing + Conversational Working Memory — RFC 0026 full + RFC 0031 Phase 1 + RFC 0034 Phase 1)
 **Created**: 2026-05-16
 **Branch prefix**: `feature/v031-release-prep-`
@@ -36,8 +36,8 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 |----|-------|-------|--------|--------|-----------|--------|
 | 0 | — | v0.3.1 release-prep plan (this document) | `feature/v031-release-prep-plan` | ✅ Merged | [#360](https://github.com/mkhomutov/Persatrix/pull/360) | 2026-05-16 |
 | 1 | A | Manual test execution report (v0.3.1 surface) | `feature/v031-release-prep-mt-exec` | ✅ Merged | [#361](https://github.com/mkhomutov/Persatrix/pull/361) | 2026-05-17 |
-| 2 | A | README + ROADMAP + persona/channels guide refresh + diagram pass + release checklist | `feature/v031-release-prep-docs` | 🔀 PR open | — | — |
-| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v031-release-prep-version-bump` | ⬜ Not started | — | — |
+| 2 | A | README + ROADMAP + persona/channels guide refresh + diagram pass + release checklist | `feature/v031-release-prep-docs` | ✅ Merged | [#363](https://github.com/mkhomutov/Persatrix/pull/363) | 2026-05-17 |
+| 3 | B | Version bump (`agents/pyproject.toml`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v031-release-prep-version-bump` | 🔀 PR open | — | — |
 | 4 | B | Final pre-tag verification & release notes | `feature/v031-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -16,7 +16,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 # Files that contain the project version and need updating.
-# Each entry: (relative path, regex pattern, replacement template)
+# Each entry: (relative path, regex pattern, replacement template).
+# A file may appear more than once when it carries the version in more
+# than one spot; each entry is applied independently (one substitution
+# per entry), so the patterns must not overlap.
 VERSION_FILES: list[tuple[str, str, str]] = [
     (
         "cli/Cargo.toml",
@@ -26,6 +29,26 @@ VERSION_FILES: list[tuple[str, str, str]] = [
     (
         "agents/pyproject.toml",
         r'^(version\s*=\s*")[^"]+(")$',
+        r"\g<1>{version}\2",
+    ),
+    # The observability runtimes hardcode a service.version default used
+    # when PERSATRIX_SERVICE_VERSION is unset. These are not build inputs,
+    # so a stale value never fails `make all` — it must be bumped here or
+    # it silently drifts. tracing.py also restates the default in its
+    # module docstring, hence the second tracing.py entry.
+    (
+        "agents/observability/metrics.py",
+        r'^(_DEFAULT_SERVICE_VERSION\s*=\s*")[^"]+(")$',
+        r"\g<1>{version}\2",
+    ),
+    (
+        "agents/observability/tracing.py",
+        r'^(_DEFAULT_SERVICE_VERSION\s*=\s*")[^"]+(")$',
+        r"\g<1>{version}\2",
+    ),
+    (
+        "agents/observability/tracing.py",
+        r'(\(default: ")\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?(")',
         r"\g<1>{version}\2",
     ),
 ]
@@ -81,7 +104,10 @@ def main() -> None:
     if not changed:
         print("\nNo files changed.")
     else:
-        print(f"\n{len(changed)} file(s) {'would be ' if args.dry_run else ''}updated.")
+        # A file may take more than one substitution (see VERSION_FILES);
+        # count distinct paths so the summary matches the file count.
+        distinct = len(set(changed))
+        print(f"\n{distinct} file(s) {'would be ' if args.dry_run else ''}updated.")
 
     # Remind about manual steps
     print("\nRemaining manual steps:")


### PR DESCRIPTION
## Summary

Release-prep **PR 3** of the [v0.3.1 release-prep plan](docs/v0.3.1-release-prep-plan.md) (Track B — Release Engineering). Version bump + changelog curation, no feature work.

- **Version bump 0.3.0 → 0.3.1** — `agents/pyproject.toml` + `cli/Cargo.toml` via `scripts/bump_version.py`; `cli/Cargo.lock` regenerated (`cargo update --workspace`); the two `agents/observability/{metrics,tracing}.py` `service.version` defaults bumped inline (not in `bump_version.py`'s `VERSION_FILES`). `make all` builds clean at `0.3.1` — CLI compiles as `persatrix v0.3.1`, no proto drift.
- **Changelog** — `[Unreleased]` → `## [0.3.1] - 2026-05-17`, codename "Memory Quality": Highlights (RFC 0026 declarative facts tier, RFC 0034 Phase 1 DM conversational memory, RFC 0031 Phase 1 session namespacing), Upgrade Notes table (7 rows per [release-checklist §3.1](docs/v0.3.1-release-checklist.md)), and the `git-cliff` per-PR Features / Bug Fixes / Documentation / Testing groups. The ISSUE-0054 facts-tier close-path fix chain is added as a curated Bug Fixes entry; RFC 0033 stays an RFC-tracking line under Documentation, not a feature entry. All prior version sections (`[0.3.0]` and earlier) preserved verbatim.
- **Release-prep plan** Progress Overview synced — PR 2 ([#363](https://github.com/mkhomutov/Persatrix/pull/363)) flipped to ✅ Merged, PR 3 to 🔀 PR open.

## Test plan

- [x] `make all` builds successfully at `0.3.1` (orchestrator + CLI; CLI version string `persatrix v0.3.1`)
- [x] `make proto && git diff --exit-code` — no generated drift
- [x] Pre-commit checks pass (filemap, ruff, fmt, doc links, doc status, file size)
- [x] `CHANGELOG.md` contains a curated `[0.3.1]` section with the §3.1 Upgrade Notes
- [x] `git diff` confirms `[0.3.0]` and all prior sections untouched (single hunk, ends at the `[0.3.1]:` compare link)
- [ ] CI green