### PR TITLE
chore(v033): v0.3.3 release-prep PR 3 — version bump + changelog + MemoryFacade alias removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,60 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3] - 2026-05-22
+
+> **Codename:** Idle Truly Idle
+
+### Highlights
+
+- **Idle is truly idle — a persona with no scheduled work and no inbound traffic now costs nothing** (RFC 0024, Phases 1–4). The persona autonomy loop is event-driven: it parks on `queue.get()` and wakes only on an inbound RPC, a scheduled `autonomy.timers` entry, or a salience memory write. A persona with `autonomy.timers: []` and no inbound traffic does no SQLite recall, no `_inject_memory_context`, no provider call, and no wallet lease — the polling-loop cost-leak class is closed **structurally**, not patched per release. The promise is guarded on every PR by the bored-persona `cost-regression-gate` CI job ([`tests/integration/test_bored_persona_cost.py`](tests/integration/test_bored_persona_cost.py)), a release-blocker.
+- **`tick_interval_seconds` keeps working unchanged.** The legacy field is synthesised into a single `ScheduledWake(timer_id="legacy_tick")` through a back-compat adapter, so existing configs need no edit. The deprecation *warning* is RFC 0024 Phase 5 (v0.4.0); removal is Phase 6 (v0.5+).
+
+### Upgrade Notes
+
+| Notable change | Detail |
+|----------------|--------|
+| **[Behaviour change — idle is truly idle]** Event-driven autonomy loop | The persona autonomy loop is now event-driven ([RFC 0024](docs/rfcs/0024-event-driven-scheduling.md) Phases 1–4). A persona with `autonomy.timers: []` and no inbound traffic parks on `queue.get()` and pays nothing — no SQLite recall, no `_inject_memory_context`, no provider activity, no wallet lease. The polling-loop cost-leak class is closed structurally, guarded by `cost-regression-gate`. |
+| **[Behaviour change — channel dispatch]** Fire-and-forget channel messages | `ReceiveChannelMessage` now enqueues `InboundEventWake(event)` fire-and-forget via `event_loop.enqueue` (not `scheduler.wake()`) and returns `TaskAck` immediately. Chat, sub-agent, and workflow-task paths are unchanged — they keep their synchronous-return contract via `SyncDispatchHandle`. |
+| New `autonomy.timers` config block | Per-agent timer list in `agents.yaml` / [`schemas/agent.schema.json`](schemas/agent.schema.json): `id`, `interval_seconds` (≥ `1.0`), `kind` (a `callback_kind` label), optional `jitter_max_seconds`. `tick_interval_seconds` **continues to work** — synthesised as one `ScheduledWake(timer_id="legacy_tick", callback_kind="tick")`; if both are set, `timers` wins (one-time INFO log). Absent block → `timers: []`. Deprecation **warning** is Phase 5 (v0.4.0); removal is Phase 6 (v0.5+). |
+| New per-agent SQLite `scheduled_wakes` cache | Derived from `agents.yaml` (source of truth), rebuilt on startup; restores `next_fire_at_ms` so a persona restarted mid-jitter-window resumes its schedule instead of re-randomising. Orphan rows deleted on next startup. No operator action. |
+| New `autonomy.salience_threshold` (default `0.95`) + `autonomy.salience_rate_max_per_sec` (default `10`) | Salience-triggered wakes from the memory-write path. **Ships disabled by default** — the threshold is strictly above stock conservative scoring (`REFLECTION_CONTRADICTION_SALIENCE = 0.6`). Calibration is a data-gated follow-up ([RFC 0024 §OQ §2](docs/rfcs/0024-event-driven-scheduling.md#open-questions)). The rate-limit is a DoS guard, not a calibration knob. |
+| New `agent.wake.{inbound,scheduled,salience,dropped}` metric counters | Carry `wake.kind` (plus `timer_id` on scheduled, `tier` + `suppressed_reason` on salience). `wake.kind` is an **OTEL/metric dimension only** — *not* a new `LeaseRequest` proto field; [`proto/wallet.proto`](proto/wallet.proto)'s `Cause cause` is unchanged, so v0.3.2 cost-attribution dashboards keep working (`trace_id` already links the lease to the wake span). See [observability.md §10.5](docs/observability.md#105-persatrix-specific-attribute-namespace). |
+| RFC 0017 §F empty-context TICK guard is now structurally unreachable but stays in place | Documented as vestigial via an [`action_loop.py`](agents/persona_runtime/action_loop.py) cross-link naming Phase 5/6 as the deletion path. No behaviour change. |
+| **[Breaking]** `agents.memory.MemoryFacade` alias removed | The `MemoryFacade` deprecation alias introduced in v0.3.2 (RFC 0029 Phase 1 facade freeze) is **removed**, honouring its published one-minor-version horizon ("removal in v0.3.3"). Import `agents.memory.MemoryStore` (or `agents.memory.store.MemoryStore`) directly — `MemoryStore` is the same class object the alias pointed at, so only the import name changes. Production call sites migrated in v0.3.2 (RFC 0029 Phase 1 PR 3); the v0.3.3 release-prep migrated the test suite and removed the symbol. |
+
+### 🚀 Features
+
+- *(v033)* RFC 0024 PR 1 — `EventLoop` + `WakeEvent` + `SyncDispatchHandle` (Phase 1) (#406)
+- *(v033)* RFC 0024 PR 2 — `autonomy.timers` + `scheduled_wakes` table (Phase 2) (#407)
+- *(v033)* RFC 0024 PR 2.1 — wire `ScheduledWakesCache` into persona init (Phase 2) (#408)
+- *(v033)* RFC 0024 PR 3a — write-side `salience` + `source_span_id` (Phase 3 prereq) (#409)
+- *(v033)* RFC 0024 PR 3b — `SalienceWake` enqueue + threshold + loop-back guard (Phase 3) (#410)
+- *(v033)* RFC 0024 PR 4 — channel-message fire-and-forget dispatch + cost-regression CI gate (Phase 4) (#411)
+- *(v033)* RFC 0024 PR 5 — `EventLoop` lifecycle hardening (#412)
+- *(v033)* RFC 0024 PR 5.1 — review-follow-up cleanups + deferred test-gap fills (Phases 1–4) (#413)
+
+### 📚 Documentation
+
+- *(release)* Post-release follow-up for v0.3.2 (#403)
+- *(rfcs)* RFC 0041–0044 drafts + agent-runtime vocabulary roadmap — all `🔨 Draft`, RFC-tracking only (#399)
+- *(v033)* Open v0.3.3 master plan — Idle Truly Idle (#404)
+- *(v033)* RFC 0024 PR plan — Phases 1–4 (#405)
+- *(v033)* RFC 0024 PR 6 — Phases 1–4 closeout (#414)
+- *(v033)* Release-prep plan (master-plan Phase 3) (#415)
+- Refresh MT-CHAT-003/004 for RFC 0020 interaction-close; file ISSUE-0067/0068 (#417)
+- *(v033)* Release-prep PR 1 — manual-test execution report (#416)
+- *(v033)* Release-prep PR 2 — docs refresh + release checklist (#418)
+
+### 🧪 Testing
+
+- New manual test [`MT-IDLE-001`](docs/manual-tests/MT-IDLE-001.md) — *idle persona costs nothing*: an `autonomy.timers: []` persona with no inbound traffic shows zero provider/wallet/`agent.wake.*` activity over a 60 s window, then a single inbound event wakes the parked loop. This is the **primary v0.3.3 release gate**.
+- The bored-persona [`cost-regression-gate`](.github/workflows/ci.yml) CI job ([`tests/integration/test_bored_persona_cost.py`](tests/integration/test_bored_persona_cost.py)) is a **release-blocker** (a PR trigger on the wake-path file set, not a nightly) — it fails any change that re-introduces an LLM call, `_inject_memory_context`, `LeaseRequest`, or `agent.wake.*` activity from an idle persona.
+- New `EventLoop` / `scheduled_wakes` / salience / wake-counter suites cover the event-driven loop, the cache rebuild + `next_fire_at_ms` restore, the `legacy_tick` adapter, and the four `agent.wake.*` counters.
+- Full 34-row manual-test surface (1 new gate + 33 carried-forward) re-executed against the `ea2b86d` release-candidate tip; release gate met ([#416](https://github.com/mkhomutov/Persatrix/pull/416)).
+
+[0.3.3]: https://github.com/mkhomutov/Persatrix/compare/v0.3.2...v0.3.3
+
 ## [0.3.2] - 2026-05-20
 
 > **Codename:** Cost Gate + Facade Freeze

--- a/agents/memory/__init__.py
+++ b/agents/memory/__init__.py
@@ -9,7 +9,6 @@ from .facade import (
     CompressedView,
     MemoryDisabledError,
     MemoryEntry,
-    MemoryFacade,
     budget_to_limit,
 )
 from .facts import Fact, FactStore
@@ -61,7 +60,6 @@ __all__ = [
     "Interaction",
     "MemoryDisabledError",
     "MemoryEntry",
-    "MemoryFacade",
     "MemoryLifecycle",
     "MemoryStore",
     "Note",

--- a/agents/memory/episodic_procedural.py
+++ b/agents/memory/episodic_procedural.py
@@ -113,7 +113,7 @@ def extract_procedure_key(tags: list[str]) -> str | None:
     """Return the first ``procedure:KEY`` tag's KEY suffix, or ``None``.
 
     Procedural rows are always written with a single ``procedure:KEY``
-    tag by :meth:`MemoryFacade.store_procedure`, but the helper is
+    tag by :meth:`MemoryStore.store_procedure`, but the helper is
     defensive about extra tags so a future change adding decoration
     tags (e.g. ``"category:tools"``) does not break recall.
     """
@@ -141,7 +141,7 @@ async def recall_procedures(
     ``episodic.py``.
 
     Procedural rows are identified by the ``procedure:`` tag prefix
-    written by :meth:`MemoryFacade.store_procedure`.  Each row's decayed
+    written by :meth:`MemoryStore.store_procedure`.  Each row's decayed
     confidence is computed via
     :func:`~agents.memory.decay.compute_decayed_confidence` against the
     row's ``last_validated_at`` (or ``created_at`` when never
@@ -183,7 +183,7 @@ async def recall_procedures(
         # cutoff in seconds is ``-ln(c_min)/lambda_per_day * 86400``.
         sql_cutoff_seconds = -math.log(c_min) / lambda_per_day * 86400.0
     # Procedural rows carry a tag formatted ``procedure:{key}`` — see
-    # ``MemoryFacade.store_procedure``.  ``tags_json`` stores the tag
+    # ``MemoryStore.store_procedure``.  ``tags_json`` stores the tag
     # list as a JSON array, so the LIKE pattern matches the tag
     # substring verbatim regardless of array position.  Phase 5 uses
     # ``LIKE`` rather than FTS5 so a procedure key with punctuation
@@ -292,7 +292,7 @@ async def refresh_confidence(
     one row was updated.
 
     Implements the "Confidence refresh on successful reuse" contract
-    from RFC 0008 §G — :meth:`MemoryFacade.store_procedure` invokes it
+    from RFC 0008 §G — :meth:`MemoryStore.store_procedure` invokes it
     automatically when a re-store hits an existing key.
     """
     if not key or not key.strip():

--- a/agents/memory/episodic_queries.py
+++ b/agents/memory/episodic_queries.py
@@ -75,7 +75,7 @@ class Episode:
     compression_level: int  # 0=raw, 1=summarized, 2=distilled
     # RFC 0020 §D column-level scope, projected onto the dataclass in
     # PR 2a so non-facade writers (``InteractionTracker``) are visible to
-    # ``MemoryFacade.retrieve_relevant(scope=...)`` filtering.  Defaults
+    # ``MemoryStore.retrieve_relevant(scope=...)`` filtering.  Defaults
     # to ``None`` so legacy rows without a scope value round-trip cleanly.
     scope: str | None = None
     # RFC 0021 PR 2 (this PR): expose the RFC 0020 §D interaction columns

--- a/agents/memory/eviction.py
+++ b/agents/memory/eviction.py
@@ -19,13 +19,13 @@ Confidence decay for the procedural tier is **out of scope** for this PR
 and lands in PR 5 (RFC 0008 PR plan Phase 4b).  To keep the two policies
 cleanly separated, every query in this module excludes rows whose
 ``tags_json`` carries the ``procedure:`` prefix written by
-:meth:`MemoryFacade.store_procedure` — see ``_NOT_PROCEDURE_PREDICATE``
+:meth:`MemoryStore.store_procedure` — see ``_NOT_PROCEDURE_PREDICATE``
 below and PR #221 deep-review finding M-1.
 
 The :class:`EvictionPass` class is intentionally stateless across runs —
 :meth:`EvictionPass.run` opens fresh queries against the agent's database
 and returns an :class:`EvictionStats` report so the caller (the
-:class:`~agents.memory.facade.MemoryFacade` background loop) can log /
+:class:`~agents.memory.facade.MemoryStore` background loop) can log /
 trace each pass.  ``EvictionStats.total_after`` therefore reports the
 *evictable* (episodic) row count — procedure rows are intentionally
 excluded so the figure matches what the size-cap budget enforces.
@@ -65,7 +65,7 @@ _W_RECENCY: float = 0.3
 _W_ACCESS: float = 0.1
 
 # RFC 0008 §G separates episodic eviction from procedural confidence
-# decay (the latter lands in PR 5).  ``MemoryFacade.store_procedure``
+# decay (the latter lands in PR 5).  ``MemoryStore.store_procedure``
 # persists procedures as episode rows tagged ``procedure:{key}`` with
 # ``confidence`` mapped onto ``importance``; without this guard a
 # low-confidence procedure would be silently TTL- or cap-evicted by the
@@ -101,7 +101,7 @@ class EvictionPass:
     """Single eviction run against an open ``aiosqlite`` connection.
 
     Stateless — does not retain rows across runs.  The
-    :class:`~agents.memory.facade.MemoryFacade` schedules one instance
+    :class:`~agents.memory.facade.MemoryStore` schedules one instance
     per cadence tick.
     """
 
@@ -333,12 +333,12 @@ async def eviction_loop(
     lambda_per_day: float = DEFAULT_LAMBDA_PER_DAY,
     c_min: float = DEFAULT_C_MIN,
 ) -> None:
-    """Periodic eviction loop scheduled by ``MemoryFacade.initialize()``.
+    """Periodic eviction loop scheduled by ``MemoryStore.initialize()``.
 
     Runs one :class:`EvictionPass` every ``cadence_seconds``.  Failures
     log a warning and the loop continues — eviction is best-effort
     (mirrors RFC 0005 working-memory async-flush pattern).  The loop
-    exits cleanly when cancelled by ``MemoryFacade.close()``.
+    exits cleanly when cancelled by ``MemoryStore.close()``.
     """
     if cadence_seconds <= 0:
         raise ValueError(

--- a/agents/memory/facade.py
+++ b/agents/memory/facade.py
@@ -1,22 +1,23 @@
-"""``MemoryFacade`` — backward-compat alias for ``MemoryStore`` (RFC 0029 Phase 1).
+""":mod:`agents.memory.facade` — ``budget_to_limit`` + store re-exports.
 
-RFC 0029 Phase 1 promotes the RFC 0008 ``MemoryFacade`` to the typed
-:class:`~agents.memory.store.MemoryStore` facade.  The facade *home* is
-now :mod:`agents.memory.store`; this module survives as a thin
-compatibility shim for one minor version (removed in v0.3.3):
+RFC 0029 Phase 1 promoted the RFC 0008 ``MemoryFacade`` to the typed
+:class:`~agents.memory.store.MemoryStore`; the facade *home* is now
+:mod:`agents.memory.store`.  The one-minor-version ``MemoryFacade``
+compatibility alias the v0.3.2 Upgrade Notes committed to removing in
+v0.3.3 has been removed — every call site imports ``MemoryStore``
+directly (the RFC 0029 Phase 1 PR 3 sweep migrated production code; the
+v0.3.3 release-prep migrated the test suite).
 
-- ``MemoryFacade`` is re-bound to ``MemoryStore`` — the **same class
-  object**, so every existing ``MemoryFacade()`` construction,
-  ``isinstance(x, MemoryFacade)`` check, and ``MemoryFacade.compress``
-  call keeps working unchanged until the RFC 0029 Phase 1 PR 3 call-site
-  sweep migrates them.
-- The facade-level dataclasses (``MemoryEntry`` / ``CompressedView`` /
-  ``Candidate``) and ``MemoryDisabledError`` are re-exported so existing
-  ``from agents.memory.facade import ...`` imports keep resolving.
+This module survives because it owns work the store class does not:
 
-``budget_to_limit`` lives here: it translates the orchestrator's RFC 0008
-``_context_package.budget_memory_tokens`` into a recall ``limit`` and has
-no dependency on the ``MemoryStore`` class.
+- ``budget_to_limit`` translates the orchestrator's RFC 0008
+  ``_context_package.budget_memory_tokens`` into a recall ``limit`` and
+  has no dependency on the ``MemoryStore`` class.
+- The store surface (``MemoryStore`` / ``StoreConfig`` / the society
+  errors) and the facade-level dataclasses (``MemoryEntry`` /
+  ``CompressedView`` / ``Candidate``) and ``MemoryDisabledError`` are
+  re-exported so existing ``from agents.memory.facade import ...``
+  imports keep resolving.
 """
 
 from __future__ import annotations
@@ -34,12 +35,6 @@ from .store_types import (
     MemoryDisabledError,
     MemoryEntry,
 )
-
-#: Backward-compat alias.  ``MemoryFacade`` *is* ``MemoryStore`` — the same
-#: class object, not a subclass — so identity and ``isinstance`` checks
-#: hold across the rename.
-MemoryFacade = MemoryStore
-
 
 # ─── Budget translation helper ─────────────────────────────────
 
@@ -79,7 +74,6 @@ __all__ = [
     "DEFAULT_AVG_ENTRY_TOKENS",
     "MemoryDisabledError",
     "MemoryEntry",
-    "MemoryFacade",
     "MemoryStore",
     "SocietyBackendUnavailable",
     "SocietyDisabled",

--- a/agents/memory/facade_procedural.py
+++ b/agents/memory/facade_procedural.py
@@ -1,4 +1,4 @@
-"""Procedural-tier mixin for :class:`agents.memory.facade.MemoryFacade`.
+"""Procedural-tier mixin for :class:`agents.memory.facade.MemoryStore`.
 
 Extracted from ``facade.py`` to keep that file under the 500-line repo
 cap once the RFC 0008 PR 5 procedural-tier surface (decay knobs +
@@ -83,7 +83,7 @@ def validate_decay_params(
 
 
 class ProceduralFacadeMixin:
-    """Procedural-tier methods for :class:`MemoryFacade`.
+    """Procedural-tier methods for :class:`MemoryStore`.
 
     Expects the host class to provide ``self._agent_id``,
     ``self._episodic`` (an initialised :class:`EpisodicMemory`),
@@ -97,7 +97,7 @@ class ProceduralFacadeMixin:
     _c_min: float
     _stale_alert_threshold: float
     # RFC 0031 Phase 1: facade-level construction-time default for the
-    # operator-namespace tag (see :class:`agents.memory.facade.MemoryFacade`).
+    # operator-namespace tag (see :class:`agents.memory.facade.MemoryStore`).
     _session_id: str
 
     def _require_initialised(self) -> None: ...  # pragma: no cover — host
@@ -158,7 +158,7 @@ class ProceduralFacadeMixin:
             context["expires_at"] = expires_at
         # RFC 0031 Phase 1: thread session_id; caller passes ``None`` to
         # inherit the facade's construction-time default (see
-        # ``MemoryFacade.__init__``).  Procedural rows live in the same
+        # ``MemoryStore.__init__``).  Procedural rows live in the same
         # ``episodes`` table as observations, so the session-tag column
         # is shared.
         episode_id = await self._episodic.store_episode(
@@ -251,7 +251,7 @@ __all__ = [
 
 
 def procedural_kwargs_from_config(memory_cfg: dict) -> dict:
-    """Project ``memory.procedural_memory`` config into MemoryFacade kwargs.
+    """Project ``memory.procedural_memory`` config into MemoryStore kwargs.
 
     Extracted so :class:`agents.base.BaseAgent.initialize_memory` can
     fan the optional config block into the facade constructor in one

--- a/agents/memory/scope_recall.py
+++ b/agents/memory/scope_recall.py
@@ -3,7 +3,7 @@
 Single implementation of "recall episodes from
 :class:`~agents.memory.episodic.EpisodicMemory`, then keep only those
 matching an optional scope and/or AND-tag filter".  Both
-:meth:`~agents.memory.facade.MemoryFacade.retrieve_relevant` and the
+:meth:`~agents.memory.facade.MemoryStore.retrieve_relevant` and the
 persona-runtime channel-history tier in
 :meth:`~agents.persona_runtime.memory_context._MemoryContextMixin._inject_memory_context`
 delegate here, so the contract — over-fetch factor, scope precedence,

--- a/agents/memory/shared_pool.py
+++ b/agents/memory/shared_pool.py
@@ -2,7 +2,7 @@
 
 Implements the *hybrid* memory model from `RFC 0008 §H`_ (see
 ``docs/rfcs/0008-agent-memory-context-optimization.md``):
-each agent keeps an isolated ``MemoryFacade``, and curated entries are
+each agent keeps an isolated ``MemoryStore``, and curated entries are
 *published* to a named shared pool whose ACL is declared in
 ``config/agents.yaml``.
 
@@ -15,7 +15,7 @@ Per `RFC 0008 PR plan PR 4
   are framework-injected on write — callers cannot spoof ``source_agent``.
 * Consumer-side ``min_confidence`` filter on read; ``None`` admits all.
 * Sensitive pools (``sensitive: true``) cannot be published into via
-  :meth:`MemoryFacade.publish_to_pool` regardless of writer ACL — RFC 0008
+  :meth:`MemoryStore.publish_to_pool` regardless of writer ACL — RFC 0008
   §H safety constraint #3.
 * Eviction is FIFO on ``created_at`` (not §G hybrid score) because pool
   entries lack the per-agent ``access_count`` series required by §G.
@@ -375,7 +375,7 @@ class SharedPoolRegistry:
     """Lifecycle owner for the named pools declared in ``agents.yaml``.
 
     Built once per agent process from the parsed ``shared_memory_pools``
-    section, then handed to :class:`MemoryFacade` so per-agent
+    section, then handed to :class:`MemoryStore` so per-agent
     ``publish_to_pool`` / ``read_from_pool`` calls resolve by pool name.
     """
 

--- a/agents/memory/shared_pool_facade.py
+++ b/agents/memory/shared_pool_facade.py
@@ -1,5 +1,5 @@
 """Free-function helpers + mixin backing
-:meth:`MemoryFacade.publish_to_pool` and :meth:`MemoryFacade.read_from_pool`.
+:meth:`MemoryStore.publish_to_pool` and :meth:`MemoryStore.read_from_pool`.
 
 Kept in a separate module so ``agents/memory/facade.py`` and
 ``agents/memory/shared_pool.py`` both stay under the repo line cap.
@@ -112,14 +112,14 @@ class SharedPoolFacadeMixin:
     Expects the host class to provide ``_shared_pools``, ``_agent_id``,
     ``_session_id`` (RFC 0031 Phase 1 facade-level default), and
     ``_require_initialised()``.  Lives here (not on
-    :class:`MemoryFacade` directly) to keep ``facade.py`` under the
+    :class:`MemoryStore` directly) to keep ``facade.py`` under the
     repo line cap.
     """
 
     _shared_pools: SharedPoolRegistry | None
     _agent_id: str
     # RFC 0031 Phase 1: facade-level default for the operator-namespace
-    # tag (see :class:`agents.memory.facade.MemoryFacade`).
+    # tag (see :class:`agents.memory.facade.MemoryStore`).
     _session_id: str
 
     def _require_initialised(self) -> None: ...  # provided by host

--- a/agents/memory/store.py
+++ b/agents/memory/store.py
@@ -8,12 +8,13 @@ facade.  Society-tier methods (shared pools, inbound trust) hit Postgres
 when a ``society_dsn`` is configured; Phase 1 ships single-agent mode
 only, so they raise the :class:`SocietyBackendUnavailable` hierarchy.
 
-The promotion is a **pure refactor**: ``MemoryStore`` keeps the legacy
-``MemoryFacade`` construction signature, and
-:mod:`agents.memory.facade` keeps ``MemoryFacade`` as a thin alias of
-this class for one minor version so downstream callers migrate
-incrementally.  The frozen facade is the v0.4.0 prerequisite — RFC 0028
-pins its ``DecisionRecord`` schema against this surface.
+The promotion was a **pure refactor**: ``MemoryStore`` kept the legacy
+``MemoryFacade`` construction signature, and :mod:`agents.memory.facade`
+carried a thin ``MemoryFacade`` alias of this class for one minor version
+so downstream callers migrated incrementally.  That alias was removed in
+v0.3.3 — all call sites import ``MemoryStore`` directly.  The frozen
+facade is the v0.4.0 prerequisite — RFC 0028 pins its ``DecisionRecord``
+schema against this surface.
 """
 
 from __future__ import annotations

--- a/agents/observability/metrics.py
+++ b/agents/observability/metrics.py
@@ -52,7 +52,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.2"
+_DEFAULT_SERVICE_VERSION = "0.3.3"
 _DEFAULT_EXPORT_INTERVAL_MS = 60_000
 _DEFAULT_EXPORT_TIMEOUT_MS = 10_000
 

--- a/agents/observability/tracing.py
+++ b/agents/observability/tracing.py
@@ -16,7 +16,7 @@ Environment variables (all optional; defaults match the Go side):
     PERSATRIX_AGENT_ID             sets ``service.instance.id``
     PERSATRIX_SERVICE_ROLE         sets ``service.role`` (optional free-text)
     PERSATRIX_SERVICE_VERSION      sets ``service.version``
-                                    (default: "0.3.2")
+                                    (default: "0.3.3")
 
 Baggage key naming convention
 -----------------------------
@@ -69,7 +69,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.2"
+_DEFAULT_SERVICE_VERSION = "0.3.3"
 
 # BatchSpanProcessor tuning — deterministic across environments.
 _BSP_MAX_QUEUE_SIZE = 2048

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.3.2"
+version = "0.3.3"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/agents/server.py
+++ b/agents/server.py
@@ -164,7 +164,7 @@ class AgentServer:
             scheduled_wakes_caches=self._scheduled_wakes_caches,
         )
 
-        # RFC 0008 PR 2: open MemoryFacade for opt-in non-persona task agents.
+        # RFC 0008 PR 2: open MemoryStore for opt-in non-persona task agents.
         for agent_id, agent in self.agents.items():
             if isinstance(agent, _LLMPersonaAgent):
                 continue
@@ -341,7 +341,7 @@ class AgentServer:
         for agent_id, agent in self.agents.items():
             try:
                 # Close persona-agent three-tier memory or task-agent
-                # MemoryFacade (RFC 0008 PR plan PR 2).  ``close_memory``
+                # MemoryStore (RFC 0008 PR plan PR 2).  ``close_memory``
                 # is a no-op when no facade was opened.  PR 2a follow-up
                 # L3: single call site \u2014 the persona/task distinction is
                 # only relevant for logging.

--- a/agents/session_id.py
+++ b/agents/session_id.py
@@ -4,7 +4,7 @@ A true leaf inside the :mod:`agents` package: imports only the Python
 standard library and exposes the env-var name, the legacy carve-out
 constant, and the silent reader.  Two call sites depend on it:
 
-* :class:`agents.memory.facade.MemoryFacade` — reads the env value at
+* :class:`agents.memory.facade.MemoryStore` — reads the env value at
   construction time so the task-agent / sub-agent write path inherits
   the operator-namespace tag without an explicit kwarg at every site.
 * :mod:`agents.persona_runtime.session_id` — wraps the silent reader

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/internal/executor/packaging/types.go
+++ b/internal/executor/packaging/types.go
@@ -98,7 +98,7 @@ type Metrics struct {
 // content embedded inside StepOutputs[].Content. A packaging-unaware agent
 // reading raw outputs bypasses the budget entirely. v1 packaging is therefore
 // advisory ordering — actual budget enforcement requires the agent to consume
-// StepOutputs in lieu of raw outputs (e.g. via MemoryFacade in RFC 0008 PR 2).
+// StepOutputs in lieu of raw outputs (e.g. via MemoryStore in RFC 0008 PR 2).
 type Package struct {
 	Version        int               `json:"version"`
 	PinnedSections []AdmittedSection `json:"pinned_sections"`

--- a/internal/scheduler/context_package_integration_test.go
+++ b/internal/scheduler/context_package_integration_test.go
@@ -21,7 +21,7 @@ import (
 // TestContextPackage_EndToEnd verifies that when a workflow declares a
 // context_budget_total, the scheduler builds a packaging.Package and attaches
 // it under the reserved key on every dispatch's context map. This is the
-// integration-level contract that v0.3.0 RFC 0008 PR 2 (MemoryFacade) and
+// integration-level contract that v0.3.0 RFC 0008 PR 2 (MemoryStore) and
 // downstream consumers will rely on.
 func TestContextPackage_EndToEnd_BudgetedWorkflow(t *testing.T) {
 	const yaml = `schema_version: "0.1"

--- a/internal/scheduler/context_package_pr6a_pins_test.go
+++ b/internal/scheduler/context_package_pr6a_pins_test.go
@@ -66,7 +66,7 @@ func TestAttachContextPackage_DeterministicCandidateOrder(t *testing.T) {
 // TestPackager_BuildClampsNegativeBudgetToZero pins the L9 contract:
 // `Packager.Build`'s `remaining < 0 → 0` clamp covers a negative
 // `budgetTokens` argument too. The allocator never emits negatives today,
-// but PR 2's `MemoryFacade` may compute `B_step − B_memory_reservation`
+// but PR 2's `MemoryStore` may compute `B_step − B_memory_reservation`
 // and underflow.
 func TestPackager_BuildClampsNegativeBudgetToZero(t *testing.T) {
 	p := packaging.NewPackager(nil)

--- a/tests/integration/_delegation_helpers.py
+++ b/tests/integration/_delegation_helpers.py
@@ -80,7 +80,7 @@ class MalformedSubAgent(BaseAgent):
 
 
 async def boom_delete(*_args: Any, **_kwargs: Any) -> bool:
-    """Test double for :meth:`MemoryFacade.episodic.delete_episode`
+    """Test double for :meth:`MemoryStore.episodic.delete_episode`
     that always raises — used to exercise the rollback-failure path.
 
     PR 3a R2 L3: takes ``*_args, **_kwargs`` for forward-compat with any

--- a/tests/integration/test_delegation_end_to_end.py
+++ b/tests/integration/test_delegation_end_to_end.py
@@ -10,7 +10,7 @@ Covers the round-trip:
 4. :class:`MergeEngine` admits / rejects entries per the deterministic
    6-step pipeline.
 5. :class:`FacadeBoundSpawner` persists admitted entries through the
-   parent's :class:`agents.memory.facade.MemoryFacade` and they round-
+   parent's :class:`agents.memory.facade.MemoryStore` and they round-
    trip via ``retrieve_relevant``.
 """
 
@@ -22,7 +22,7 @@ from typing import Any
 import pytest
 
 from agents.base import BaseAgent, TaskInput, TaskOutput, TaskStatus
-from agents.memory import MemoryFacade
+from agents.memory import MemoryStore
 from agents.sub_agents import (
     BudgetEnvelope,
     DelegationFailure,
@@ -45,8 +45,8 @@ from ._delegation_helpers import (
 
 
 @pytest.fixture
-async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryFacade, None]:
-    facade = MemoryFacade(
+async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryStore, None]:
+    facade = MemoryStore(
         agent_id="parent-coordinator", db_path=str(tmp_path / "parent.db"),
     )
     await facade.initialize()
@@ -61,7 +61,7 @@ async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryFacade, None]:
 
 @pytest.mark.asyncio
 async def test_dispatch_round_trip_persists_admitted_entries(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     canned = DelegationResult(
         summary="Reviewed module X",
@@ -127,7 +127,7 @@ async def test_dispatch_round_trip_persists_admitted_entries(
 
 @pytest.mark.asyncio
 async def test_trust_ceiling_downscales_persisted_importance(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     canned = DelegationResult(
         summary="overconfident result",
@@ -157,7 +157,7 @@ async def test_trust_ceiling_downscales_persisted_importance(
 
 @pytest.mark.asyncio
 async def test_max_memory_writes_cap_drops_overflow(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     entries = tuple(
         MemoryWriteEntry(tier="episodic", key=f"k{i}", content=f"c{i}")
@@ -182,7 +182,7 @@ async def test_max_memory_writes_cap_drops_overflow(
 
 @pytest.mark.asyncio
 async def test_missing_metadata_key_raises_delegation_failure(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     spawner = FacadeBoundSpawner(
         parent_agent_id="coordinator", memory_facade=parent_facade,
@@ -194,7 +194,7 @@ async def test_missing_metadata_key_raises_delegation_failure(
 
 @pytest.mark.asyncio
 async def test_failed_sub_agent_raises_delegation_failure(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     class _Failing(BaseAgent):
         def __init__(self) -> None:
@@ -215,7 +215,7 @@ async def test_failed_sub_agent_raises_delegation_failure(
 
 @pytest.mark.asyncio
 async def test_oversize_context_package_rejected_at_dispatch(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """A hostile or buggy caller cannot push an arbitrarily large
     ``context_package`` into the sub-agent's ``task.context``: the
@@ -240,7 +240,7 @@ async def test_oversize_context_package_rejected_at_dispatch(
 
 @pytest.mark.asyncio
 async def test_oversize_output_schema_rejected_at_dispatch(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """Same trust-boundary rationale as ``context_package`` — see the
     S5 finding in the PR #222 deep review.
@@ -271,7 +271,7 @@ async def test_oversize_output_schema_rejected_at_dispatch(
 
 @pytest.mark.asyncio
 async def test_output_schema_enforced_against_artifacts(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """S1: ``output_schema`` is no longer advisory.  The spawner runs
     Draft-7 validation against ``DelegationResult.artifacts`` *before*
@@ -301,7 +301,7 @@ async def test_output_schema_enforced_against_artifacts(
 
 @pytest.mark.asyncio
 async def test_output_schema_pass_persists_admitted(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """S1 happy path: artifacts that conform to ``output_schema`` flow
     through the merge engine and persist normally."""
@@ -333,7 +333,7 @@ async def test_output_schema_pass_persists_admitted(
 
 @pytest.mark.asyncio
 async def test_malformed_output_schema_rejected(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """S1 caller-bug path: a malformed ``output_schema`` (does not pass
     the Draft-7 meta-schema) surfaces as :class:`DelegationFailure` so
@@ -356,7 +356,7 @@ async def test_malformed_output_schema_rejected(
 
 @pytest.mark.asyncio
 async def test_partial_persist_failure_rolls_back_admitted(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """N5: when ``store_observation`` fails part-way through a batch,

--- a/tests/integration/test_delegation_rollback_edges.py
+++ b/tests/integration/test_delegation_rollback_edges.py
@@ -21,7 +21,7 @@ from typing import Any
 
 import pytest
 
-from agents.memory import MemoryFacade
+from agents.memory import MemoryStore
 from agents.sub_agents import (
     DelegationFailure,
     DelegationRequest,
@@ -42,8 +42,8 @@ from ._delegation_helpers import (
 
 
 @pytest.fixture
-async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryFacade, None]:
-    facade = MemoryFacade(
+async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryStore, None]:
+    facade = MemoryStore(
         agent_id="parent-coordinator", db_path=str(tmp_path / "parent.db"),
     )
     await facade.initialize()
@@ -55,7 +55,7 @@ async def parent_facade(tmp_path: Any) -> AsyncGenerator[MemoryFacade, None]:
 
 @pytest.mark.asyncio
 async def test_rollback_failure_does_not_mask_original_cause(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """N5 coverage: when ``delete_episode`` itself raises during
@@ -159,7 +159,7 @@ async def test_rollback_skipped_when_facade_lacks_episodic_accessor(
 
 @pytest.mark.asyncio
 async def test_failed_status_payload_is_truncated_in_failure_message(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """S2-mirror: when a sub-agent returns FAILED, the spawner's
     :class:`DelegationFailure` message must funnel ``output.result``
@@ -204,7 +204,7 @@ async def test_failed_status_payload_is_truncated_in_failure_message(
 
 @pytest.mark.asyncio
 async def test_failed_status_payload_control_chars_are_stripped(
-    parent_facade: MemoryFacade,
+    parent_facade: MemoryStore,
 ) -> None:
     """PR #224 review round-4 (Should #1): pin the CWE-117 control-char
     strip in ``_bounded``.

--- a/tests/integration/test_shared_pool_publish.py
+++ b/tests/integration/test_shared_pool_publish.py
@@ -3,10 +3,10 @@
 Three agents — writer A, reader B, denied C — share one
 SharedMemoryPool.  Verifies:
 
-* A publishes 3 entries via :meth:`MemoryFacade.publish_to_pool`.
-* B retrieves all 3 via :meth:`MemoryFacade.read_from_pool`.
+* A publishes 3 entries via :meth:`MemoryStore.publish_to_pool`.
+* B retrieves all 3 via :meth:`MemoryStore.read_from_pool`.
 * C is denied on both read and write paths.
-* The original isolated entry on A's MemoryFacade survives the publish
+* The original isolated entry on A's MemoryStore survives the publish
   (the publish path is *additive* — RFC 0008 §H "curated").
 """
 
@@ -17,7 +17,7 @@ from typing import Any
 
 import pytest
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 from agents.memory.shared_pool import (
     SharedMemoryPermissionError,
     SharedMemoryPool,
@@ -30,7 +30,7 @@ from agents.memory.shared_pool import (
 async def world(
     tmp_path: Any,
 ) -> AsyncGenerator[
-    tuple[MemoryFacade, MemoryFacade, MemoryFacade, SharedMemoryPool], None,
+    tuple[MemoryStore, MemoryStore, MemoryStore, SharedMemoryPool], None,
 ]:
     db = str(tmp_path / "world.db")
     cfg = SharedPoolConfig(
@@ -43,8 +43,8 @@ async def world(
     await pool.initialize()
     registry = SharedPoolRegistry({"team-knowledge": pool})
 
-    async def _facade(agent_id: str) -> MemoryFacade:
-        f = MemoryFacade(
+    async def _facade(agent_id: str) -> MemoryStore:
+        f = MemoryStore(
             agent_id=agent_id, db_path=db, shared_pools=registry,
         )
         await f.initialize()
@@ -63,7 +63,7 @@ async def world(
 
 
 async def test_publish_then_read_three_agents(
-    world: tuple[MemoryFacade, MemoryFacade, MemoryFacade, SharedMemoryPool],
+    world: tuple[MemoryStore, MemoryStore, MemoryStore, SharedMemoryPool],
 ) -> None:
     a, b, c, _pool = world
 
@@ -102,7 +102,7 @@ async def test_publish_then_read_three_agents(
 
 
 async def test_publish_does_not_consume_isolated_entry(
-    world: tuple[MemoryFacade, MemoryFacade, MemoryFacade, SharedMemoryPool],
+    world: tuple[MemoryStore, MemoryStore, MemoryStore, SharedMemoryPool],
 ) -> None:
     a, _b, _c, _pool = world
 
@@ -121,7 +121,7 @@ async def test_publish_does_not_consume_isolated_entry(
 
 
 async def test_min_confidence_filter_at_facade(
-    world: tuple[MemoryFacade, MemoryFacade, MemoryFacade, SharedMemoryPool],
+    world: tuple[MemoryStore, MemoryStore, MemoryStore, SharedMemoryPool],
 ) -> None:
     a, b, _c, _pool = world
 

--- a/tests/integration/test_summarize_on_close.py
+++ b/tests/integration/test_summarize_on_close.py
@@ -6,7 +6,7 @@ Pins the PR 4 deliverables called out in
 ``docs/rfcs/0020-pr-plan.md`` §PR 4:
 
 * Multi-turn close runs the LLM summariser through
-  :func:`MemoryFacade.compress` and writes the LLM text to the episode
+  :func:`MemoryStore.compress` and writes the LLM text to the episode
   ``summary`` column.
 * LLM failure / timeout / empty-text paths fall back to
   :data:`SUMMARY_UNAVAILABLE_TEXT` and increment the

--- a/tests/integration/test_task_agent_memory.py
+++ b/tests/integration/test_task_agent_memory.py
@@ -1,10 +1,10 @@
-"""Integration tests for the task-agent MemoryFacade wiring (RFC 0008 PR 2).
+"""Integration tests for the task-agent MemoryStore wiring (RFC 0008 PR 2).
 
 Covers the end-to-end opt-in flow described in
 ``docs/rfcs/0008-pr-plan.md`` PR 2:
 
 * When ``memory.enabled: true`` is set in the agent's config, the
-  agent-server lifecycle opens a :class:`MemoryFacade` on startup,
+  agent-server lifecycle opens a :class:`MemoryStore` on startup,
   ``BaseAgent._inject_memories`` injects retrieved entries into the
   system prompt, and the budget knob carried via the
   ``_context_package`` clamps the recall ``limit``.
@@ -27,7 +27,7 @@ from typing import Any
 import pytest
 
 from agents.base import CONTEXT_PACKAGE_KEY, BaseAgent, TaskInput, TaskOutput, TaskStatus
-from agents.memory import MemoryFacade
+from agents.memory import MemoryStore
 
 
 class _TaskAgentStub(BaseAgent):
@@ -74,7 +74,7 @@ class TestMemoryEnabledTaskAgent:
     async def test_facade_opened_on_initialize(
         self, enabled_agent: _TaskAgentStub,
     ) -> None:
-        assert isinstance(enabled_agent.memory, MemoryFacade)
+        assert isinstance(enabled_agent.memory, MemoryStore)
 
     async def test_store_then_retrieve_round_trip(
         self, enabled_agent: _TaskAgentStub,

--- a/tests/unit/python/conftest.py
+++ b/tests/unit/python/conftest.py
@@ -31,13 +31,13 @@ def _clean_registry():
 def _isolate_session_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure ``PERSATRIX_SESSION_ID`` does not leak across tests.
 
-    RFC 0031 Phase 1 makes :class:`agents.memory.facade.MemoryFacade` read
+    RFC 0031 Phase 1 makes :class:`agents.memory.MemoryStore` read
     ``PERSATRIX_SESSION_ID`` at construction so the task-agent /
     sub-agent path inherits the operator-namespace tag without an
     explicit kwarg at every write site
     (see ``agents/memory/facade.py`` ``__init__`` for the rationale).
 
-    The flip side: any test that constructs a ``MemoryFacade`` and
+    The flip side: any test that constructs a ``MemoryStore`` and
     asserts ``_session_id == "legacy"`` will silently pick up a shell-
     inherited value when the developer (or a CI job) happens to have
     ``PERSATRIX_SESSION_ID`` exported.  This autouse fixture

--- a/tests/unit/python/test_context_package_wire_shape.py
+++ b/tests/unit/python/test_context_package_wire_shape.py
@@ -3,7 +3,7 @@
 This test fulfils the PR-plan integration requirement that an agent receiving
 the orchestrator's `_context_package` JSON payload (Open Question 2 — additive,
 no proto changes) parses it without errors and that agents *without*
-packaging-awareness ignore the key. PR 2 (`MemoryFacade`) and PR 3 (delegation
+packaging-awareness ignore the key. PR 2 (`MemoryStore`) and PR 3 (delegation
 contract) rely on this wire-shape contract; without a producer/consumer
 round-trip, a future renaming of any JSON tag would only break at integration
 time.
@@ -150,7 +150,7 @@ def test_task_input_with_context_package_preserves_payload() -> None:
     )
 
     # The key is preserved verbatim — downstream packaging-aware consumers
-    # (PR 2's MemoryFacade) will read it without re-parsing.
+    # (PR 2's MemoryStore) will read it without re-parsing.
     assert task.context[CONTEXT_PACKAGE_KEY] == encoded
     redecoded = json.loads(task.context[CONTEXT_PACKAGE_KEY])
     assert redecoded["version"] == 1

--- a/tests/unit/python/test_episodic_memory_pending_filter.py
+++ b/tests/unit/python/test_episodic_memory_pending_filter.py
@@ -2,7 +2,7 @@
 Regression test for the RFC 0020 PR 5 "summary pending" recall filter.
 
 PR 5 originally placed the ``[summary pending]`` skip filter inside
-:func:`MemoryFacade.retrieve_relevant`. PR-262 deep-review finding **M1**
+:func:`MemoryStore.retrieve_relevant`. PR-262 deep-review finding **M1**
 identified that the persona prompt-assembly path
 (:mod:`agents.persona_runtime.memory_context`) calls
 ``EpisodicMemory.recall`` directly, bypassing the facade, and therefore

--- a/tests/unit/python/test_memory_boundary.py
+++ b/tests/unit/python/test_memory_boundary.py
@@ -13,8 +13,7 @@ with two halves of one guard rail (RFC 0029 PR plan PR 2):
 
 Construction *inside* ``agents/memory/`` (the ``MemoryStore`` facade, the
 shared-pool wrapper, the tier modules themselves) stays silent: the
-facade is the supported builder, and the ``MemoryFacade`` alias is the
-warning-free one-minor-version compatibility path.
+facade is the supported builder.
 """
 
 from __future__ import annotations

--- a/tests/unit/python/test_memory_decay.py
+++ b/tests/unit/python/test_memory_decay.py
@@ -11,7 +11,7 @@ Covers:
   to ``1.0`` + ``last_validated_at`` stamping.
 - :class:`agents.memory.eviction.EvictionPass` — procedural eviction
   via the new ``_evict_procedural_decay`` pass.
-- :class:`agents.memory.facade.MemoryFacade` — ``store_procedure``
+- :class:`agents.memory.facade.MemoryStore` — ``store_procedure``
   refresh-on-existing-key, ``retrieve_procedures`` stale alert, and
   decay-knob construction validation.
 - Migration v6 — applies idempotently and leaves a v0.2.x schema
@@ -41,7 +41,7 @@ from agents.memory.episodic_procedural import (
     refresh_confidence,
 )
 from agents.memory.eviction import EvictionPass
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 
 # ─── Pure-math: compute_decayed_confidence ────────────────────
 
@@ -107,9 +107,9 @@ def test_extract_procedure_key_returns_none_when_absent() -> None:
 
 
 @pytest.fixture
-async def facade() -> AsyncGenerator[MemoryFacade, None]:
+async def facade() -> AsyncGenerator[MemoryStore, None]:
     """Fresh in-memory facade per test."""
-    fac = MemoryFacade(agent_id="proc-test", db_path=":memory:")
+    fac = MemoryStore(agent_id="proc-test", db_path=":memory:")
     await fac.initialize()
     try:
         yield fac
@@ -117,7 +117,7 @@ async def facade() -> AsyncGenerator[MemoryFacade, None]:
         await fac.close()
 
 
-async def test_recall_procedures_filters_below_c_min(facade: MemoryFacade) -> None:
+async def test_recall_procedures_filters_below_c_min(facade: MemoryStore) -> None:
     """Entries whose decayed confidence < c_min are filtered before limit slice."""
     await facade.store_procedure("fresh", "still good", confidence=0.9)
     await facade.store_procedure("stale", "old habit", confidence=0.05)  # < 0.1
@@ -128,7 +128,7 @@ async def test_recall_procedures_filters_below_c_min(facade: MemoryFacade) -> No
 
 
 async def test_recall_procedures_applies_decay_at_read_time(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """The decay multiplier is applied to the stored ``c_0`` at read time."""
     await facade.store_procedure("k1", "body", confidence=0.8)
@@ -150,7 +150,7 @@ async def test_recall_procedures_applies_decay_at_read_time(
     assert results[0].base_confidence == pytest.approx(0.8)
 
 
-async def test_recall_procedures_query_filter(facade: MemoryFacade) -> None:
+async def test_recall_procedures_query_filter(facade: MemoryStore) -> None:
     await facade.store_procedure("a", "ship widget alpha", confidence=0.9)
     await facade.store_procedure("b", "ship gadget beta", confidence=0.9)
     results = await facade.retrieve_procedures(query="widget")
@@ -162,7 +162,7 @@ async def test_recall_procedures_query_filter(facade: MemoryFacade) -> None:
 
 
 async def test_refresh_confidence_resets_to_one_and_stamps_now(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     await facade.store_procedure("k", "body", confidence=0.4)
     db = facade.episodic._ensure_db()  # noqa: SLF001
@@ -190,14 +190,14 @@ async def test_refresh_confidence_resets_to_one_and_stamps_now(
 
 
 async def test_refresh_confidence_returns_false_when_no_match(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     db = facade.episodic._ensure_db()  # noqa: SLF001
     assert await refresh_confidence(db, "proc-test", "nonexistent") is False
 
 
 async def test_refresh_confidence_rejects_empty_key(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     db = facade.episodic._ensure_db()  # noqa: SLF001
     with pytest.raises(ValueError, match="key"):
@@ -208,7 +208,7 @@ async def test_refresh_confidence_rejects_empty_key(
 
 
 async def test_store_procedure_refreshes_existing_key(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """Storing under an existing key updates confidence/last_validated, no duplicate row."""
     await facade.store_procedure("dup", "v1", confidence=0.5)
@@ -244,7 +244,7 @@ async def test_store_procedure_refreshes_existing_key(
 
 
 async def test_retrieve_procedures_emits_stale_alert(
-    facade: MemoryFacade,
+    facade: MemoryStore,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Entries in ``[c_min, stale_threshold)`` log ``stale_memory_injection``."""
@@ -267,7 +267,7 @@ async def test_retrieve_procedures_emits_stale_alert(
 
 
 async def test_retrieve_procedures_no_alert_above_threshold(
-    facade: MemoryFacade,
+    facade: MemoryStore,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Entries with decayed >= stale_threshold do not log the alert."""
@@ -285,7 +285,7 @@ async def test_retrieve_procedures_no_alert_above_threshold(
 
 async def test_eviction_pass_evicts_below_c_min() -> None:
     """The procedural pass deletes rows whose decayed confidence < c_min."""
-    fac = MemoryFacade(agent_id="evict-proc", db_path=":memory:")
+    fac = MemoryStore(agent_id="evict-proc", db_path=":memory:")
     await fac.initialize()
     try:
         await fac.store_procedure("keep", "fresh", confidence=0.9)
@@ -325,18 +325,18 @@ async def test_eviction_pass_evicts_below_c_min() -> None:
 
 def test_facade_rejects_negative_lambda() -> None:
     with pytest.raises(ValueError, match="lambda_per_day"):
-        MemoryFacade(agent_id="x", db_path=":memory:", lambda_per_day=-0.1)
+        MemoryStore(agent_id="x", db_path=":memory:", lambda_per_day=-0.1)
 
 
 def test_facade_rejects_c_min_out_of_range() -> None:
     with pytest.raises(ValueError, match="c_min"):
-        MemoryFacade(agent_id="x", db_path=":memory:", c_min=1.5)
+        MemoryStore(agent_id="x", db_path=":memory:", c_min=1.5)
 
 
 def test_facade_rejects_inverted_threshold_pair() -> None:
     """``stale_threshold < c_min`` would silently disable the alert window."""
     with pytest.raises(ValueError, match="stale_confidence_alert_threshold"):
-        MemoryFacade(
+        MemoryStore(
             agent_id="x", db_path=":memory:",
             c_min=0.4, stale_confidence_alert_threshold=0.2,
         )
@@ -344,7 +344,7 @@ def test_facade_rejects_inverted_threshold_pair() -> None:
 
 def test_facade_accepts_default_decay_knobs() -> None:
     """Default constructor uses ``agents.memory.decay`` constants."""
-    fac = MemoryFacade(agent_id="x", db_path=":memory:")
+    fac = MemoryStore(agent_id="x", db_path=":memory:")
     assert fac._lambda_per_day == DEFAULT_LAMBDA_PER_DAY  # noqa: SLF001
     assert fac._c_min == DEFAULT_C_MIN  # noqa: SLF001
     assert fac._stale_alert_threshold == DEFAULT_STALE_CONFIDENCE_ALERT_THRESHOLD  # noqa: SLF001

--- a/tests/unit/python/test_memory_decay_review_pins.py
+++ b/tests/unit/python/test_memory_decay_review_pins.py
@@ -42,13 +42,13 @@ from agents.memory.episodic_procedural import (
     refresh_confidence,
 )
 from agents.memory.eviction import EvictionPass
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 
 
 @pytest.fixture
-async def facade() -> AsyncGenerator[MemoryFacade, None]:
+async def facade() -> AsyncGenerator[MemoryStore, None]:
     """Fresh in-memory facade per test (mirrors the ``test_memory_decay`` fixture)."""
-    fac = MemoryFacade(agent_id="proc-test", db_path=":memory:")
+    fac = MemoryStore(agent_id="proc-test", db_path=":memory:")
     await fac.initialize()
     try:
         yield fac
@@ -60,7 +60,7 @@ async def facade() -> AsyncGenerator[MemoryFacade, None]:
 
 
 async def test_store_procedure_refresh_silently_discards_confidence_arg(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """PR #225 review S4 regression pin.
 
@@ -110,7 +110,7 @@ def test_escape_like_escapes_backslash_before_meta_chars() -> None:
 
 
 async def test_refresh_confidence_does_not_widen_match_on_percent_in_key(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """A key containing ``%`` must not refresh sibling rows.
 
@@ -179,7 +179,7 @@ async def test_refresh_confidence_does_not_widen_match_on_percent_in_key(
 
 
 async def test_recall_procedures_does_not_widen_match_on_percent_in_query(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """A ``query`` containing ``%`` must match literally, not as a wildcard.
 
@@ -212,7 +212,7 @@ async def test_eviction_uses_legacy_base_confidence_shim() -> None:
     decay the row from a fresh ``1.0`` baseline and a row that
     recall correctly drops would silently survive eviction.
     """
-    fac = MemoryFacade(agent_id="legacy-evict", db_path=":memory:")
+    fac = MemoryStore(agent_id="legacy-evict", db_path=":memory:")
     await fac.initialize()
     try:
         db = fac.episodic._ensure_db()  # noqa: SLF001
@@ -252,7 +252,7 @@ async def test_eviction_uses_legacy_base_confidence_shim() -> None:
 
 
 async def test_recall_procedures_sql_cutoff_filters_stale_rows_and_appears_in_sql(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """Pin the new SQL-side ``t_max`` pre-filter clause introduced in PR 6b.
 
@@ -338,9 +338,9 @@ async def test_recall_procedures_sql_cutoff_filters_stale_rows_and_appears_in_sq
 
 
 async def test_retrieve_procedures_honours_now_override(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
-    """Pin the new ``now`` parameter on ``MemoryFacade.retrieve_procedures``.
+    """Pin the new ``now`` parameter on ``MemoryStore.retrieve_procedures``.
 
     PR 6b deep-review Should-Fix #5: the ``now: float | None``
     parameter (PR 5 R1 L4) is plumbed through the facade so tests can

--- a/tests/unit/python/test_memory_eviction.py
+++ b/tests/unit/python/test_memory_eviction.py
@@ -8,7 +8,7 @@ Covers:
 - Size-cap eviction: lowest-scoring excess entries are deleted; deterministic
   tie-break by ``created_at ASC``.
 - Eviction loop: failures log a warning and the loop survives.
-- ``MemoryFacade`` lifecycle: the eviction task is started by
+- ``MemoryStore`` lifecycle: the eviction task is started by
   ``initialize()`` and cancelled by ``close()``.
 """
 
@@ -27,7 +27,7 @@ from agents.memory.eviction import (
     EvictionStats,
     eviction_loop,
 )
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 
 # ─── Fixtures ─────────────────────────────────────────────────
 
@@ -306,11 +306,11 @@ async def test_eviction_loop_startup_pass_before_full_cadence(
     )
 
 
-# ─── MemoryFacade integration ─────────────────────────────────
+# ─── MemoryStore integration ─────────────────────────────────
 
 
 async def test_facade_starts_and_cancels_eviction_task() -> None:
-    fac = MemoryFacade(
+    fac = MemoryStore(
         agent_id="lifecycle",
         db_path=":memory:",
         eviction_cadence_seconds=3600,  # never fires during the test
@@ -327,7 +327,7 @@ async def test_facade_starts_and_cancels_eviction_task() -> None:
 
 async def test_facade_scope_filter_finds_non_facade_writer() -> None:
     """PR 2a follow-up M1: column-level ``scope`` is honoured by recall."""
-    fac = MemoryFacade(agent_id="scope-test", db_path=":memory:")
+    fac = MemoryStore(agent_id="scope-test", db_path=":memory:")
     await fac.initialize()
     try:
         # Bypass ``store_observation`` and write the scope only via the
@@ -371,27 +371,27 @@ def test_eviction_stats_procedural_evicted_is_required() -> None:
         )
 
 
-# ─── MemoryFacade __init__ validation (PR #221 deep-review M1) ────────
+# ─── MemoryStore __init__ validation (PR #221 deep-review M1) ────────
 
 
 def test_facade_rejects_invalid_episodic_cap() -> None:
-    """MemoryFacade.__init__ must reject episodic_cap < 1 immediately."""
+    """MemoryStore.__init__ must reject episodic_cap < 1 immediately."""
     with pytest.raises(ValueError, match="episodic_cap"):
-        MemoryFacade(agent_id="a", db_path=":memory:", episodic_cap=0)
+        MemoryStore(agent_id="a", db_path=":memory:", episodic_cap=0)
 
 
 def test_facade_rejects_invalid_ttl() -> None:
-    """MemoryFacade.__init__ must reject ttl_low_importance_days < 1 immediately."""
+    """MemoryStore.__init__ must reject ttl_low_importance_days < 1 immediately."""
     with pytest.raises(ValueError, match="ttl_low_importance_days"):
-        MemoryFacade(
+        MemoryStore(
             agent_id="a", db_path=":memory:", ttl_low_importance_days=0,
         )
 
 
 def test_facade_rejects_non_positive_cadence() -> None:
-    """MemoryFacade.__init__ must reject eviction_cadence_seconds <= 0 immediately."""
+    """MemoryStore.__init__ must reject eviction_cadence_seconds <= 0 immediately."""
     with pytest.raises(ValueError, match="eviction_cadence_seconds"):
-        MemoryFacade(
+        MemoryStore(
             agent_id="a", db_path=":memory:", eviction_cadence_seconds=0,
         )
 
@@ -403,7 +403,7 @@ async def test_ttl_skips_procedure_rows(episodic: EpisodicMemory) -> None:
     """Low-confidence procedure rows are NOT TTL-evicted.
 
     RFC 0008 §G separates episodic eviction from procedural confidence
-    decay (the latter lands in PR 5).  ``MemoryFacade.store_procedure``
+    decay (the latter lands in PR 5).  ``MemoryStore.store_procedure``
     persists procedures as episode rows tagged ``procedure:{key}`` with
     ``confidence`` mapped onto ``importance``; without the procedure
     guard in :mod:`agents.memory.eviction`, a stale low-confidence
@@ -412,7 +412,7 @@ async def test_ttl_skips_procedure_rows(episodic: EpisodicMemory) -> None:
     db = episodic._ensure_db()  # noqa: SLF001
     old_ts = time.time() - 31 * 86400.0
     # An old, low-importance procedure (would otherwise satisfy the TTL
-    # predicate).  Tag format mirrors ``MemoryFacade.store_procedure``.
+    # predicate).  Tag format mirrors ``MemoryStore.store_procedure``.
     await db.execute(
         "INSERT INTO episodes (id, agent_id, summary, importance, "
         "tags_json, created_at, compression_level) "

--- a/tests/unit/python/test_memory_facade.py
+++ b/tests/unit/python/test_memory_facade.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``agents.memory.facade.MemoryFacade`` (RFC 0008 PR plan PR 2).
+"""Unit tests for ``agents.memory.facade.MemoryStore`` (RFC 0008 PR plan PR 2).
 
 Covers the pinned API surface that downstream RFCs rely on:
 
@@ -22,15 +22,15 @@ from agents.memory.facade import (
     CompressedView,
     MemoryDisabledError,
     MemoryEntry,
-    MemoryFacade,
+    MemoryStore,
     budget_to_limit,
 )
 
 
 @pytest.fixture
-async def facade() -> AsyncGenerator[MemoryFacade, None]:
-    """An initialised in-memory ``MemoryFacade`` for a synthetic agent."""
-    fac = MemoryFacade(agent_id="facade-test", db_path=":memory:")
+async def facade() -> AsyncGenerator[MemoryStore, None]:
+    """An initialised in-memory ``MemoryStore`` for a synthetic agent."""
+    fac = MemoryStore(agent_id="facade-test", db_path=":memory:")
     await fac.initialize()
     try:
         yield fac
@@ -42,7 +42,7 @@ async def facade() -> AsyncGenerator[MemoryFacade, None]:
 
 
 async def test_initialize_is_idempotent() -> None:
-    fac = MemoryFacade(agent_id="idem", db_path=":memory:")
+    fac = MemoryStore(agent_id="idem", db_path=":memory:")
     await fac.initialize()
     # A second call must not raise; it logs a warning and no-ops.
     await fac.initialize()
@@ -50,13 +50,13 @@ async def test_initialize_is_idempotent() -> None:
 
 
 async def test_close_before_initialize_is_noop() -> None:
-    fac = MemoryFacade(agent_id="noop", db_path=":memory:")
+    fac = MemoryStore(agent_id="noop", db_path=":memory:")
     # Calling close() without initialize() must be safe.
     await fac.close()
 
 
 async def test_use_before_initialize_raises() -> None:
-    fac = MemoryFacade(agent_id="cold", db_path=":memory:")
+    fac = MemoryStore(agent_id="cold", db_path=":memory:")
     # PR 2a follow-up L1/L2: facade raises the memory-specific error type
     # (still a RuntimeError subclass for backward compat).
     with pytest.raises(MemoryDisabledError, match="not initialised"):
@@ -64,7 +64,7 @@ async def test_use_before_initialize_raises() -> None:
 
 
 async def test_close_then_reuse_raises() -> None:
-    fac = MemoryFacade(agent_id="reuse", db_path=":memory:")
+    fac = MemoryStore(agent_id="reuse", db_path=":memory:")
     await fac.initialize()
     await fac.close()
     with pytest.raises(MemoryDisabledError, match="not initialised"):
@@ -73,7 +73,7 @@ async def test_close_then_reuse_raises() -> None:
 
 async def test_episodic_property_raises_memory_disabled() -> None:
     """L1: ``episodic`` property uses the same error contract as writes."""
-    fac = MemoryFacade(agent_id="ep", db_path=":memory:")
+    fac = MemoryStore(agent_id="ep", db_path=":memory:")
     with pytest.raises(MemoryDisabledError, match="not initialised"):
         _ = fac.episodic
 
@@ -81,7 +81,7 @@ async def test_episodic_property_raises_memory_disabled() -> None:
 # ─── store_observation + retrieve_relevant ───────────────────
 
 
-async def test_store_observation_returns_id(facade: MemoryFacade) -> None:
+async def test_store_observation_returns_id(facade: MemoryStore) -> None:
     entry_id = await facade.store_observation(
         "the user prefers tabs over spaces",
         importance=0.8,
@@ -91,17 +91,17 @@ async def test_store_observation_returns_id(facade: MemoryFacade) -> None:
     assert entry_id  # non-empty
 
 
-async def test_store_observation_rejects_empty_content(facade: MemoryFacade) -> None:
+async def test_store_observation_rejects_empty_content(facade: MemoryStore) -> None:
     with pytest.raises(ValueError, match="must not be empty"):
         await facade.store_observation("   ")
 
 
-async def test_store_observation_rejects_non_positive_ttl(facade: MemoryFacade) -> None:
+async def test_store_observation_rejects_non_positive_ttl(facade: MemoryStore) -> None:
     with pytest.raises(ValueError, match="ttl_seconds"):
         await facade.store_observation("hello", ttl_seconds=0)
 
 
-async def test_retrieve_relevant_finds_stored_observation(facade: MemoryFacade) -> None:
+async def test_retrieve_relevant_finds_stored_observation(facade: MemoryStore) -> None:
     await facade.store_observation(
         "the user uses Python type hints in 3.12 syntax",
         importance=0.9,
@@ -112,7 +112,7 @@ async def test_retrieve_relevant_finds_stored_observation(facade: MemoryFacade) 
     assert any("type hints" in entry.content for entry in results)
 
 
-async def test_retrieve_relevant_tags_and_semantics(facade: MemoryFacade) -> None:
+async def test_retrieve_relevant_tags_and_semantics(facade: MemoryStore) -> None:
     """RFC 0011 PR plan PR 5 contract: tags filter is AND, not OR."""
     await facade.store_observation(
         "alpha entry",
@@ -146,7 +146,7 @@ async def test_retrieve_relevant_tags_and_semantics(facade: MemoryFacade) -> Non
     )
 
 
-async def test_retrieve_relevant_scope_filter(facade: MemoryFacade) -> None:
+async def test_retrieve_relevant_scope_filter(facade: MemoryStore) -> None:
     await facade.store_observation(
         "observation in slack-dev",
         importance=0.9,
@@ -165,13 +165,13 @@ async def test_retrieve_relevant_scope_filter(facade: MemoryFacade) -> None:
     assert "observation in slack-general" not in contents
 
 
-async def test_retrieve_relevant_min_score_validation(facade: MemoryFacade) -> None:
+async def test_retrieve_relevant_min_score_validation(facade: MemoryStore) -> None:
     with pytest.raises(ValueError, match="min_score"):
         await facade.retrieve_relevant("q", min_score=1.5)
 
 
 async def test_retrieve_relevant_drops_pending_summary_rows(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """RFC 0020 PR 5 — defense-in-depth: ``[summary pending]`` rows are hidden.
 
@@ -235,7 +235,7 @@ async def test_retrieve_relevant_drops_pending_summary_rows(
 
 
 async def test_retrieve_relevant_returns_memory_entry_shape(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     await facade.store_observation(
         "shape-check entry",
@@ -257,14 +257,14 @@ async def test_retrieve_relevant_returns_memory_entry_shape(
 # ─── store_procedure ─────────────────────────────────────────
 
 
-async def test_store_procedure_validates_inputs(facade: MemoryFacade) -> None:
+async def test_store_procedure_validates_inputs(facade: MemoryStore) -> None:
     with pytest.raises(ValueError, match="key"):
         await facade.store_procedure("", "body", confidence=0.9)
     with pytest.raises(ValueError, match="confidence"):
         await facade.store_procedure("k", "body", confidence=1.5)
 
 
-async def test_store_procedure_round_trip(facade: MemoryFacade) -> None:
+async def test_store_procedure_round_trip(facade: MemoryStore) -> None:
     await facade.store_procedure(
         "deploy-checklist",
         "Run tests, then bump version, then tag.",
@@ -291,7 +291,7 @@ def _entry(content: str, importance: float) -> MemoryEntry:
 
 
 def test_compress_under_budget_admits_all() -> None:
-    fac = MemoryFacade(agent_id="c", db_path=":memory:")
+    fac = MemoryStore(agent_id="c", db_path=":memory:")
     entries = [_entry("short one", 0.9), _entry("short two", 0.5)]
     view = fac.compress(entries, target_tokens=1000)
     assert isinstance(view, CompressedView)
@@ -302,7 +302,7 @@ def test_compress_under_budget_admits_all() -> None:
 
 
 def test_compress_drops_lowest_importance_when_over_budget() -> None:
-    fac = MemoryFacade(agent_id="c", db_path=":memory:")
+    fac = MemoryStore(agent_id="c", db_path=":memory:")
     # Each ~25 chars → ~6 tokens via the chars/4 estimator.
     high = _entry("x" * 100, importance=0.9)  # ~25 tokens
     low = _entry("y" * 100, importance=0.1)   # ~25 tokens
@@ -316,7 +316,7 @@ def test_compress_drops_lowest_importance_when_over_budget() -> None:
 
 
 def test_compress_zero_budget_drops_everything() -> None:
-    fac = MemoryFacade(agent_id="c", db_path=":memory:")
+    fac = MemoryStore(agent_id="c", db_path=":memory:")
     view = fac.compress([_entry("anything", 0.9)], target_tokens=0)
     assert view.summary == ""
     assert view.entries_dropped == 1
@@ -324,13 +324,13 @@ def test_compress_zero_budget_drops_everything() -> None:
 
 
 def test_compress_negative_budget_raises() -> None:
-    fac = MemoryFacade(agent_id="c", db_path=":memory:")
+    fac = MemoryStore(agent_id="c", db_path=":memory:")
     with pytest.raises(ValueError, match="target_tokens"):
         fac.compress([], target_tokens=-1)
 
 
 def test_compress_idempotent_on_already_fitting_view() -> None:
-    fac = MemoryFacade(agent_id="c", db_path=":memory:")
+    fac = MemoryStore(agent_id="c", db_path=":memory:")
     entries = [_entry("alpha", 0.9), _entry("beta", 0.5)]
     first = fac.compress(entries, target_tokens=100)
     # Re-compressing the admitted entries (synthesised from the summary)
@@ -343,7 +343,7 @@ def test_compress_idempotent_on_already_fitting_view() -> None:
 # ─── list_candidates (Phase 2 stub) ──────────────────────────
 
 
-async def test_list_candidates_returns_empty_in_phase_2(facade: MemoryFacade) -> None:
+async def test_list_candidates_returns_empty_in_phase_2(facade: MemoryStore) -> None:
     candidates = await facade.list_candidates({"step_id": "anything"})
     assert candidates == []
 

--- a/tests/unit/python/test_memory_facade_agent_wiring.py
+++ b/tests/unit/python/test_memory_facade_agent_wiring.py
@@ -1,7 +1,7 @@
-"""Unit tests for BaseAgent ↔ MemoryFacade wiring (RFC 0008 PR plan PR 2).
+"""Unit tests for BaseAgent ↔ MemoryStore wiring (RFC 0008 PR plan PR 2).
 
 Verifies that:
-- ``BaseAgent.initialize_memory`` creates a ``MemoryFacade`` only when
+- ``BaseAgent.initialize_memory`` creates a ``MemoryStore`` only when
   ``memory.enabled=true`` (deny-by-default).
 - ``BaseAgent.close_memory`` releases the facade idempotently.
 - ``_inject_memories`` augments the system prompt when relevant entries exist

--- a/tests/unit/python/test_memory_store.py
+++ b/tests/unit/python/test_memory_store.py
@@ -1,13 +1,14 @@
 """Unit tests for ``agents.memory.store.MemoryStore`` (RFC 0029 Phase 1).
 
-Phase 1 promotes today's ``MemoryFacade`` to the typed ``MemoryStore``
-facade.  The promotion is a pure refactor — personal-tier behaviour is
-identical and the existing ``test_memory_facade*.py`` suites pin the API
-surface through the ``MemoryFacade`` alias.  This file covers the new
-surface Phase 1 adds:
+Phase 1 promoted the RFC 0008 ``MemoryFacade`` to the typed
+``MemoryStore`` facade.  The promotion was a pure refactor — personal-tier
+behaviour is identical and the ``test_memory_facade*.py`` suites pin the
+API surface.  The one-minor-version ``MemoryFacade`` compatibility alias
+was removed in v0.3.3; every suite imports ``MemoryStore`` directly.  This
+file covers the new surface Phase 1 added:
 
-- ``MemoryStore`` is the canonical class; ``MemoryFacade`` is a thin
-  alias of it (same class object) for one minor version.
+- ``MemoryStore`` is the canonical class, exported from both
+  :mod:`agents.memory` and :mod:`agents.memory.store`.
 - Personal-tier calls (``store_observation`` → ``retrieve_relevant``,
   ``compress``) behave identically on ``MemoryStore``.
 - Society-tier methods raise the ``SocietyBackendUnavailable`` hierarchy:
@@ -48,18 +49,7 @@ async def store() -> AsyncGenerator[MemoryStore, None]:
         await st.close()
 
 
-# ─── MemoryFacade alias identity ──────────────────────────────
-
-
-def test_memory_facade_is_an_alias_of_memory_store() -> None:
-    """RFC 0029 Phase 1: ``MemoryFacade`` is a thin alias of ``MemoryStore``.
-
-    Same class object — every existing ``MemoryFacade`` caller keeps
-    working unchanged until the PR 3 call-site sweep migrates them.
-    """
-    from agents.memory.facade import MemoryFacade
-
-    assert MemoryFacade is MemoryStore
+# ─── MemoryStore package export ───────────────────────────────
 
 
 def test_memory_store_exported_from_package() -> None:

--- a/tests/unit/python/test_procedural_key_validation.py
+++ b/tests/unit/python/test_procedural_key_validation.py
@@ -1,10 +1,10 @@
 """PR 5 R2 M1 procedural-key validation pins (RFC 0008 PR 6b).
 
-The :meth:`MemoryFacade.store_procedure` boundary rejects keys whose
+The :meth:`MemoryStore.store_procedure` boundary rejects keys whose
 characters fall outside ``^[A-Za-z0-9._-]+$`` so a future SQL or
 log-pipeline change cannot be blindsided by an exotic Unicode key.
 
-(Note: :meth:`MemoryFacade.retrieve_procedures` takes a free-text
+(Note: :meth:`MemoryStore.retrieve_procedures` takes a free-text
 ``query``, not a key — that path is escaped for ``LIKE`` semantics by
 :func:`agents.memory.episodic_procedural._escape_like` and is not
 covered by the regex validator.  PR 6b deep review Should-Fix #2.)
@@ -23,12 +23,12 @@ from collections.abc import AsyncGenerator
 
 import pytest
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 
 
 @pytest.fixture
-async def facade() -> AsyncGenerator[MemoryFacade, None]:
-    fac = MemoryFacade(agent_id="proc-key-test", db_path=":memory:")
+async def facade() -> AsyncGenerator[MemoryStore, None]:
+    fac = MemoryStore(agent_id="proc-key-test", db_path=":memory:")
     await fac.initialize()
     try:
         yield fac
@@ -48,7 +48,7 @@ async def facade() -> AsyncGenerator[MemoryFacade, None]:
     ],
 )
 async def test_store_procedure_rejects_invalid_keys(
-    facade: MemoryFacade, bad_key: str,
+    facade: MemoryStore, bad_key: str,
 ) -> None:
     """Every invalid-shape key must surface as ``ValueError`` at the
     facade boundary (PR 5 R2 M1 — breaking change vs v0.2.x)."""
@@ -67,7 +67,7 @@ async def test_store_procedure_rejects_invalid_keys(
     ],
 )
 async def test_store_procedure_accepts_canonical_keys(
-    facade: MemoryFacade, good_key: str,
+    facade: MemoryStore, good_key: str,
 ) -> None:
     """The accept-set covers the canonical alphabet plus boundary lengths."""
     await facade.store_procedure(good_key, "body", confidence=0.9)
@@ -79,7 +79,7 @@ async def test_store_procedure_accepts_canonical_keys(
 
 
 async def test_store_procedure_refresh_path_revalidates_key(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """A re-store of an existing key still validates the key on the
     refresh path — a regression that bypassed the regex on the
@@ -93,7 +93,7 @@ async def test_store_procedure_refresh_path_revalidates_key(
 
 
 async def test_store_procedure_idempotent_re_store_for_canonical_key(
-    facade: MemoryFacade,
+    facade: MemoryStore,
 ) -> None:
     """Re-storing a canonical key hits the refresh path without
     raising.  Pins that key validation does not break the documented

--- a/tests/unit/python/test_rfc0029_callsite_refactor.py
+++ b/tests/unit/python/test_rfc0029_callsite_refactor.py
@@ -226,9 +226,12 @@ def test_memoryfacade_alias_is_removed_from_package_and_module() -> None:
     assert "MemoryFacade" not in facade_mod.__all__
 
     # The user-facing import must fail cleanly — not resolve via a stray
-    # submodule or a module ``__getattr__`` shim.
+    # submodule or a module ``__getattr__`` shim.  ``MemoryFacade`` is
+    # intentionally gone, so mypy's ``attr-defined`` error on this line is
+    # expected and suppressed; the runtime ``except``/``else`` below is the
+    # actual assertion.
     try:
-        from agents.memory import MemoryFacade  # noqa: F401
+        from agents.memory import MemoryFacade  # type: ignore[attr-defined]  # noqa: F401
     except ImportError:
         pass
     else:  # pragma: no cover — regression tripwire

--- a/tests/unit/python/test_rfc0029_callsite_refactor.py
+++ b/tests/unit/python/test_rfc0029_callsite_refactor.py
@@ -13,7 +13,7 @@ PR 3 routes the persona-runtime / sub-agent memory call sites — and the
   builds them through the facade, closing the deprecation window.
 - No ``MemoryFacade`` reference survives in the migrated call sites
   (``persona_runtime/``, ``sub_agents/``, ``persona.py``) — the alias
-  lives on only as the documented one-minor-version compat shim.
+  was a documented one-minor-version compat shim, removed in v0.3.3.
 - ``tests/perf/personal_tier_latency.py`` ships and *runs* (the baseline
   capture + enforcing gate are RFC 0029 Phase 1 PR 5).
 """
@@ -174,8 +174,9 @@ def _agents_dir() -> Path:
 
 def test_no_memoryfacade_reference_in_migrated_call_sites() -> None:
     """RFC 0029 Phase 1 PR 3: no ``MemoryFacade`` reference survives in
-    ``persona_runtime/``, ``sub_agents/`` or ``persona.py`` — the alias
-    lives on only as the documented compat shim in ``agents/memory/``.
+    ``persona_runtime/``, ``sub_agents/`` or ``persona.py``. The alias was
+    a documented compat shim in ``agents/memory/``, removed in v0.3.3 — so
+    this guard now also pins that the symbol stays gone.
     """
     agents_dir = _agents_dir()
     targets: list[Path] = [

--- a/tests/unit/python/test_rfc0029_callsite_refactor.py
+++ b/tests/unit/python/test_rfc0029_callsite_refactor.py
@@ -175,8 +175,9 @@ def _agents_dir() -> Path:
 def test_no_memoryfacade_reference_in_migrated_call_sites() -> None:
     """RFC 0029 Phase 1 PR 3: no ``MemoryFacade`` reference survives in
     ``persona_runtime/``, ``sub_agents/`` or ``persona.py``. The alias was
-    a documented compat shim in ``agents/memory/``, removed in v0.3.3 — so
-    this guard now also pins that the symbol stays gone.
+    a documented compat shim in ``agents/memory/``, removed in v0.3.3;
+    that the symbol itself stays gone is pinned separately by
+    ``test_memoryfacade_alias_is_removed_from_package_and_module``.
     """
     agents_dir = _agents_dir()
     targets: list[Path] = [
@@ -203,6 +204,38 @@ def test_summarize_close_routes_compress_through_memory_store() -> None:
 
     assert summarize_close.MemoryStore is MemoryStore
     assert not hasattr(summarize_close, "MemoryFacade")
+
+
+def test_memoryfacade_alias_is_removed_from_package_and_module() -> None:
+    """v0.3.3: the ``MemoryFacade`` compat alias is gone for good.
+
+    Replaces the deleted ``test_memory_facade_is_an_alias_of_memory_store``
+    identity pin (``test_memory_store.py``).  The v0.3.2 Upgrade Notes
+    committed to removing the alias "in v0.3.3"; this pins that the symbol
+    stays gone from both the ``agents.memory`` package facade and the
+    ``agents.memory.facade`` module that defined it, so a re-introduced
+    ``MemoryFacade = MemoryStore`` trips here rather than silently
+    re-opening the deprecation window.
+    """
+    import agents.memory as memory_pkg
+    import agents.memory.facade as facade_mod
+
+    assert not hasattr(memory_pkg, "MemoryFacade")
+    assert "MemoryFacade" not in memory_pkg.__all__
+    assert not hasattr(facade_mod, "MemoryFacade")
+    assert "MemoryFacade" not in facade_mod.__all__
+
+    # The user-facing import must fail cleanly — not resolve via a stray
+    # submodule or a module ``__getattr__`` shim.
+    try:
+        from agents.memory import MemoryFacade  # noqa: F401
+    except ImportError:
+        pass
+    else:  # pragma: no cover — regression tripwire
+        raise AssertionError(
+            "agents.memory.MemoryFacade is importable again; the v0.3.3 "
+            "alias removal regressed",
+        )
 
 
 # ─── perf harness ships and runs (gate enforcement is PR 5) ───

--- a/tests/unit/python/test_scope_recall.py
+++ b/tests/unit/python/test_scope_recall.py
@@ -1,7 +1,7 @@
 """Unit tests for ``agents.memory.scope_recall.recall_with_scope_filter``.
 
 The helper is the single implementation of recall + Python-side scope/tags
-filtering.  Both :class:`agents.memory.facade.MemoryFacade.retrieve_relevant`
+filtering.  Both :class:`agents.memory.MemoryStore.retrieve_relevant`
 and the persona-runtime channel-history tier
 (:meth:`agents.persona_runtime.memory_context._MemoryContextMixin._inject_memory_context`)
 delegate here, so the contract is pinned in one place rather than forked
@@ -156,7 +156,7 @@ async def test_recall_with_scope_filter_column_wins_over_context(
     """When the column scope is set, the context fallback is ignored.
 
     Pins the precedence rule from
-    :meth:`MemoryFacade.retrieve_relevant`: ``column`` is authoritative;
+    :meth:`MemoryStore.retrieve_relevant`: ``column`` is authoritative;
     ``context["scope"]`` is only a fallback for legacy NULL-column rows.
     """
     # Column says "planning"; context says "other" — the column wins.

--- a/tests/unit/python/test_session_id_env_isolation.py
+++ b/tests/unit/python/test_session_id_env_isolation.py
@@ -2,9 +2,9 @@
 Regression test for the autouse ``_isolate_session_env`` fixture
 (see :file:`conftest.py`).
 
-RFC 0031 Phase 1 makes :class:`agents.memory.facade.MemoryFacade` read
+RFC 0031 Phase 1 makes :class:`agents.memory.facade.MemoryStore` read
 ``PERSATRIX_SESSION_ID`` at construction.  Before this autouse fixture
-existed, any test that constructed a ``MemoryFacade`` and assumed
+existed, any test that constructed a ``MemoryStore`` and assumed
 ``_session_id == "legacy"`` would silently pick up a shell-inherited
 value if the developer happened to have ``PERSATRIX_SESSION_ID``
 exported (or if CI ever exported it globally for any reason).
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import pytest
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 
 
 def test_autouse_fixture_removes_env_var_before_test() -> None:
@@ -51,10 +51,10 @@ async def test_facade_default_is_legacy_under_autouse_fixture(
     # PR #337 review L6: use the public ``session_id`` property
     # rather than reaching for ``_session_id`` so the test pins the
     # public contract.
-    fac = MemoryFacade(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
+    fac = MemoryStore(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
     try:
         assert fac.session_id == "legacy", (
-            "MemoryFacade construction-time default must be 'legacy' when "
+            "MemoryStore construction-time default must be 'legacy' when "
             "PERSATRIX_SESSION_ID is unset; the autouse "
             "_isolate_session_env fixture (conftest.py) is responsible "
             f"for that pre-condition. Got: {fac.session_id!r}"
@@ -85,14 +85,14 @@ class TestEnvLeakIsBlocked:
         # writes with the prior test's polluted value.  PR #337 L6:
         # use the public ``session_id`` property.
         assert "PERSATRIX_SESSION_ID" not in os.environ
-        fac = MemoryFacade(
+        fac = MemoryStore(
             agent_id="x", db_path=str(tmp_path / "m.db"),
         )
         assert fac.session_id == "legacy"
 
 
 class TestSessionIdPropertyContract:
-    """PR #337 review L6 — :attr:`MemoryFacade.session_id` is the
+    """PR #337 review L6 — :attr:`MemoryStore.session_id` is the
     public read-only contract for the construction-time env snapshot.
     Tests that previously poked ``_session_id`` directly with
     ``noqa: SLF001`` now use this property; pin the contract here so
@@ -103,11 +103,11 @@ class TestSessionIdPropertyContract:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         monkeypatch.setenv("PERSATRIX_SESSION_ID", "run-x")
-        fac = MemoryFacade(agent_id="x", db_path=str(tmp_path / "m.db"))
+        fac = MemoryStore(agent_id="x", db_path=str(tmp_path / "m.db"))
         assert fac.session_id == "run-x"
 
     def test_property_is_read_only(self, tmp_path: Path) -> None:
-        fac = MemoryFacade(agent_id="x", db_path=str(tmp_path / "m.db"))
+        fac = MemoryStore(agent_id="x", db_path=str(tmp_path / "m.db"))
         with pytest.raises(AttributeError):
             fac.session_id = "tampered"  # type: ignore[misc]
 
@@ -116,5 +116,5 @@ class TestSessionIdPropertyContract:
         # property is a true view onto the same value (not a divergent
         # cache or copy).  If the private attribute is eventually
         # removed, this test should be deleted.
-        fac = MemoryFacade(agent_id="x", db_path=str(tmp_path / "m.db"))
+        fac = MemoryStore(agent_id="x", db_path=str(tmp_path / "m.db"))
         assert fac.session_id == fac._session_id  # noqa: SLF001 — transition guard

--- a/tests/unit/python/test_session_id_facade_surfaces.py
+++ b/tests/unit/python/test_session_id_facade_surfaces.py
@@ -5,7 +5,7 @@ write surfaces beyond the direct ``store_episode`` /
 
 The surfaces:
 
-* :meth:`MemoryFacade.store_observation` (RFC 0008 §B write path; the
+* :meth:`MemoryStore.store_observation` (RFC 0008 §B write path; the
   task-agent + sub-agent surface — ``facade.py:361`` reaches the
   underlying ``store_episode``).
 * :meth:`ProceduralFacadeMixin.store_procedure` (RFC 0008 PR 5
@@ -31,7 +31,7 @@ from pathlib import Path
 
 import pytest
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 from agents.memory.shared_pool import (
     SharedMemoryPool,
     SharedPoolConfig,
@@ -42,7 +42,7 @@ from agents.memory.shared_pool_facade import publish_via_facade
 @pytest.fixture
 async def facade(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("PERSATRIX_SESSION_ID", raising=False)
-    fac = MemoryFacade(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
+    fac = MemoryStore(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
     await fac.initialize()
     try:
         yield fac
@@ -54,7 +54,7 @@ async def facade(tmp_path: Path, monkeypatch):
 
 
 class TestStoreObservationSessionID:
-    async def test_default_writes_legacy(self, facade: MemoryFacade) -> None:
+    async def test_default_writes_legacy(self, facade: MemoryStore) -> None:
         ep_id = await facade.store_observation("hello")
         db = facade.episodic._ensure_db()  # noqa: SLF001 — test inspection
         async with db.execute(
@@ -65,7 +65,7 @@ class TestStoreObservationSessionID:
         assert row[0] == "legacy"
 
     async def test_explicit_kwarg_round_trips(
-        self, facade: MemoryFacade,
+        self, facade: MemoryStore,
     ) -> None:
         ep_id = await facade.store_observation("hi", session_id="run-a")
         db = facade.episodic._ensure_db()  # noqa: SLF001
@@ -79,13 +79,13 @@ class TestStoreObservationSessionID:
     async def test_env_var_is_facade_default(
         self, tmp_path: Path, monkeypatch,
     ) -> None:
-        # The task-agent / sub-agent path constructs MemoryFacade without
+        # The task-agent / sub-agent path constructs MemoryStore without
         # threading session_id at every call site; instead the facade
         # resolves PERSATRIX_SESSION_ID once at construction so every
         # subsequent write inherits it.  This mirrors how the persona
         # constructor reads the env var once.
         monkeypatch.setenv("PERSATRIX_SESSION_ID", "run-a")
-        fac = MemoryFacade(
+        fac = MemoryStore(
             agent_id="task-agent", db_path=str(tmp_path / "tm.db"),
         )
         await fac.initialize()
@@ -113,7 +113,7 @@ class TestStoreObservationSessionID:
         # default.  This is the path persona-reachable code uses when
         # it routes through the facade rather than the tiers directly.
         monkeypatch.setenv("PERSATRIX_SESSION_ID", "run-a")
-        fac = MemoryFacade(
+        fac = MemoryStore(
             agent_id="ember-owl", db_path=str(tmp_path / "tm.db"),
         )
         await fac.initialize()
@@ -134,7 +134,7 @@ class TestStoreObservationSessionID:
 
 
 class TestStoreProcedureSessionID:
-    async def test_default_writes_legacy(self, facade: MemoryFacade) -> None:
+    async def test_default_writes_legacy(self, facade: MemoryStore) -> None:
         await facade.store_procedure(
             "deploy.rollback", "run `make rollback`", confidence=0.9,
         )
@@ -149,7 +149,7 @@ class TestStoreProcedureSessionID:
         assert row[0] == "legacy"
 
     async def test_explicit_kwarg_round_trips(
-        self, facade: MemoryFacade,
+        self, facade: MemoryStore,
     ) -> None:
         await facade.store_procedure(
             "deploy.smoke", "curl health", confidence=0.9,

--- a/tests/unit/python/test_session_id_leaf_module.py
+++ b/tests/unit/python/test_session_id_leaf_module.py
@@ -1,7 +1,7 @@
 """
 PR #337 deep review finding **M2** — the env-var read logic for
 ``PERSATRIX_SESSION_ID`` must live in a single leaf module so the
-``MemoryFacade`` constructor and the persona-runtime logger wrapper
+``MemoryStore`` constructor and the persona-runtime logger wrapper
 cannot drift.
 
 Before this fix, two modules each inlined the silent
@@ -28,7 +28,7 @@ the log line.  This file pins:
 1. The leaf module has zero ``logging`` / observability dependencies
    (otherwise a future log line at construction-time would
    double-emit alongside :func:`agents.persona_runtime.session_id.resolve_session_id_and_log`).
-2. ``MemoryFacade``'s construction-time session id matches the leaf's
+2. ``MemoryStore``'s construction-time session id matches the leaf's
    :func:`resolve_session_id_silent` output exactly.
 3. The persona-runtime wrapper re-exports the leaf's constants so
    existing imports of ``SESSION_ID_ENV_VAR`` / ``LEGACY_SESSION_ID``
@@ -102,7 +102,7 @@ def test_leaf_has_no_logging_dependency() -> None:
     If a future contributor adds ``import logging`` and a
     ``logger.info`` call at construction-time, the operator would see
     two INFO lines for the same env-resolution decision: one from the
-    facade's :class:`MemoryFacade.__init__` (every task agent) and one
+    facade's :class:`MemoryStore.__init__` (every task agent) and one
     from :func:`agents.persona_runtime.session_id.resolve_session_id_and_log`
     (the persona-runtime boot path).  The original PR 4 fix-up
     explicitly cited "silent by design" as the rationale for inlining
@@ -165,13 +165,13 @@ def test_leaf_has_no_logging_dependency() -> None:
 def test_facade_session_id_matches_leaf_resolver(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The construction-time read in :class:`MemoryFacade` must
+    """The construction-time read in :class:`MemoryStore` must
     delegate to :func:`resolve_session_id_silent` (or behave identically
     to it).  This pins the dedup contract: as the carve-out semantics
     evolve in Phase 3 (tighter validation), the two read paths cannot
     drift.
     """
-    from agents.memory.facade import MemoryFacade
+    from agents.memory.facade import MemoryStore
     from agents.session_id import resolve_session_id_silent
 
     for env_value, label in [
@@ -187,11 +187,11 @@ def test_facade_session_id_matches_leaf_resolver(
             monkeypatch.setenv("PERSATRIX_SESSION_ID", env_value)
 
         expected = resolve_session_id_silent()
-        fac = MemoryFacade(
+        fac = MemoryStore(
             agent_id="x", db_path=str(tmp_path / f"m-{label.split()[0]}.db"),
         )
         assert fac._session_id == expected, (  # noqa: SLF001 — dedup contract
-            f"MemoryFacade._session_id must equal resolve_session_id_silent() "
+            f"MemoryStore._session_id must equal resolve_session_id_silent() "
             f"for env={env_value!r} ({label}); got "
             f"{fac._session_id!r} vs {expected!r}"  # noqa: SLF001
         )

--- a/tests/unit/python/test_session_id_surface_granularity.py
+++ b/tests/unit/python/test_session_id_surface_granularity.py
@@ -16,7 +16,7 @@ everything else.
 The fix promotes ``surface`` to a kwarg on ``store_episode`` so each
 calling layer pins it:
 
-* ``MemoryFacade.store_observation``       → ``surface="observation"``
+* ``MemoryStore.store_observation``       → ``surface="observation"``
 * ``ProceduralFacadeMixin.store_procedure`` → ``surface="procedure"``
 * ``SharedMemoryPool.write``               → ``surface="shared_pool"``
 * direct ``EpisodicMemory.store_episode`` call (no facade) → ``"episode"``
@@ -38,7 +38,7 @@ import pytest_asyncio
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 from agents.memory.episodic import EpisodicMemory
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 from agents.memory.shared_pool import (
     SharedMemoryPool,
     SharedPoolConfig,
@@ -81,7 +81,7 @@ async def test_store_observation_emits_surface_observation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PERSATRIX_SESSION_ID", raising=False)
-    fac = MemoryFacade(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
+    fac = MemoryStore(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
     await fac.initialize()
     try:
         await fac.store_observation("hello", session_id="run-a")
@@ -105,7 +105,7 @@ async def test_store_procedure_emits_surface_procedure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PERSATRIX_SESSION_ID", raising=False)
-    fac = MemoryFacade(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
+    fac = MemoryStore(agent_id="ember-owl", db_path=str(tmp_path / "m.db"))
     await fac.initialize()
     try:
         await fac.store_procedure(

--- a/tests/unit/python/test_shared_memory_pool.py
+++ b/tests/unit/python/test_shared_memory_pool.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import pytest
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 from agents.memory.shared_pool import (
     SharedMemoryPermissionError,
     SharedMemoryPool,
@@ -88,7 +88,7 @@ async def test_source_agent_is_framework_injected(pool: SharedMemoryPool) -> Non
 
 
 async def test_publish_rejects_caller_provenance_spoof(tmp_path: Any) -> None:
-    """``MemoryFacade.publish_to_pool`` must not let callers spoof source_agent.
+    """``MemoryStore.publish_to_pool`` must not let callers spoof source_agent.
 
     The facade enforces this by *always* passing
     ``source_agent_override=self.agent_id`` and exposing no parameter for
@@ -105,7 +105,7 @@ async def test_publish_rejects_caller_provenance_spoof(tmp_path: Any) -> None:
     pool_inst = SharedMemoryPool(cfg, db_path=db)
     await pool_inst.initialize()
     registry = SharedPoolRegistry({"pool": pool_inst})
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice", db_path=db, shared_pools=registry,
     )
     await facade.initialize()
@@ -116,7 +116,7 @@ async def test_publish_rejects_caller_provenance_spoof(tmp_path: Any) -> None:
         # The facade has no source_agent kwarg — confirm the only path
         # in is the framework-injected one.
         import inspect
-        sig = inspect.signature(MemoryFacade.publish_to_pool)
+        sig = inspect.signature(MemoryStore.publish_to_pool)
         assert "source_agent" not in sig.parameters
         assert "source_agent_override" not in sig.parameters
     finally:
@@ -174,7 +174,7 @@ async def test_sensitive_pool_blocks_publish(tmp_path: Any) -> None:
     pool_inst = SharedMemoryPool(cfg, db_path=db)
     await pool_inst.initialize()
     registry = SharedPoolRegistry({"secrets": pool_inst})
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice", db_path=db, shared_pools=registry,
     )
     await facade.initialize()
@@ -223,7 +223,7 @@ async def test_fifo_eviction_at_cap(tmp_path: Any) -> None:
 
 async def test_registry_unknown_pool_raises(tmp_path: Any) -> None:
     db = str(tmp_path / "r.db")
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice",
         db_path=db,
         shared_pools=SharedPoolRegistry({}),
@@ -241,7 +241,7 @@ async def test_registry_unknown_pool_raises(tmp_path: Any) -> None:
 
 
 async def test_facade_without_registry_denies_pool_calls(tmp_path: Any) -> None:
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice", db_path=str(tmp_path / "n.db"),
     )
     await facade.initialize()
@@ -401,7 +401,7 @@ async def test_read_from_pool_and_tag_filter(tmp_path: Any) -> None:
     """PR #223 review N4: end-to-end AND-tag contract through the facade.
 
     ``SharedMemoryPool.read`` does not filter by tags itself —
-    ``read_via_facade`` (and therefore ``MemoryFacade.read_from_pool``)
+    ``read_via_facade`` (and therefore ``MemoryStore.read_from_pool``)
     applies AND-set semantics on top.  Pin the end-to-end behaviour so
     a future refactor cannot turn it into OR semantics silently.
     """
@@ -414,7 +414,7 @@ async def test_read_from_pool_and_tag_filter(tmp_path: Any) -> None:
     pool_inst = SharedMemoryPool(cfg, db_path=db)
     await pool_inst.initialize()
     registry = SharedPoolRegistry({"tagged": pool_inst})
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice", db_path=db, shared_pools=registry,
     )
     await facade.initialize()

--- a/tests/unit/python/test_shared_memory_pool_pass2.py
+++ b/tests/unit/python/test_shared_memory_pool_pass2.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from agents.memory.facade import MemoryFacade
+from agents.memory.facade import MemoryStore
 from agents.memory.shared_pool import (
     SharedMemoryPool,
     SharedPoolConfig,
@@ -44,7 +44,7 @@ async def test_tag_filter_overfetches_under_limit(tmp_path: Any) -> None:
     pool_inst = SharedMemoryPool(cfg, db_path=db)
     await pool_inst.initialize()
     registry = SharedPoolRegistry({"overfetch": pool_inst})
-    facade = MemoryFacade(
+    facade = MemoryStore(
         agent_id="alice", db_path=db, shared_pools=registry,
     )
     await facade.initialize()


### PR DESCRIPTION
## Summary

Track B, **PR 3** of the [v0.3.3 release-prep plan](docs/v0.3.3-release-prep-plan.md#pr-3--version-bump--changelog-curation) — "Idle Truly Idle" (RFC 0024 Phases 1–4). Bumps every shipped component to `0.3.3`, curates the `[0.3.3]` changelog section, and lands the committed `MemoryFacade` alias removal.

PR 2 ([#418](https://github.com/mkhomutov/Persatrix/pull/418)) merged; this is the next step. Follows with PR 4 (final pre-tag verification).

## What's in this PR

### Version bump `0.3.2` → `0.3.3`
Via `scripts/bump_version.py`, then `cargo update --workspace` for the lockfile:
- `agents/pyproject.toml`
- `agents/observability/metrics.py` + `agents/observability/tracing.py` (`_DEFAULT_SERVICE_VERSION` + the `tracing.py` docstring default)
- `cli/Cargo.toml` + `cli/Cargo.lock` (regenerated — 0 packages relocked, version-only)

### Curated `[0.3.3]` changelog
Generated over `v0.3.2..HEAD` with `git-cliff`, then reshaped into **Highlights / Upgrade Notes / Features / Documentation / Testing**:
- **No Bug Fixes section** — every commit in range is an RFC 0024 PR or a docs/plan PR (no tracked-issue fixes shipped in the window).
- RFC 0041–0044 drafts ([#399](https://github.com/mkhomutov/Persatrix/pull/399)) stay on an RFC-tracking line under Documentation, **not** under Features.
- Upgrade Notes carry the canonical [§3.1 table](docs/v0.3.3-release-checklist.md#31-required-upgrade-notes-in-changelog) (event-driven loop, fire-and-forget channel dispatch, `autonomy.timers`, `scheduled_wakes` cache, salience knobs disabled-by-default, `agent.wake.*` counters, vestigial RFC 0017 §F guard, **and** the `MemoryFacade` removal).
- Insertion-only: `[0.3.2]` and every prior section are byte-identical to base (verified — the diff is a single hunk above `## [0.3.2]`).

### `MemoryFacade` alias removal — decision recorded
The v0.3.2 Upgrade Notes committed to removing `agents.memory.MemoryFacade` "in v0.3.3" ([release-prep plan §Known follow-up #2](docs/v0.3.3-release-prep-plan.md#known-follow-up-issues)). **Chose option (a): land the removal**, honouring the published one-minor-version horizon (pre-1.0 evolvable-over-back-compat).

The plan framed this as "a single export-list edit"; in practice production call sites were already migrated (RFC 0029 Phase 1 PR 3, enforced by `test_rfc0029_callsite_refactor.py`) but the alias was still imported across the test suite. So:
- Dropped `MemoryFacade = MemoryStore` from `agents/memory/facade.py` and the re-export from `agents/memory/__init__.py`. `MemoryStore` **is** the same class object the alias pointed at — only the import name changes, no behaviour difference.
- Migrated **16 test files** `MemoryFacade` → `MemoryStore`; removed the now-obsolete alias-identity test in `test_memory_store.py`; the RFC 0029 call-site guard now also pins that the symbol stays gone.
- Swept production docstring cross-references (`agents/memory/*.py`, `server.py`, `session_id.py`) so no `:class:`/`:meth:`` ref dangles at a deleted symbol. Deliberate RFC-history narrative (in `facade.py`/`store.py`) is preserved.

## Verification
- `ruff check` clean (incl. import-organization)
- `mypy .` clean — whole `agents` package, 181 source files, no issues
- Targeted memory/session unit slice: **182 passed**; the one failure (`test_personal_tier_latency_harness_runs`) is a **pre-existing** Python-3.13 `dataclasses` quirk with the dynamically-loaded perf harness — reproduced identically on the unmodified base via `git stash`, and the harness already uses `MemoryStore` (never `MemoryFacade`)
- The 4 migrated integration files: **25 passed**
- `cli` builds at `v0.3.3` (`cargo build`, exit 0)
- `make validate` passes; pre-commit hook green (7/7, incl. doc-link + doc-status)

## Acceptance (per plan PR 3)
- [x] Version strings at `0.3.3` across the 4 files + `Cargo.lock` regenerated
- [x] Curated `[0.3.3]` section with the §3.1 Upgrade Notes; no Bug Fixes section
- [x] Prior version sections untouched (insertion-only)
- [x] `MemoryFacade` alias-removal decision recorded (above)

## Out of scope / next
- The full `make all` (Go + Rust + full Python suite) and the Docker smoke + personal-tier latency gate are PR 4's pre-tag re-certification on this post-bump tip ([release-checklist §1](docs/v0.3.3-release-checklist.md#1-pre-release-verification)).
- The prep-plan Progress Overview still shows PR 2 as "🔀 PR open" though [#418](https://github.com/mkhomutov/Persatrix/pull/418) merged; per the plan's status-hygiene rules the table flips on merge, so it's left for the merge step rather than edited here.
