### PR TITLE
docs(release): post-release follow-up for v0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Persatrix is BUSL-1.1 licensed with no warranty. Use at your own risk
 | **v0.2.x** | Run persistent personas with memory, chat with them from a terminal, observe everything end-to-end with traces and metrics | ✅ Released |
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | ✅ Released |
 | **v0.3.1** | Chat with a persona that remembers stated facts about you across interactions and follows the conversation it's currently having | ✅ Released |
-| **v0.3.2** | Every LLM call passes through a wallet lease before it's issued — cost becomes a structural gate, not a post-hoc accountant — and the memory facade is frozen as the single path to agent memory ahead of the v0.4.0 Postgres split | 🚧 Release prep |
+| **v0.3.2** | Every LLM call passes through a wallet lease before it's issued — cost becomes a structural gate, not a post-hoc accountant — and the memory facade is frozen as the single path to agent memory ahead of the v0.4.0 Postgres split | ✅ Released |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
 | **v0.6.0** | Run agent societies across multiple nodes and networks | 📋 Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-05-20 (v0.3.2 release-prep PR 4 — final pre-tag verification. PRs 0–3 of release prep merged: plan ([#393](https://github.com/mkhomutov/Persatrix/pull/393)), MT execution report ([#394](https://github.com/mkhomutov/Persatrix/pull/394) → re-run [#397](https://github.com/mkhomutov/Persatrix/pull/397) with release gate met), docs refresh + release checklist ([#400](https://github.com/mkhomutov/Persatrix/pull/400)), version bump + curated changelog ([#401](https://github.com/mkhomutov/Persatrix/pull/401)). PR 4 (this PR) flips the Version Map v0.3.2 row 🚧 Release prep → ✅ Released; the `v0.3.2` git tag and GitHub Release follow post-merge per [release-prep plan Phase 5](docs/v0.3.2-release-prep-plan.md).)
+> **Last updated**: 2026-05-20 (v0.3.2 post-release follow-up — `v0.3.2` tagged and the [GitHub Release "Cost Gate + Facade Freeze"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.2) published. README v0.3.2 roadmap row → ✅ Released; ROADMAP `Last updated` refresh; Merged PR History backfill for the full v0.3.2 cycle ([#367](https://github.com/mkhomutov/Persatrix/pull/367) through [#402](https://github.com/mkhomutov/Persatrix/pull/402) — the table had stopped at [#391](https://github.com/mkhomutov/Persatrix/pull/391)); master plan + release-prep plan + release checklist status hygiene.)
 > **Current phase**: v0.3.2 (Cost Gate + Facade Freeze — RFC 0023 full + RFC 0029 Phase 1) — ✅ Released
 > **Current milestone**: v0.3.2 released. Every LLM call in the system passes through a server-issued wallet lease before it is issued (RFC 0023 Phases 1–6, all five origins wired — workflow / chat / autonomous TICK / sub-agent / channel-message — closing the v0.2.3 chat-bypass known limitation), and the `MemoryStore` facade is frozen as the single path to agent memory ahead of the v0.4.0 Postgres split (RFC 0029 Phase 1). Next phase is v0.3.3 (Idle, RFC 0024).
 
@@ -993,6 +993,16 @@ v0.5.0 complete
 | [#389](https://github.com/mkhomutov/Persatrix/pull/389) | feat(v032): RFC 0023 PR 6 — channel-message origin lease wiring | 0023 (6/8) | 2026-05-20 |
 | [#390](https://github.com/mkhomutov/Persatrix/pull/390) | fix(v032): ISSUE-0064 — persona-as-sub-agent attribution gap | ISSUE-0064 fix | 2026-05-20 |
 | [#391](https://github.com/mkhomutov/Persatrix/pull/391) | feat(v032): RFC 0023 PR 7 — review follow-ups (finalize log shape) | 0023 (7/8) | 2026-05-20 |
+| [#392](https://github.com/mkhomutov/Persatrix/pull/392) | docs(v032): RFC 0023 PR 8 — full-RFC closeout | 0023 (8/8) | 2026-05-20 |
+| [#393](https://github.com/mkhomutov/Persatrix/pull/393) | docs(v032): release-prep plan (master-plan Phase 3) | v0.3.2 release prep | 2026-05-20 |
+| [#394](https://github.com/mkhomutov/Persatrix/pull/394) | docs(v032): release-prep PR 1 — manual test execution report (release gate not met) | v0.3.2 release prep | 2026-05-20 |
+| [#395](https://github.com/mkhomutov/Persatrix/pull/395) | fix(v032): ISSUE-0065 — publish chat-error reply on channel under wallet denial | ISSUE-0065 fix | 2026-05-20 |
+| [#396](https://github.com/mkhomutov/Persatrix/pull/396) | fix(v032): ISSUE-0066 — publish chat-error reply on channel under wallet lease-cap / rate-limit | ISSUE-0066 fix | 2026-05-20 |
+| [#397](https://github.com/mkhomutov/Persatrix/pull/397) | docs(v032): release-prep PR 1 — manual test re-execution report (release gate met) | v0.3.2 release prep | 2026-05-20 |
+| [#398](https://github.com/mkhomutov/Persatrix/pull/398) | fix(v032): ISSUE-0066 reopen — handle AioRpcError(RESOURCE_EXHAUSTED) in action_loop | ISSUE-0066 fix | 2026-05-20 |
+| [#400](https://github.com/mkhomutov/Persatrix/pull/400) | docs(v032): release-prep PR 2 — docs refresh + release checklist | v0.3.2 release prep | 2026-05-20 |
+| [#401](https://github.com/mkhomutov/Persatrix/pull/401) | chore(release): bump to v0.3.2 + curate changelog (PR 3) | v0.3.2 release prep | 2026-05-20 |
+| [#402](https://github.com/mkhomutov/Persatrix/pull/402) | docs(v032): v0.3.2 release-prep PR 4 — final pre-tag verification | v0.3.2 release prep | 2026-05-20 |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -110,6 +110,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | v0.2.3 | [v0.2.3-execution-report.md](v0.2.3-execution-report.md) | ✅ Complete |
 | v0.3.0 | [v0.3.0-execution-report.md](v0.3.0-execution-report.md) | ✅ Complete |
 | v0.3.1 | [v0.3.1-execution-report.md](v0.3.1-execution-report.md) | ✅ Complete |
+| v0.3.2 | [v0.3.2-execution-report.md](v0.3.2-execution-report.md) | ✅ Complete |
 
 ---
 

--- a/docs/v0.3.2-plan.md
+++ b/docs/v0.3.2-plan.md
@@ -1,8 +1,9 @@
 # v0.3.2 Plan — Cost Gate + Facade Freeze
 
-**Status**: 🚧 In progress (Phase 2 complete — both RFCs merged; Phase 3 — release-prep plan — next)
+**Status**: ✅ Complete
 **Target version**: v0.3.2 (RFC 0023 full + RFC 0029 Phase 1)
 **Created**: 2026-05-17
+**Completed**: 2026-05-20
 **Branch prefix**: `feature/v032-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -93,8 +94,8 @@ Update this table as each step PR merges. For multi-PR workstream rows, roll up 
 | 2 | 2 | RFC 0023 implementation (per `0023-pr-plan.md`) | `feature/v032-rfc0023-…` | ✅ Merged | [#378](https://github.com/mkhomutov/Persatrix/pull/378), [#384](https://github.com/mkhomutov/Persatrix/pull/384), [#385](https://github.com/mkhomutov/Persatrix/pull/385), [#387](https://github.com/mkhomutov/Persatrix/pull/387), [#388](https://github.com/mkhomutov/Persatrix/pull/388), [#389](https://github.com/mkhomutov/Persatrix/pull/389), [#391](https://github.com/mkhomutov/Persatrix/pull/391) (+ closeout this PR) | 2026-05-20 |
 | 3 | 2 | RFC 0029 Phase 1 implementation (per `0029-pr-plan.md`) | `feature/v032-rfc0029p1-…` | ✅ Merged | [#370](https://github.com/mkhomutov/Persatrix/pull/370), [#372](https://github.com/mkhomutov/Persatrix/pull/372), [#373](https://github.com/mkhomutov/Persatrix/pull/373), [#375](https://github.com/mkhomutov/Persatrix/pull/375), [#376](https://github.com/mkhomutov/Persatrix/pull/376) | 2026-05-18 |
 | 4 | 3 | v0.3.2 release-prep plan | `feature/v032-release-prep-plan` | ✅ Merged | [#393](https://github.com/mkhomutov/Persatrix/pull/393) | 2026-05-20 |
-| 5 | 4 | v0.3.2 release-prep execution | `feature/v032-release-prep-…` | 🔀 PR open | [#394](https://github.com/mkhomutov/Persatrix/pull/394) / [#397](https://github.com/mkhomutov/Persatrix/pull/397) / [#400](https://github.com/mkhomutov/Persatrix/pull/400) / [#401](https://github.com/mkhomutov/Persatrix/pull/401) + this PR | — |
-| 6 | 5 | v0.3.2 tag + post-release follow-up | `feature/v032-post-release` | ⬜ Not started | — | — |
+| 5 | 4 | v0.3.2 release-prep execution | `feature/v032-release-prep-…` | ✅ Merged | [#394](https://github.com/mkhomutov/Persatrix/pull/394) / [#397](https://github.com/mkhomutov/Persatrix/pull/397) / [#400](https://github.com/mkhomutov/Persatrix/pull/400) / [#401](https://github.com/mkhomutov/Persatrix/pull/401) / [#402](https://github.com/mkhomutov/Persatrix/pull/402) | 2026-05-20 |
+| 6 | 5 | v0.3.2 tag + post-release follow-up | `feature/v032-post-release` | 🔀 PR open | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred
 

--- a/docs/v0.3.2-release-checklist.md
+++ b/docs/v0.3.2-release-checklist.md
@@ -1,6 +1,6 @@
 # v0.3.2 Release Checklist
 
-> **Status**: ✅ Released — release-prep PR 1 ([#394](https://github.com/mkhomutov/Persatrix/pull/394) initial run + [#397](https://github.com/mkhomutov/Persatrix/pull/397) re-run with release gate met) recorded the live MT execution against the `a9c4860` RC tip; release-prep PR 2 ([#400](https://github.com/mkhomutov/Persatrix/pull/400)) refreshed public docs; release-prep PR 3 ([#401](https://github.com/mkhomutov/Persatrix/pull/401)) bumped versions and curated the changelog; release-prep PR 4 (this PR) is the final pre-tag verification sweep. The `v0.3.2` git tag and GitHub Release follow post-merge per [release-prep plan Phase 5](v0.3.2-release-prep-plan.md).
+> **Status**: ✅ Released — `v0.3.2` tagged and the [GitHub Release "Cost Gate + Facade Freeze"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.2) published 2026-05-20. Release-prep PR 1 ([#394](https://github.com/mkhomutov/Persatrix/pull/394) initial run + [#397](https://github.com/mkhomutov/Persatrix/pull/397) re-run with release gate met) recorded the live MT execution against the `a9c4860` RC tip; release-prep PR 2 ([#400](https://github.com/mkhomutov/Persatrix/pull/400)) refreshed public docs; release-prep PR 3 ([#401](https://github.com/mkhomutov/Persatrix/pull/401)) bumped versions and curated the changelog; release-prep PR 4 ([#402](https://github.com/mkhomutov/Persatrix/pull/402)) was the final pre-tag verification sweep.
 
 > v0.3.2 — "Cost Gate + Facade Freeze" — ships the combined deliverable of RFC 0023 (LLM-call leasing — full, Phases 1–6) and RFC 0029 Phase 1 (personal/society storage split — `MemoryStore` facade promotion + alias shim + lint rule + downstream-call-site sweep + recall-latency regression gate). The user-facing promise: *every LLM call passes through a wallet lease before it is issued — cost is a structural gate, not a post-hoc accountant — and the memory facade is frozen as the single path to agent memory ahead of the v0.4.0 Postgres split.*
 
@@ -174,11 +174,11 @@ git push origin v0.3.2
 
 GitHub Release checklist (post-merge manual steps after PR 4 merges):
 
-- [ ] Create the GitHub Release from tag `v0.3.2`
-- [ ] Use the curated `[0.3.2]` changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body
-- [ ] Attach binaries or container references if produced for this release — none planned (matches the v0.3.1 / v0.3.0 / v0.2.3 pattern)
+- [x] Create the GitHub Release from tag `v0.3.2`
+- [x] Use the curated `[0.3.2]` changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body
+- [ ] Attach binaries or container references if produced for this release — none produced (matches the v0.3.1 / v0.3.0 / v0.2.3 pattern)
 
 ---
 
@@ -236,6 +236,6 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] Personal-tier latency regression gate green on the RC tip (p99=2.04 ms, p50=1.29 ms; informational-only — baseline not yet committed)
 [x] Known gaps documented for release notes (§6 above)
 [x] Docker smoke test — carried forward from PR 1 re-run #397; PR 3 was version-strings-only with no production code change
-[ ] git tag v0.3.2 created and pushed (post-merge)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (post-merge)
+[x] git tag v0.3.2 created and pushed (2026-05-20)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (2026-05-20)
 ```

--- a/docs/v0.3.2-release-prep-plan.md
+++ b/docs/v0.3.2-release-prep-plan.md
@@ -38,7 +38,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 1 | A | Manual test execution report (v0.3.2 surface) | `feature/v032-release-prep-mt-exec` | ✅ Merged | [#394](https://github.com/mkhomutov/Persatrix/pull/394) + re-run [#397](https://github.com/mkhomutov/Persatrix/pull/397) | 2026-05-20 |
 | 2 | A | README + ROADMAP + persona-agents + observability guide refresh + release checklist | `feature/v032-release-prep-docs` | ✅ Merged | [#400](https://github.com/mkhomutov/Persatrix/pull/400) | 2026-05-20 |
 | 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog curation | `feature/v032-release-prep-version-bump` | ✅ Merged | [#401](https://github.com/mkhomutov/Persatrix/pull/401) | 2026-05-20 |
-| 4 | B | Final pre-tag verification & release notes | `feature/v032-release-prep-final` | 🔀 PR open (this PR) | — | — |
+| 4 | B | Final pre-tag verification & release notes | `feature/v032-release-prep-final` | ✅ Merged | [#402](https://github.com/mkhomutov/Persatrix/pull/402) | 2026-05-20 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
## Summary

v0.3.2 was tagged and the [GitHub Release "Cost Gate + Facade Freeze"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.2) published 2026-05-20. This is the post-release docs sweep, mirroring [#366](https://github.com/mkhomutov/Persatrix/pull/366) (v0.3.1 post-release) and [#330](https://github.com/mkhomutov/Persatrix/pull/330) (v0.3.0 post-release) — flips any remaining docs that still described v0.3.2 as unreleased work-in-progress, and rolls Phase 5 of the [v0.3.2 master plan](docs/v0.3.2-plan.md#phase-5--tag-and-post-release-follow-up) to closed.

### Changes

- **README.md** — roadmap row for v0.3.2 flips from 🚧 Release prep to ✅ Released.
- **ROADMAP.md** — refresh "Last updated" (post-tag context, links to the GitHub Release); backfill the **Merged PR History** table with the full v0.3.2 cycle ([#392](https://github.com/mkhomutov/Persatrix/pull/392) through [#402](https://github.com/mkhomutov/Persatrix/pull/402) — the table had stopped at [#391](https://github.com/mkhomutov/Persatrix/pull/391); [#399](https://github.com/mkhomutov/Persatrix/pull/399) is still open and intentionally skipped). The "Current phase" / "Current milestone" lines and the Version Map v0.3.2 row already flipped in release-prep PR 4 ([#402](https://github.com/mkhomutov/Persatrix/pull/402)).
- **docs/v0.3.2-release-checklist.md** — Status blurb flips to the pushed-tag/published-release state with the Release URL; tick the §5 GitHub Release procedure items and the §7 tag/release summary gates. "Attach binaries" left unchecked (none produced — matches the v0.3.1 / v0.3.0 / v0.2.3 pattern).
- **docs/v0.3.2-plan.md** — top-level Status flips from 🚧 In progress to ✅ Complete; add `Completed: 2026-05-20`; Master Progress Overview row 5 flips to ✅ Merged with the release-prep PR links (rolls in [#402](https://github.com/mkhomutov/Persatrix/pull/402)), row 6 (post-release follow-up) flips to 🔀 PR open.
- **docs/v0.3.2-release-prep-plan.md** — Progress Overview PR 4 row flips from 🔀 PR open to ✅ Merged ([#402](https://github.com/mkhomutov/Persatrix/pull/402), 2026-05-20).
- **docs/manual-tests/README.md** — Execution Reports table: append the v0.3.2 row at ✅ Complete.

No code changes. No tests affected. `scripts/checks/file_size.py` grandfather list not touched — `docs/v0.3.2-plan.md` (2979 words) and `docs/v0.3.2-release-prep-plan.md` (2997 words) both finish the post-release sweep under the 3000-word prose cap.

## Test plan

- [x] `make validate` — clean
- [x] `python scripts/checks/file_size.py --strict` — clean (all docs under cap)
- [x] Pre-commit hooks (filemap / go fmt / ruff / cargo fmt / doc links / doc status / file size) — 7/7 PASS at commit time
- [x] Reviewer spot-checks the [GitHub Release "Cost Gate + Facade Freeze"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.2) URL renders in the checklist Status blockquote and the ROADMAP "Last updated" line
- [x] Reviewer confirms [#399](https://github.com/mkhomutov/Persatrix/pull/399) (still open) is correctly skipped from the Merged PR History backfill