### PR TITLE
docs(release): post-release follow-up for v0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Persatrix is BUSL-1.1 licensed with no warranty. Use at your own risk
 |---------|------------------|--------|
 | **v0.2.x** | Run persistent personas with memory, chat with them from a terminal, observe everything end-to-end with traces and metrics | ✅ Released |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | ✅ Released |
-| **v0.3.1** | Chat with a persona that remembers stated facts about you across interactions and follows the conversation it's currently having | 🚧 Release prep |
+| **v0.3.1** | Chat with a persona that remembers stated facts about you across interactions and follows the conversation it's currently having | ✅ Released |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
 | **v0.6.0** | Run agent societies across multiple nodes and networks | 📋 Planned |
@@ -159,7 +159,7 @@ Persatrix is BUSL-1.1 licensed with no warranty. Use at your own risk
 For PR-level progress and per-RFC status, see [ROADMAP.md](ROADMAP.md).
 For per-release upgrade notes and operator-visible changes, see
 [CHANGELOG.md](CHANGELOG.md). For known limitations and deferred scope in
-the current pre-release (channels are internal-only and unauthenticated,
+the current release (channels are internal-only and unauthenticated,
 per-session recall filtering and conversational memory for group channels
 deferred, RFC 0009 Phases 3–4 deferred to v0.4.0), see the
 [v0.3.1 release checklist § Known Gaps](docs/v0.3.1-release-checklist.md#6-known-gaps-to-document-in-release-notes).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-05-17 (v0.3.1 release-prep PR 4 — final pre-tag verification: automated gate sweep green, Docker stack builds and comes up healthy; v0.3.1 Version Map row flipped to `✅ Released`.)
+> **Last updated**: 2026-05-17 (v0.3.1 released — post-release document update: Current milestone advanced to the published tag, Merged PR History backfilled through #365, release checklist §5 GitHub-Release gates ticked, v0.3.1 master plan flipped to ✅ Complete, manual-tests README Execution Reports row flipped to ✅ Complete.)
 > **Current phase**: v0.3.1 (Memory Quality + Session Plumbing + Conversational Working Memory — RFC 0026 full + RFC 0031 Phase 1 + RFC 0034 Phase 1) — ✅ Released
-> **Current milestone**: v0.3.1 released — all three RFC workstreams merged and release-prep PRs 1–4 landed; the `v0.3.1` git tag and GitHub Release follow post-merge per [v0.3.1-release-prep-plan.md](docs/v0.3.1-release-prep-plan.md) Phase 5.
+> **Current milestone**: v0.3.1 released ([tag v0.3.1](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.1) pushed 2026-05-17, GitHub Release "Memory Quality" published the same day); v0.3.2 planning next (RFC 0029 Phase 1 `MemoryStore` facade refactor + RFC 0023 LLM-call leasing, sequenced per [v0.3.x-sequencing.md](docs/v0.3.x-sequencing.md)).
 
 This document tracks development progress across all versions. Update it when merging PRs or completing milestones.
 
@@ -930,6 +930,42 @@ v0.5.0 complete
 | [#326](https://github.com/mkhomutov/Persatrix/pull/326) | docs(rfcs): YAML front-matter + auto-generated INDEX.md | cross-RFC docs | 2026-05-12 |
 | [#327](https://github.com/mkhomutov/Persatrix/pull/327) | feat(persona): reply-discretion + conversational-pacing prompt snippets | cross-RFC persona | 2026-05-12 |
 | [#328](https://github.com/mkhomutov/Persatrix/pull/328) | chore(release): v0.3.0 — version bump + curated changelog + PR 4 pre-tag verification | v0.3.0 release prep | 2026-05-12 |
+| [#330](https://github.com/mkhomutov/Persatrix/pull/330) | docs(release): post-release follow-up for v0.3.0 | v0.3.0 release prep | 2026-05-12 |
+| [#331](https://github.com/mkhomutov/Persatrix/pull/331) | docs(v0.3.1): re-sequence v0.3.x and open v0.3.1 master plan | v0.3.1 plan | 2026-05-12 |
+| [#332](https://github.com/mkhomutov/Persatrix/pull/332) | docs(v0.3.1): RFC 0026 + RFC 0031 PR plans (Phase 1 combined scaffold) | 0026 + 0031 (PR plans) | 2026-05-12 |
+| [#333](https://github.com/mkhomutov/Persatrix/pull/333) | feat(v031): RFC 0031 PR 1 — rename chat session_id → chat_session_id | 0031 (1/5) | 2026-05-13 |
+| [#334](https://github.com/mkhomutov/Persatrix/pull/334) | docs(rfcs): RFC 0032 stub — channel interaction layer unification | 0032 (RFC) | 2026-05-15 |
+| [#335](https://github.com/mkhomutov/Persatrix/pull/335) | feat(v031): RFC 0031 PR 2 — sessions table + Go session_id columns + PERSATRIX_SESSION_ID | 0031 (2/5) | 2026-05-13 |
+| [#336](https://github.com/mkhomutov/Persatrix/pull/336) | feat(v031): RFC 0031 PR 3 — Python session_id columns + persona-runtime PERSATRIX_SESSION_ID | 0031 (3/5) | 2026-05-13 |
+| [#337](https://github.com/mkhomutov/Persatrix/pull/337) | feat(v031): RFC 0031 PR 4 — Phase 1 review follow-ups | 0031 (4/5) | 2026-05-13 |
+| [#338](https://github.com/mkhomutov/Persatrix/pull/338) | docs(v031): RFC 0031 PR 5 — Phase 1 closeout | 0031 (5/5) | 2026-05-14 |
+| [#339](https://github.com/mkhomutov/Persatrix/pull/339) | feat(v031): RFC 0026 PR 1 — facts schema + FactStore + erasure primitive | 0026 (1/6) | 2026-05-14 |
+| [#340](https://github.com/mkhomutov/Persatrix/pull/340) | feat(v031): RFC 0026 PR 2 — extractor + predicate allowlist + audit | 0026 (2/6) | 2026-05-14 |
+| [#341](https://github.com/mkhomutov/Persatrix/pull/341) | feat(v031): RFC 0026 PR 3 — FactStore.recall + MemoryBudget tier slot + config | 0026 (3/6) | 2026-05-14 |
+| [#342](https://github.com/mkhomutov/Persatrix/pull/342) | feat(v031): RFC 0026 PR 4 — reinforcement + retraction + tier provenance + MT update | 0026 (4/6) | 2026-05-15 |
+| [#343](https://github.com/mkhomutov/Persatrix/pull/343) | docs(rfcs): RFC 0033 — provider-agnostic model alias layer | 0033 (RFC) | 2026-05-15 |
+| [#344](https://github.com/mkhomutov/Persatrix/pull/344) | feat(v031): RFC 0026 PR 5a — symmetric latest-asserted-wins + source_interaction_id nullability | 0026 (5/6 — slice 5a) | 2026-05-15 |
+| [#345](https://github.com/mkhomutov/Persatrix/pull/345) | feat(v031): RFC 0026 PR 5b — envelope parse-failure observability | 0026 (5/6 — slice 5b) | 2026-05-15 |
+| [#346](https://github.com/mkhomutov/Persatrix/pull/346) | feat(v031): RFC 0026 PR 5c — PR 3 review storage/render defensive fixes | 0026 (5/6 — slice 5c) | 2026-05-15 |
+| [#347](https://github.com/mkhomutov/Persatrix/pull/347) | feat(v031): RFC 0026 PR 5d — PR 3 review tests + counter polish | 0026 (5/6 — slice 5d) | 2026-05-15 |
+| [#348](https://github.com/mkhomutov/Persatrix/pull/348) | feat(v031): RFC 0026 PR 5e — PR 4 review audit/chunking/edge cases | 0026 (5/6 — slice 5e) | 2026-05-15 |
+| [#349](https://github.com/mkhomutov/Persatrix/pull/349) | docs(v0.3.1): absorb RFC 0034 — persona conversational working memory | v0.3.1 plan | 2026-05-15 |
+| [#350](https://github.com/mkhomutov/Persatrix/pull/350) | docs(rfc-0034): resolve open questions and add Phase 1 PR plan | 0034 (PR plan) | 2026-05-15 |
+| [#351](https://github.com/mkhomutov/Persatrix/pull/351) | feat(v031): RFC 0034 PR 1 — channel-history fetcher behind Protocol | 0034 (1/5) | 2026-05-16 |
+| [#352](https://github.com/mkhomutov/Persatrix/pull/352) | feat(v031): RFC 0034 PR 2 — conversation-window module + config/schema | 0034 (2/5) | 2026-05-16 |
+| [#353](https://github.com/mkhomutov/Persatrix/pull/353) | docs(rfcs): RFC 0035 + RFC 0036 — membership ledger and persona message recall | 0035 + 0036 (RFC) | 2026-05-16 |
+| [#354](https://github.com/mkhomutov/Persatrix/pull/354) | docs(rfcs): RFC 0012 + 0037 + 0038 — confidentiality, authority & concurrent-context awareness | 0012 + 0037 + 0038 (RFC) | 2026-05-16 |
+| [#355](https://github.com/mkhomutov/Persatrix/pull/355) | docs(rfcs): RFC 0039 — user accounts & authentication foundation | 0039 (RFC) | 2026-05-16 |
+| [#356](https://github.com/mkhomutov/Persatrix/pull/356) | feat(v031): RFC 0034 PR 3 — wire conversation window + DM itest | 0034 (3/5) | 2026-05-16 |
+| [#357](https://github.com/mkhomutov/Persatrix/pull/357) | feat(v031): RFC 0034 PR 4 — review follow-ups (history-fetcher hardening) | 0034 (4/5) | 2026-05-16 |
+| [#358](https://github.com/mkhomutov/Persatrix/pull/358) | docs(v031): RFC 0034 PR 5 — Phase 1 closeout | 0034 (5/5) | 2026-05-16 |
+| [#359](https://github.com/mkhomutov/Persatrix/pull/359) | docs(v031): RFC 0026 PR 6 — RFC close | 0026 (6/6) | 2026-05-16 |
+| [#360](https://github.com/mkhomutov/Persatrix/pull/360) | docs(v031): v0.3.1 release-prep plan (master-plan Phase 3) | v0.3.1 release prep | 2026-05-16 |
+| [#361](https://github.com/mkhomutov/Persatrix/pull/361) | docs(v031): v0.3.1 release-prep PR 1 — manual test execution report | v0.3.1 release prep | 2026-05-17 |
+| [#362](https://github.com/mkhomutov/Persatrix/pull/362) | fix(v031): single-turn interactions extract facts (MT-MEMORY-005 F-6) | 0026 follow-up | 2026-05-17 |
+| [#363](https://github.com/mkhomutov/Persatrix/pull/363) | docs(v031): v0.3.1 release-prep PR 2 — docs refresh + release checklist | v0.3.1 release prep | 2026-05-17 |
+| [#364](https://github.com/mkhomutov/Persatrix/pull/364) | chore(release): bump to v0.3.1 + curate changelog (PR 3) | v0.3.1 release prep | 2026-05-17 |
+| [#365](https://github.com/mkhomutov/Persatrix/pull/365) | docs(v031): v0.3.1 release-prep PR 4 — final pre-tag verification | v0.3.1 release prep | 2026-05-17 |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -109,7 +109,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | v0.2.2 | [v0.2.2-execution-report.md](v0.2.2-execution-report.md) | ✅ Complete |
 | v0.2.3 | [v0.2.3-execution-report.md](v0.2.3-execution-report.md) | ✅ Complete |
 | v0.3.0 | [v0.3.0-execution-report.md](v0.3.0-execution-report.md) | ✅ Complete |
-| v0.3.1 | [v0.3.1-execution-report.md](v0.3.1-execution-report.md) | 🔄 In progress |
+| v0.3.1 | [v0.3.1-execution-report.md](v0.3.1-execution-report.md) | ✅ Complete |
 
 ---
 

--- a/docs/v0.3.1-plan.md
+++ b/docs/v0.3.1-plan.md
@@ -1,8 +1,9 @@
 # v0.3.1 Plan — Memory Quality + Session Plumbing + Conversational Working Memory
 
-**Status**: 📋 Proposed
+**Status**: ✅ Complete (v0.3.1 released 2026-05-17 — GitHub Release "Memory Quality" published from tag `v0.3.1`)
 **Target version**: v0.3.1 (RFCs 0026 full + 0031 Phase 1 + 0034 Phase 1)
 **Created**: 2026-05-12 (amended 2026-05-15 — RFC 0034 absorbed; see [Amendment](#amendment-2026-05-15--rfc-0034-conversational-working-memory))
+**Completed**: 2026-05-17
 **Branch prefix**: `feature/v031-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -82,8 +83,8 @@ Update this table as each step PR merges. For multi-PR workstream rows, roll up 
 | 3 | 2 | RFC 0031 Phase 1 implementation (per `0031-pr-plan.md`) | `feature/v031-rfc0031p1-…` | ✅ Merged | [#333](https://github.com/mkhomutov/Persatrix/pull/333), [#335](https://github.com/mkhomutov/Persatrix/pull/335), [#336](https://github.com/mkhomutov/Persatrix/pull/336), [#337](https://github.com/mkhomutov/Persatrix/pull/337), [#338](https://github.com/mkhomutov/Persatrix/pull/338) | 2026-05-14 |
 | 3b | 2 | RFC 0034 Phase 1 implementation (per `0034-pr-plan.md`) — conversational working memory, DM channels | `feature/v031-rfc0034p1-…` | ✅ Merged | [#351](https://github.com/mkhomutov/Persatrix/pull/351), [#352](https://github.com/mkhomutov/Persatrix/pull/352), [#356](https://github.com/mkhomutov/Persatrix/pull/356), [#357](https://github.com/mkhomutov/Persatrix/pull/357), [#358](https://github.com/mkhomutov/Persatrix/pull/358) | 2026-05-16 |
 | 4 | 3 | v0.3.1 release-prep plan | `feature/v031-release-prep-plan` | ✅ Merged | [#360](https://github.com/mkhomutov/Persatrix/pull/360) | 2026-05-16 |
-| 5 | 4 | v0.3.1 release-prep execution (MT report → docs → version bump → final) | `feature/v031-release-prep-…` | 🔄 In progress | — | — |
-| 6 | 5 | v0.3.1 tag + post-release follow-up | `feature/v031-post-release` | ⬜ Not started | — | — |
+| 5 | 4 | v0.3.1 release-prep execution (MT report → docs → version bump → final) | `feature/v031-release-prep-…` | ✅ Merged | PR 1 [#361](https://github.com/mkhomutov/Persatrix/pull/361), PR 2 [#363](https://github.com/mkhomutov/Persatrix/pull/363), PR 3 [#364](https://github.com/mkhomutov/Persatrix/pull/364), PR 4 [#365](https://github.com/mkhomutov/Persatrix/pull/365); F-6 close-path fix [#362](https://github.com/mkhomutov/Persatrix/pull/362) bundled mid-stream | 2026-05-17 |
+| 6 | 5 | v0.3.1 tag + post-release follow-up | `feature/v031-post-release` | 🔀 PR open | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred
 

--- a/docs/v0.3.1-release-checklist.md
+++ b/docs/v0.3.1-release-checklist.md
@@ -1,6 +1,6 @@
 # v0.3.1 Release Checklist
 
-> **Status**: ✅ Released — every automated pre-release gate verified green on the release-candidate tip by PR 4 (final pre-tag verification); the `v0.3.1` git tag and GitHub Release are cut post-merge per [release-prep plan Phase 5](v0.3.1-release-prep-plan.md). The live `MT-MEMORY-005` dementia test and the live-LLM Docker smoke interactions were not re-executed on the post-version-bump tip — they are carried forward from the [`47a7797`](https://github.com/mkhomutov/Persatrix/commit/47a7797) execution-report run (see §1 and §4); the only intervening close-path change is the F-6 fix ([#362](https://github.com/mkhomutov/Persatrix/pull/362)), covered by unit + integration tests that passed in the PR 4 sweep.
+> **Status**: ✅ Released — every automated pre-release gate verified green on the release-candidate tip by PR 4 (final pre-tag verification); the `v0.3.1` git tag was pushed and the GitHub Release "Memory Quality" published on 2026-05-17 per [release-prep plan Phase 5](v0.3.1-release-prep-plan.md). The live `MT-MEMORY-005` dementia test and the live-LLM Docker smoke interactions were not re-executed on the post-version-bump tip — they are carried forward from the [`47a7797`](https://github.com/mkhomutov/Persatrix/commit/47a7797) execution-report run (see §1 and §4); the only intervening close-path change is the F-6 fix ([#362](https://github.com/mkhomutov/Persatrix/pull/362)), covered by unit + integration tests that passed in the PR 4 sweep.
 
 > v0.3.1 — "Memory Quality + Session Plumbing + Conversational Working Memory" — ships the combined deliverable of RFC 0026 (declarative facts tier — full, Phases 1–3), RFC 0031 Phase 1 (per-session namespacing — `sessions` table + `session_id` columns + `PERSATRIX_SESSION_ID` env-var plumbing), and RFC 0034 Phase 1 (persona conversational working memory — DM channels). The user-facing promise: *the persona remembers stated facts about you across interactions and follows the conversation it is currently having.*
 
@@ -58,7 +58,7 @@ Checklist (filled in by release-prep plan PR 3):
 - [x] `cli/Cargo.toml` updated to `0.3.1`
 - [x] `cli/Cargo.lock` regenerated and committed
 - [x] `make all` builds successfully with the new versions
-- [ ] No docs or examples still describe v0.3.1 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist flipped in the post-release follow-up PR)
+- [x] No docs or examples still describe v0.3.1 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist flipped in the post-release follow-up PR)
 
 ---
 
@@ -171,11 +171,11 @@ git push origin v0.3.1
 
 GitHub Release checklist (post-merge manual steps after PR 4 merges):
 
-- [ ] Create the GitHub Release from tag `v0.3.1`
-- [ ] Use the curated `[0.3.1]` changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body
-- [ ] Attach binaries or container references if produced for this release
+- [x] Create the GitHub Release from tag `v0.3.1` — published 2026-05-17 as "Memory Quality" ([releases/tag/v0.3.1](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.1))
+- [x] Use the curated `[0.3.1]` changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body
+- [ ] Attach binaries or container references if produced for this release — none produced for this release (matches the v0.3.0 / v0.2.3 pattern)
 
 ---
 
@@ -241,6 +241,6 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] MT-MEMORY-005 — 47a7797 run carried forward; not re-run on the post-bump tip (F-6 delta unit+integration-covered) — see §1
 [x] Known gaps documented for release notes (§6 above)
 [x] Docker smoke test — build + stack-up healthy verified on the RC tip; live-LLM interactions carried forward from 47a7797 (see §1)
-[ ] git tag v0.3.1 created and pushed (post-merge — release-prep plan Phase 5)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (post-merge — Phase 5)
+[x] git tag v0.3.1 created and pushed (2026-05-17)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (2026-05-17 — "Memory Quality")
 ```

--- a/scripts/checks/file_size.py
+++ b/scripts/checks/file_size.py
@@ -83,6 +83,16 @@ GRANDFATHERED_FILES: frozenset[str] = frozenset({
     # work and trimming the surrounding narrative would erase release-cycle
     # context. Remove this entry once v0.3.0 ships and the plan is archived.
     "docs/v0.3.0-plan.md",
+    # docs/v0.3.1-plan.md is the v0.3.1 master plan — same release-cycle
+    # accumulator pattern as docs/v0.3.0-plan.md above. It crossed the
+    # 3000-word prose cap when the v0.3.1 post-release follow-up flipped the
+    # Status / Completed header and rolled the release-prep and post-release
+    # PRs into the Master Progress Overview. The RFC 0034 amendment was
+    # already split out into docs/v0.3.1-plan-amendment-2026-05-15.md to
+    # hold the line earlier in the cycle; trimming the remaining
+    # release-cycle narrative would erase context. Remove this entry once
+    # v0.3.1 is archived.
+    "docs/v0.3.1-plan.md",
     # docs/v0.3.x-sequencing.md orchestrates the v0.3.1 / v0.3.2 / v0.3.3
     # patch sequence and accumulates amendments as new v0.3.x-targeted
     # RFCs file (the 2026-05-12 amendment captured the RFC 0030 + RFC


### PR DESCRIPTION
## Summary

v0.3.1 — "Memory Quality + Session Plumbing + Conversational Working Memory" — was tagged and the GitHub Release ["Memory Quality"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.1) published on 2026-05-17. This is the Phase 5 post-release sweep ([v0.3.1-plan.md Phase 5](docs/v0.3.1-plan.md#phase-5--tag-and-post-release-follow-up)), mirroring the v0.3.0 follow-up (#330): update every document that still described v0.3.1 as unreleased work-in-progress.

## Changes

- **README.md** — roadmap row for v0.3.1 flips `🚧 Release prep` → `✅ Released`; the known-gaps pointer below the table reworded from "current pre-release" to "current release".
- **ROADMAP.md** — refresh `Last updated`; rewrite `Current milestone` to the published-tag state with a v0.3.2 forward-pointer; **backfill the Merged PR History table** with the full v0.3.1 cycle (#330 through #365 — the table had stopped at #328, so the entire v0.3.1 development cycle was missing).
- **docs/v0.3.1-release-checklist.md** — status blurb flips to the pushed-tag / published-release state; ticked the §2 "no docs describe v0.3.1 as unreleased" gate, the four §5 GitHub Release procedure items, and the §7 tag/release summary gates. "Attach binaries" left unchecked (none produced — matches the v0.3.0 / v0.2.3 pattern).
- **docs/v0.3.1-plan.md** — top-level Status flips `📋 Proposed` → `✅ Complete`; added `Completed: 2026-05-17`; Master Progress Overview row 5 flips to `✅ Merged` with the release-prep PR links, row 6 (post-release follow-up) flips to `🔀 PR open`.
- **docs/manual-tests/README.md** — Execution Reports table: v0.3.1 row flips `🔄 In progress` → `✅ Complete`.
- **scripts/checks/file_size.py** — grandfather `docs/v0.3.1-plan.md`, which crossed the 3000-word prose cap once the header flip + PR roll-up landed. Same release-cycle-accumulator treatment already applied to `docs/v0.3.0-plan.md` and `docs/v0.3.x-sequencing.md`; `v0.3.1-plan.md` was the conspicuous omission.

`CHANGELOG.md` needed no change — release-prep PR 3 (#364) already curated the `[0.3.1]` section and its compare link.

No code changes. No tests affected.

## Test plan

- [x] `python scripts/checks/file_size.py --strict` passes
- [x] Pre-commit hook green (doc links, doc status markers, file size — 7/7)
- [x] Reviewer confirms the Merged PR History backfill rows match the v0.3.1 PR cycle