### PR TITLE
chore(release): bump to v0.3.2 + curate changelog (PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,84 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2] - 2026-05-20
+
+> **Codename:** Cost Gate + Facade Freeze
+
+### Highlights
+
+- **Wallet lease — every LLM call is gated by a server-issued lease before issuing** (RFC 0023, Phases 1–6). A new `WalletService` (proto + Go) issues short-TTL leases against per-agent / per-cause / global budgets; an asynchronous reaper sweeps abandoned leases on a 5 s tick. `WalletClient` in the persona runtime wraps every LLM call with `AcquireLease` → call → `SettleLease`; five origins are now leased (workflow task, chat dispatch, autonomous TICK, sub-agent delegation, channel-message reply). A wallet denial surfaces as `reply_status="error"` on chat (carrying `LeaseDenied.message`) and as `idle_reason=budget_denied` on autonomous TICK — cost is a **structural gate**, not a post-hoc accountant. Closes the v0.2.3 chat-bypass known limitation.
+- **Memory facade freeze ahead of the v0.4.0 personal/society split** (RFC 0029 Phase 1). `MemoryFacade` is promoted to the single boundary for all agent-memory access and renamed to `MemoryStore`; `agents.memory.MemoryFacade` survives as a deprecation alias for one minor version. Society-tier methods raise `SocietyBackendUnavailable` in single-agent mode — no Postgres opened, no surprise dependency. A new ruff rule blocks direct `aiosqlite` imports outside `agents/memory/`, and direct `EpisodicMemory` / `RelationshipMemory` construction emits a `DeprecationWarning`. The personal-tier recall-latency regression gate (`tests/perf/personal_tier_latency.py`) ships green from Phase 1 closeout.
+
+### Upgrade Notes
+
+| Notable change | Detail |
+|----------------|--------|
+| **[Behaviour change — cost gate]** every LLM call acquires a wallet lease | All five origins (workflow task, chat dispatch, autonomous TICK, sub-agent, channel-message reply) now go through `WalletClient.AcquireLease` before issuing. A wallet outage surfaces as `reply_status="error"` on chat and `idle_reason=budget_denied` on TICK ([RFC 0023 §F](docs/rfcs/0023-llm-call-leasing.md#f-failure-modes)). Closes the v0.2.3 chat-bypass known limitation. |
+| New `wallet:` block in `config/optimization.yaml` | Top-level sibling of `cost:`. Keys: `ttl_seconds` (default `60`, = 2× the 30 s per-call timeout — [RFC 0023 OQ §2](docs/rfcs/0023-llm-call-leasing.md#open-questions)), `reaper_interval_seconds` (default `5`), `max_active_leases` (default `16`, per-agent DoS ceiling). Absent block / key falls back to defaults; no operator action required. |
+| New `BudgetExceededError` failure surface | `WalletClient` raises it on `LeaseDenied`. The chat path re-surfaces it as a structured `reply_status="error"` payload carrying `LeaseDenied.message` (HTTP 200, not 500); autonomous TICK short-circuits to idle with `idle_reason=budget_denied`. Sub-agent and channel-message origins propagate the same error envelope. |
+| `MemoryFacade` → `MemoryStore` rename (Phase 1 facade freeze) | `agents.memory.MemoryFacade` is preserved as a deprecation alias for one minor version (removal in v0.3.3 per [RFC 0029 §Phased Implementation Plan](docs/rfcs/0029-personal-society-storage-split.md#phased-implementation-plan)); new code must import `MemoryStore`. Society-tier methods raise `SocietyBackendUnavailable` — single-agent mode never opens Postgres. |
+| New direct-`aiosqlite` import lint rule | `import aiosqlite` outside `agents/memory/` fails CI (new ruff rule). Direct `EpisodicMemory` / `RelationshipMemory` construction emits a `DeprecationWarning`; route through `MemoryStore`. |
+| `tiktoken` promoted to a hard runtime dep | Per [RFC 0023 OQ #5](docs/rfcs/0023-llm-call-leasing.md#open-questions), the `accurate-tokens` extra is removed and `tiktoken` is now a required runtime dependency. Builds depending on `[accurate-tokens]` must drop the extra from their install command. The `cl100k_base` encoding is what `LLMClient` already used — no behaviour change. |
+| Wallet lease log shape finalised | `lease_acquire` / `lease_settle` / `lease_reap` events carry a stable field set ([RFC 0023 PR 7](https://github.com/mkhomutov/Persatrix/pull/391)); downstream log consumers can pin field names. |
+| gRPC server panic-recovery interceptor | A server-side recovery interceptor ([ISSUE-0059](https://github.com/mkhomutov/Persatrix/pull/379)) converts an unhandled handler panic into a structured `Internal` status with a redacted message instead of tearing the connection down. Operator-visible: panics now show up as gRPC errors in client logs, not socket resets. |
+| Repo-root `tests/` tree under lint/type gates | `ruff` ([ISSUE-0056](https://github.com/mkhomutov/Persatrix/pull/381)) and `mypy` ([ISSUE-0062](https://github.com/mkhomutov/Persatrix/pull/382)) now cover the top-level `tests/` tree, closing a CI blind spot. Out-of-tree forks carrying patches under `tests/` may see new lint/type findings. |
+
+### 🚀 Features
+
+- *(v032)* RFC 0029 Phase 1 PR 1 — `MemoryStore` facade promotion (#370)
+- *(v032)* RFC 0029 Phase 1 PR 2 — lint rule + deprecation warnings (#372)
+- *(v032)* RFC 0029 Phase 1 PR 3 — downstream call-site refactor (#373)
+- *(v032)* RFC 0029 Phase 1 PR 4 — review follow-ups (#375)
+- *(v032)* RFC 0029 Phase 1 PR 5 — closeout + perf gate (#376)
+- *(v032)* RFC 0023 PR 1 — proto surface + `WalletService` skeleton (#378)
+- *(v032)* RFC 0023 PR 2 — wallet enforcement + TTL reaper (#384)
+- *(v032)* RFC 0023 PR 3 — `WalletClient` + workflow-task lease wiring (#385)
+- *(v032)* RFC 0023 PR 4 — chat-path wallet lease wiring (closes v0.2.3 bypass) (#387)
+- *(v032)* RFC 0023 PR 5 — autonomous TICK + sub-agent lease wiring (#388)
+- *(v032)* RFC 0023 PR 6 — channel-message origin lease wiring (#389)
+- *(v032)* RFC 0023 PR 7 — review follow-ups (finalize log shape) (#391)
+
+### 🐛 Bug Fixes
+
+- *(tests)* Isolate fact-store audit redactor-warning test from global log state (#374)
+- *(v032)* ISSUE-0059 — add gRPC server panic-recovery interceptor (#379)
+- *(v032)* ISSUE-0055 — drain the RETURNING cursor racing close-path COMMIT (#380)
+- *(v032)* ISSUE-0056 — ruff-gate the repo-root tests/ tree (#381)
+- *(v032)* ISSUE-0062 — mypy-gate the repo-root tests/ tree (#382)
+- *(v032)* ISSUE-0064 — persona-as-sub-agent attribution gap (#390)
+- *(v032)* ISSUE-0065 — publish chat-error reply on channel under wallet denial (#395)
+- *(v032)* ISSUE-0066 — publish chat-error reply on channel under wallet lease-cap / rate-limit (#396)
+- *(v032)* ISSUE-0066 reopen — handle `AioRpcError(RESOURCE_EXHAUSTED)` in `action_loop` (#398)
+
+### 📚 Documentation
+
+- *(release)* Post-release follow-up for v0.3.1 (#366)
+- *(v032)* Open v0.3.2 master plan — Cost Gate + Facade Freeze (#367)
+- *(rfcs)* RFC 0040 — agent–orchestrator transport unification (#368)
+- *(v032)* RFC 0023 + RFC 0029 PR plans (Phase 1 combined scaffold) (#369)
+- *(v032)* Resolve RFC 0023 open questions + v0.3.2 tracking hygiene (#371)
+- Note full-suite runtime + long-command guidance in CLAUDE.md (#377)
+- *(rfcs)* RFC 0031 Phase 2 PR plan — recall filtering + dementia-test bridge (#383)
+- *(v032)* RFC 0023 PR 8 — full-RFC closeout (#392)
+- *(v032)* Release-prep plan (master-plan Phase 3) (#393)
+- *(v032)* Release-prep PR 1 — manual test execution report (release gate not met) (#394)
+- *(v032)* Release-prep PR 1 — manual test re-execution report (release gate met) (#397)
+- *(v032)* Release-prep PR 2 — docs refresh + release checklist (#400)
+
+### 🧪 Testing
+
+- New manual tests [`MT-COST-003`](docs/manual-tests/MT-COST-003.md) (chat budget exceed surfaces as `reply_status="error"`, RFC 0023 Phase 4) and [`MT-COST-004`](docs/manual-tests/MT-COST-004.md) (TICK budget exhaustion records idle with `idle_reason=budget_denied` and no provider spend, RFC 0023 Phase 5).
+- Wallet acquire+settle p99 loopback measurement added to the v0.3.2 execution report as an informational target (RFC 0023 §Goal #6 — ≤ 5 ms p99). Regression is a release-review finding, not a build gate.
+- Personal-tier recall-latency regression gate (`tests/perf/personal_tier_latency.py`) shipped from RFC 0029 PR 5 ([#376](https://github.com/mkhomutov/Persatrix/pull/376)) to lock in the facade-freeze baseline ahead of the v0.4.0 personal/society split.
+- Full 32-test manual-test surface (30 v0.3.1 carry-forward + 2 new MTs) re-executed against the v0.3.2 release-candidate tip; release gate met ([#397](https://github.com/mkhomutov/Persatrix/pull/397)).
+
+### 🏗️ Build
+
+- *(deps)* Bump openssl from 0.10.79 to 0.10.80 in /cli (#386)
+
+[0.3.2]: https://github.com/mkhomutov/Persatrix/compare/v0.3.1...v0.3.2
+
 ## [0.3.1] - 2026-05-17
 
 > **Codename:** Memory Quality

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -241,10 +241,10 @@ Collected via `cargo license --json` inside `cli/` (206 crates).
 | `objc2-encode` | 4.1.0 | MIT | [link](https://github.com/madsmtm/objc2) |
 | `once_cell` | 1.21.4 | Apache-2.0 OR MIT | [link](https://github.com/matklad/once_cell) |
 | `once_cell_polyfill` | 1.70.2 | Apache-2.0 OR MIT | [link](https://github.com/polyfill-rs/once_cell_polyfill) |
-| `openssl` | 0.10.79 | Apache-2.0 | [link](https://github.com/rust-openssl/rust-openssl) |
+| `openssl` | 0.10.80 | Apache-2.0 | [link](https://github.com/rust-openssl/rust-openssl) |
 | `openssl-macros` | 0.1.1 | Apache-2.0 OR MIT |  |
 | `openssl-probe` | 0.2.1 | Apache-2.0 OR MIT | [link](https://github.com/rustls/openssl-probe) |
-| `openssl-sys` | 0.9.115 | MIT | [link](https://github.com/rust-openssl/rust-openssl) |
+| `openssl-sys` | 0.9.116 | MIT | [link](https://github.com/rust-openssl/rust-openssl) |
 | `papergrid` | 0.17.0 | MIT | [link](https://github.com/zhiburt/tabled) |
 | `percent-encoding` | 2.3.2 | Apache-2.0 OR MIT | [link](https://github.com/servo/rust-url/) |
 | `pin-project-lite` | 0.2.17 | Apache-2.0 OR MIT | [link](https://github.com/taiki-e/pin-project-lite) |

--- a/agents/observability/metrics.py
+++ b/agents/observability/metrics.py
@@ -52,7 +52,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.1"
+_DEFAULT_SERVICE_VERSION = "0.3.2"
 _DEFAULT_EXPORT_INTERVAL_MS = 60_000
 _DEFAULT_EXPORT_TIMEOUT_MS = 10_000
 

--- a/agents/observability/tracing.py
+++ b/agents/observability/tracing.py
@@ -16,7 +16,7 @@ Environment variables (all optional; defaults match the Go side):
     PERSATRIX_AGENT_ID             sets ``service.instance.id``
     PERSATRIX_SERVICE_ROLE         sets ``service.role`` (optional free-text)
     PERSATRIX_SERVICE_VERSION      sets ``service.version``
-                                    (default: "0.3.1")
+                                    (default: "0.3.2")
 
 Baggage key naming convention
 -----------------------------
@@ -69,7 +69,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.1"
+_DEFAULT_SERVICE_VERSION = "0.3.2"
 
 # BatchSpanProcessor tuning — deterministic across environments.
 _BSP_MAX_QUEUE_SIZE = 2048

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.3.1"
+version = "0.3.2"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/docs/v0.3.2-release-checklist.md
+++ b/docs/v0.3.2-release-checklist.md
@@ -54,11 +54,11 @@ Before tagging, all shipped components must declare `0.3.2` consistently.
 
 Checklist (filled in by release-prep plan PR 3):
 
-- [ ] `agents/pyproject.toml` updated to `0.3.2`
-- [ ] `agents/observability/{metrics,tracing}.py` `service.version` defaults updated to `0.3.2`
-- [ ] `cli/Cargo.toml` updated to `0.3.2`
-- [ ] `cli/Cargo.lock` regenerated and committed
-- [ ] `make all` builds successfully with the new versions
+- [x] `agents/pyproject.toml` updated to `0.3.2`
+- [x] `agents/observability/{metrics,tracing}.py` `service.version` defaults updated to `0.3.2`
+- [x] `cli/Cargo.toml` updated to `0.3.2`
+- [x] `cli/Cargo.lock` regenerated and committed
+- [x] `make all` builds successfully with the new versions
 - [ ] No docs or examples still describe v0.3.2 as unreleased work-in-progress (README + ROADMAP + release-prep plan + this checklist flipped in the post-release follow-up PR)
 
 ---
@@ -69,16 +69,16 @@ The release changelog must preserve every existing curated section in [`CHANGELO
 
 Checklist:
 
-- [ ] `CHANGELOG.md` contains a `[0.3.2]` section
-- [ ] The existing curated `[0.3.1]`, `[0.3.0]`, `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
-- [ ] The `[0.3.2]` section includes:
+- [x] `CHANGELOG.md` contains a `[0.3.2]` section
+- [x] The existing curated `[0.3.1]`, `[0.3.0]`, `[0.2.3]`, `[0.2.2]`, `[0.2.1]`, `[0.2.0]`, and `[0.1.0]` sections are preserved verbatim — not overwritten
+- [x] The `[0.3.2]` section includes:
   - **Highlights**: every LLM call passes through a server-issued wallet lease before it is issued (closes the v0.2.3 chat-bypass known limitation); `MemoryStore` facade frozen as the single path to agent memory ahead of the v0.4.0 Postgres split
   - **Features**: RFC 0023 PRs 1–8 (proto + skeleton → enforcement + TTL reaper → `WalletClient` + workflow-task wiring → chat-path wiring → autonomous TICK + sub-agent wiring → channel-message wiring → review follow-ups → RFC closeout); RFC 0029 Phase 1 PRs 1–5 (facade promotion + alias shim → lint rule + deprecation warnings → downstream call-site refactor → review follow-ups → Phase 1 closeout + perf gate); PR ranges per [release-prep plan §RFC PR roll-up](v0.3.2-release-prep-plan.md#rfc-pr-roll-up)
   - **Bug fixes**: [ISSUE-0055](issues/ISSUE-0055-close-path-sqlite-commit-race-catchup-storm.md) ([#380](https://github.com/mkhomutov/Persatrix/pull/380)), [ISSUE-0056](issues/ISSUE-0056-tests-tree-outside-ci-lint-type-gate.md) ([#381](https://github.com/mkhomutov/Persatrix/pull/381)), [ISSUE-0059](issues/ISSUE-0059-grpc-server-no-panic-recovery-interceptor.md) ([#379](https://github.com/mkhomutov/Persatrix/pull/379)), [ISSUE-0062](issues/ISSUE-0062-tests-tree-outside-ci-mypy-gate.md) ([#382](https://github.com/mkhomutov/Persatrix/pull/382)), [ISSUE-0064](issues/ISSUE-0064-persona-as-sub-agent-attribution-gap.md) ([#390](https://github.com/mkhomutov/Persatrix/pull/390)), [ISSUE-0065](issues/ISSUE-0065-chat-rest-budget-denied-no-channel-reply.md) ([#395](https://github.com/mkhomutov/Persatrix/pull/395)), [ISSUE-0066](issues/ISSUE-0066-chat-rest-resource-exhausted-no-channel-reply.md) ([#396](https://github.com/mkhomutov/Persatrix/pull/396) + reopen [#398](https://github.com/mkhomutov/Persatrix/pull/398))
   - **Documentation**: MT execution report (release-prep PR 1, [#394](https://github.com/mkhomutov/Persatrix/pull/394) + re-run [#397](https://github.com/mkhomutov/Persatrix/pull/397)), this docs refresh (release-prep PR 2), release-prep + master plans, RFC 0031 Phase 2 PR plan ([#383](https://github.com/mkhomutov/Persatrix/pull/383) — docs-only, RFC-tracking line)
   - **Testing**: 2 new MTs (`MT-COST-003`, `MT-COST-004`), wallet acquire+settle p99 loopback measurement, personal-tier latency regression gate, wallet/leasing integration suites
   - **Upgrade Notes** subsection (see §3.1 below)
-- [ ] RFC 0040 (`📋 Proposed`, no implementation in v0.3.2) and the RFC 0031 Phase 2 PR plan (docs-only) stay under an RFC-tracking line, **not** under Features
+- [x] RFC 0040 (`📋 Proposed`, no implementation in v0.3.2) and the RFC 0031 Phase 2 PR plan (docs-only) stay under an RFC-tracking line, **not** under Features
 
 Suggested generation command:
 
@@ -221,13 +221,13 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [ ] make check-licenses passes
 [ ] THIRD_PARTY_NOTICES.md regenerated via make notices (diff committed; only delta in v0.3.1..HEAD is openssl 0.10.79 → 0.10.80, #386)
 [ ] make generate-sanitizer-patterns-check passes (Go ↔ Python pattern parity)
-[ ] agents/pyproject.toml updated to 0.3.2
-[ ] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.2
-[ ] cli/Cargo.toml updated to 0.3.2
-[ ] cli/Cargo.lock regenerated and committed
-[ ] make all builds successfully
-[ ] CHANGELOG.md contains a curated [0.3.2] section with upgrade notes
-[ ] Existing [0.3.1], [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
+[x] agents/pyproject.toml updated to 0.3.2
+[x] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.2
+[x] cli/Cargo.toml updated to 0.3.2
+[x] cli/Cargo.lock regenerated and committed
+[x] make all builds successfully
+[x] CHANGELOG.md contains a curated [0.3.2] section with upgrade notes
+[x] Existing [0.3.1], [0.3.0], [0.2.3], [0.2.2], [0.2.1], [0.2.0], [0.1.0] sections preserved verbatim
 [x] All 32 manual tests recorded in docs/manual-tests/v0.3.2-execution-report.md
 [x] No unresolved Fail in manual tests; zero Not run
 [x] MT-COST-003 recorded Pass with HTTP 200 + reply_status="error" + LeaseDenied.message evidence (release gate)

--- a/docs/v0.3.2-release-prep-plan.md
+++ b/docs/v0.3.2-release-prep-plan.md
@@ -1,6 +1,6 @@
 # v0.3.2 Release Preparation Plan
 
-**Status**: 🚧 In progress — PRs 0–1 merged; PR 2 opening; PRs 3–4 not started
+**Status**: 🚧 In progress — PRs 0–2 merged; PR 3 opening; PR 4 not started
 **Target version**: v0.3.2 (Cost Gate + Facade Freeze — RFC 0023 full + RFC 0029 Phase 1)
 **Created**: 2026-05-20
 **Branch prefix**: `feature/v032-release-prep-`
@@ -36,8 +36,8 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 |----|-------|-------|--------|--------|-----------|--------|
 | 0 | — | v0.3.2 release-prep plan (this document) | `feature/v032-release-prep-plan` | ✅ Merged | [#393](https://github.com/mkhomutov/Persatrix/pull/393) | 2026-05-20 |
 | 1 | A | Manual test execution report (v0.3.2 surface) | `feature/v032-release-prep-mt-exec` | ✅ Merged | [#394](https://github.com/mkhomutov/Persatrix/pull/394) + re-run [#397](https://github.com/mkhomutov/Persatrix/pull/397) | 2026-05-20 |
-| 2 | A | README + ROADMAP + persona-agents + observability guide refresh + release checklist | `feature/v032-release-prep-docs` | 🔀 PR open | — | — |
-| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v032-release-prep-version-bump` | ⬜ Not started | — | — |
+| 2 | A | README + ROADMAP + persona-agents + observability guide refresh + release checklist | `feature/v032-release-prep-docs` | ✅ Merged | [#400](https://github.com/mkhomutov/Persatrix/pull/400) | 2026-05-20 |
+| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v032-release-prep-version-bump` | 🔀 PR open | — | — |
 | 4 | B | Final pre-tag verification & release notes | `feature/v032-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged


### PR DESCRIPTION
## Summary

Release-prep PR 3 of the [v0.3.2 release-prep plan](docs/v0.3.2-release-prep-plan.md) — version bump and changelog curation, no feature work. Closes the §2 Version Alignment + §3 Changelog gates in [v0.3.2-release-checklist.md](docs/v0.3.2-release-checklist.md).

- **Version bump 0.3.1 → 0.3.2** via `scripts/bump_version.py` (`agents/pyproject.toml`, `cli/Cargo.toml`, `agents/observability/{metrics,tracing}.py`) + `cd cli && cargo update --workspace` to regenerate `cli/Cargo.lock`. `make all` builds clean at 0.3.2 (no proto drift; only the persatrix workspace entry changes in Cargo.lock — no transitive bumps in `v0.3.1..HEAD` beyond the openssl 0.10.79 → 0.10.80 Dependabot PR #386 already on main).
- **`[0.3.2]` changelog section** generated via `git-cliff --tag v0.3.2 --unreleased v0.3.1..HEAD` (34 commits in range) and hand-curated under the codename **"Cost Gate + Facade Freeze"** — Highlights (RFC 0023 wallet leasing across five origins, RFC 0029 Phase 1 `MemoryStore` facade freeze), 8-row Upgrade Notes table per release-checklist §3.1, plus Features / Bug Fixes / Documentation / Testing / Build groups. RFC 0040 and the RFC 0031 Phase 2 PR plan (#383) stay under Documentation as RFC-tracking-only lines, not Features. All prior version sections preserved verbatim.
- **Release-prep plan + checklist hygiene**: Progress Overview row 2 → ✅ Merged (#400), row 3 → 🔀 PR open; §2 / §3 / §7 gates in the release checklist ticked off by this PR. The §2 docs-WIP-flip gate stays open — owned by the post-tag follow-up PR.

## Test plan

- [x] `scripts/bump_version.py 0.3.2` → 4 files updated (5 substitutions across `tracing.py`'s two occurrences)
- [x] `cd cli && cargo update --workspace` → only `persatrix 0.3.1 → 0.3.2` line in Cargo.lock changes
- [x] `make all` → proto + Go orchestrator + Rust CLI build green at 0.3.2 (CLI reports `Compiling persatrix v0.3.2`)
- [x] Pre-commit hooks (filemap / go fmt / ruff / cargo fmt / doc links / doc status / file size) all green
- [x] `[0.3.2]` section in `CHANGELOG.md` reviewed against [release-checklist §3 + §3.1](docs/v0.3.2-release-checklist.md#3-changelog) row-by-row
- [x] PR 4 will re-run `make all` + the full pre-tag verification sweep on the post-bump tip

## Dependencies

- Depends on: [release-prep PR 2 #400](https://github.com/mkhomutov/Persatrix/pull/400) (docs refresh + release checklist).
- Blocks: release-prep PR 4 (final pre-tag verification + release notes).