### PR TITLE
docs(release): post-release follow-up for v0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Persatrix is BUSL-1.1 licensed with no warranty. Use at your own risk
 | **v0.3.0** | Give agents a shared channel and watch them talk, negotiate, and form opinions over time | ✅ Released |
 | **v0.3.1** | Chat with a persona that remembers stated facts about you across interactions and follows the conversation it's currently having | ✅ Released |
 | **v0.3.2** | Every LLM call passes through a wallet lease before it's issued — cost becomes a structural gate, not a post-hoc accountant — and the memory facade is frozen as the single path to agent memory ahead of the v0.4.0 Postgres split | ✅ Released |
-| **v0.3.3** | A persona with no scheduled work and no inbound traffic costs nothing — its event loop parks until something wakes it (an inbound message, a scheduled timer, or a salience-triggered memory write) instead of polling on a fixed tick | 🚧 Release prep |
+| **v0.3.3** | A persona with no scheduled work and no inbound traffic costs nothing — its event loop parks until something wakes it (an inbound message, a scheduled timer, or a salience-triggered memory write) instead of polling on a fixed tick | ✅ Released |
 | **v0.4.0** | Define a team, lab, or company with roles and hierarchy — and let it run | 📋 Planned |
 | **v0.5.0** | Bridge your agent society into Slack, Discord, or email | 📋 Planned |
 | **v0.6.0** | Run agent societies across multiple nodes and networks | 📋 Planned |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-05-22 (v0.3.3 release-prep PR 4 — final pre-tag verification. PRs 0–3 of release prep merged: plan ([#415](https://github.com/mkhomutov/Persatrix/pull/415)), MT execution report ([#416](https://github.com/mkhomutov/Persatrix/pull/416)), docs refresh + release checklist ([#418](https://github.com/mkhomutov/Persatrix/pull/418)), version bump + curated changelog + `MemoryFacade` alias removal ([#419](https://github.com/mkhomutov/Persatrix/pull/419)). PR 4 (this PR) re-ran the full gate sweep on the post-bump tip — all green, incl. a live Docker smoke covering the four release behaviours — and flips the Version Map v0.3.3 row `🚧 Release prep` → `✅ Released`; the `v0.3.3` git tag and GitHub Release follow post-merge per [release-prep plan Phase 5](docs/v0.3.3-release-prep-plan.md).)
+> **Last updated**: 2026-05-22 (v0.3.3 post-release follow-up — `v0.3.3` tagged and the [GitHub Release "Idle Truly Idle"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.3) published. README v0.3.3 roadmap row → ✅ Released; ROADMAP `Last updated` refresh; Merged PR History backfill for the full v0.3.3 cycle ([#415](https://github.com/mkhomutov/Persatrix/pull/415) through [#420](https://github.com/mkhomutov/Persatrix/pull/420) — the table had stopped at [#414](https://github.com/mkhomutov/Persatrix/pull/414)); master plan + release-prep plan + release checklist status hygiene. The Version Map v0.3.3 row and "Current phase" / "Current milestone" already flipped to ✅ Released in release-prep PR 4 ([#420](https://github.com/mkhomutov/Persatrix/pull/420)).)
 > **Current phase**: v0.3.3 (Idle Truly Idle — RFC 0024 Phases 1–4) — ✅ Released
 > **Current milestone**: v0.3.3 released. The persona autonomy loop is now structurally event-driven (RFC 0024 Phases 1–4): a persona with `autonomy.timers: []` and no inbound traffic parks on `queue.get()` and pays nothing — no SQLite recall, no `_inject_memory_context`, no provider activity, no wallet lease — and wakes only on an inbound RPC, a scheduled timer, or a salience memory write. The polling-loop cost-leak class is closed structurally, guarded by the bored-persona `cost-regression-gate` CI job. Next phase is v0.4.0 (team/hierarchy) with the v0.3.4 patch (RFC 0031 Phases 2–4) sequenced first.
 
@@ -1015,6 +1015,12 @@ v0.5.0 complete
 | [#412](https://github.com/mkhomutov/Persatrix/pull/412) | feat(v033): RFC 0024 PR 5 — EventLoop lifecycle hardening | 0024 (5) | 2026-05-22 |
 | [#413](https://github.com/mkhomutov/Persatrix/pull/413) | feat(v033): RFC 0024 PR 5.1 — review-follow-up cleanups + deferred test-gap fills (Phase 1–4) | 0024 (5.1) | 2026-05-22 |
 | [#414](https://github.com/mkhomutov/Persatrix/pull/414) | docs(v033): RFC 0024 PR 6 — Phases 1–4 closeout | 0024 (6/close) | 2026-05-22 |
+| [#415](https://github.com/mkhomutov/Persatrix/pull/415) | docs(v033): v0.3.3 release-prep plan (master-plan Phase 3) | v0.3.3 release prep | 2026-05-22 |
+| [#416](https://github.com/mkhomutov/Persatrix/pull/416) | docs(v033): release-prep PR 1 — manual-test execution report | v0.3.3 release prep | 2026-05-22 |
+| [#417](https://github.com/mkhomutov/Persatrix/pull/417) | docs: refresh MT-CHAT-003/004 for RFC 0020 interaction-close; file ISSUE-0067/0068 | MT / docs | 2026-05-22 |
+| [#418](https://github.com/mkhomutov/Persatrix/pull/418) | docs(v033): release-prep PR 2 — docs refresh + release checklist | v0.3.3 release prep | 2026-05-22 |
+| [#419](https://github.com/mkhomutov/Persatrix/pull/419) | chore(v033): release-prep PR 3 — version bump + changelog + MemoryFacade alias removal | v0.3.3 release prep | 2026-05-22 |
+| [#420](https://github.com/mkhomutov/Persatrix/pull/420) | docs(v033): release-prep PR 4 — final pre-tag verification | v0.3.3 release prep | 2026-05-22 |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -111,6 +111,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | v0.3.0 | [v0.3.0-execution-report.md](v0.3.0-execution-report.md) | ✅ Complete |
 | v0.3.1 | [v0.3.1-execution-report.md](v0.3.1-execution-report.md) | ✅ Complete |
 | v0.3.2 | [v0.3.2-execution-report.md](v0.3.2-execution-report.md) | ✅ Complete |
+| v0.3.3 | [v0.3.3-execution-report.md](v0.3.3-execution-report.md) | ✅ Complete |
 
 ---
 

--- a/docs/v0.3.3-plan.md
+++ b/docs/v0.3.3-plan.md
@@ -1,8 +1,9 @@
 # v0.3.3 Plan — Idle Truly Idle
 
-**Status**: 🚧 In progress
+**Status**: ✅ Complete
 **Target version**: v0.3.3 (RFC 0024 Phases 1–4)
 **Created**: 2026-05-21
+**Completed**: 2026-05-22
 **Branch prefix**: `feature/v033-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -94,8 +95,8 @@ Update this table as each step PR merges. For multi-PR workstream rows, roll up 
 | 1 | 1 | RFC 0024 PR plan | `feature/v033-rfc0024-pr-plan` | ✅ Merged | [#405](https://github.com/mkhomutov/Persatrix/pull/405) | 2026-05-21 |
 | 2 | 2 | RFC 0024 implementation (Phases 1–4, per `0024-pr-plan.md`) | `feature/v033-rfc0024-…` | ✅ Merged | [#406](https://github.com/mkhomutov/Persatrix/pull/406), [#407](https://github.com/mkhomutov/Persatrix/pull/407), [#408](https://github.com/mkhomutov/Persatrix/pull/408), [#409](https://github.com/mkhomutov/Persatrix/pull/409), [#410](https://github.com/mkhomutov/Persatrix/pull/410), [#411](https://github.com/mkhomutov/Persatrix/pull/411), [#412](https://github.com/mkhomutov/Persatrix/pull/412), [#413](https://github.com/mkhomutov/Persatrix/pull/413), [#414](https://github.com/mkhomutov/Persatrix/pull/414) | 2026-05-22 |
 | 3 | 3 | v0.3.3 release-prep plan ([`v0.3.3-release-prep-plan.md`](v0.3.3-release-prep-plan.md)) | `feature/v033-release-prep-plan` | ✅ Merged | [#415](https://github.com/mkhomutov/Persatrix/pull/415) | 2026-05-22 |
-| 4 | 4 | v0.3.3 release-prep execution (MT report → docs → version bump → final) | `feature/v033-release-prep-…` | 🔀 PR open | [#416](https://github.com/mkhomutov/Persatrix/pull/416), [#418](https://github.com/mkhomutov/Persatrix/pull/418), [#419](https://github.com/mkhomutov/Persatrix/pull/419) + this PR | — |
-| 5 | 5 | v0.3.3 tag + post-release follow-up | `feature/v033-post-release` | ⬜ Not started | — | — |
+| 4 | 4 | v0.3.3 release-prep execution (MT report → docs → version bump → final) | `feature/v033-release-prep-…` | ✅ Merged | [#416](https://github.com/mkhomutov/Persatrix/pull/416), [#418](https://github.com/mkhomutov/Persatrix/pull/418), [#419](https://github.com/mkhomutov/Persatrix/pull/419), [#420](https://github.com/mkhomutov/Persatrix/pull/420) | 2026-05-22 |
+| 5 | 5 | v0.3.3 tag + post-release follow-up | `feature/v033-post-release` | 🔀 PR open | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred
 

--- a/docs/v0.3.3-release-checklist.md
+++ b/docs/v0.3.3-release-checklist.md
@@ -1,6 +1,6 @@
 # v0.3.3 Release Checklist
 
-> **Status**: ✅ Released — all four release-prep PRs merged (plan [#415](https://github.com/mkhomutov/Persatrix/pull/415), MT execution report [#416](https://github.com/mkhomutov/Persatrix/pull/416), docs refresh [#418](https://github.com/mkhomutov/Persatrix/pull/418), version bump + changelog + `MemoryFacade` removal [#419](https://github.com/mkhomutov/Persatrix/pull/419)). Release-prep PR 4 (final pre-tag verification) re-ran the full gate sweep on the post-bump tip — all green, incl. a live Docker smoke of the four release behaviours — and flipped the status docs to released. The `v0.3.3` git tag and GitHub Release are pushed after PR 4 merges per [release-prep plan Phase 5](v0.3.3-plan.md#phase-5--tag-and-post-release-follow-up).
+> **Status**: ✅ Released — `v0.3.3` tagged and the [GitHub Release "Idle Truly Idle"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.3) published 2026-05-22. All four release-prep PRs merged (plan [#415](https://github.com/mkhomutov/Persatrix/pull/415), MT execution report [#416](https://github.com/mkhomutov/Persatrix/pull/416), docs refresh [#418](https://github.com/mkhomutov/Persatrix/pull/418), version bump + changelog + `MemoryFacade` removal [#419](https://github.com/mkhomutov/Persatrix/pull/419)). Release-prep PR 4 ([#420](https://github.com/mkhomutov/Persatrix/pull/420), final pre-tag verification) re-ran the full gate sweep on the post-bump tip — all green, incl. a live Docker smoke of the four release behaviours — and flipped the status docs to released; the post-release follow-up then cut the tag and published the Release per [release-prep plan Phase 5](v0.3.3-plan.md#phase-5--tag-and-post-release-follow-up).
 
 > v0.3.3 — "Idle Truly Idle" — ships [RFC 0024](rfcs/0024-event-driven-scheduling.md) (Event-Driven Agent Scheduling — Phases 1–4). The user-facing promise: *a persona with no scheduled work and no inbound traffic costs nothing — no SQLite recall, no `_inject_memory_context`, no provider call, no wallet lease; the autonomy loop parks on `queue.get()` and wakes only on an inbound RPC, a scheduled timer, or a salience memory write.* The polling-loop cost-leak class is closed structurally, guarded by the bored-persona `cost-regression-gate` CI job.
 
@@ -172,11 +172,11 @@ git push origin v0.3.3
 
 GitHub Release checklist (post-merge manual steps after PR 4 merges):
 
-- [ ] Create the GitHub Release from tag `v0.3.3`
-- [ ] Use the curated `[0.3.3]` changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1) in the release body
-- [ ] Include known gaps (§6) in the release body
-- [ ] Attach binaries or container references if produced for this release — none planned (matches the v0.3.2 / v0.3.1 / v0.3.0 pattern)
+- [x] Create the GitHub Release from tag `v0.3.3`
+- [x] Use the curated `[0.3.3]` changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1) in the release body
+- [x] Include known gaps (§6) in the release body
+- [ ] Attach binaries or container references if produced for this release — none produced (matches the v0.3.2 / v0.3.1 / v0.3.0 pattern)
 
 ---
 
@@ -235,6 +235,6 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] Personal-tier latency regression gate re-run on the RC tip (p99=0.92 ms, p50=0.28 ms; informational, exit 0)
 [x] Known gaps documented for release notes (§6 above)
 [x] Docker smoke test — bored persona (zero spend) + scheduled-timer wake + channel fire-and-forget TaskAck + denied chat lease all verified on the post-bump tip
-[ ] git tag v0.3.3 created and pushed (Phase 5, post-merge)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (Phase 5, post-merge)
+[x] git tag v0.3.3 created and pushed (2026-05-22)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (2026-05-22)
 ```

--- a/docs/v0.3.3-release-prep-plan.md
+++ b/docs/v0.3.3-release-prep-plan.md
@@ -38,7 +38,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 1 | A | Manual test execution report (`MT-IDLE-001` + bored-persona CI gate offline run) | `feature/v033-release-prep-mt-exec` | ✅ Merged | [#416](https://github.com/mkhomutov/Persatrix/pull/416) | 2026-05-22 |
 | 2 | A | README + ROADMAP + persona-agents guide refresh + release checklist | `feature/v033-release-prep-docs` | ✅ Merged | [#418](https://github.com/mkhomutov/Persatrix/pull/418) | 2026-05-22 |
 | 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog | `feature/v033-release-prep-version-bump` | ✅ Merged | [#419](https://github.com/mkhomutov/Persatrix/pull/419) | 2026-05-22 |
-| 4 | B | Final pre-tag verification & release notes | `feature/v033-release-prep-final` | 🔀 PR open (this PR) | — | — |
+| 4 | B | Final pre-tag verification & release notes | `feature/v033-release-prep-final` | ✅ Merged | [#420](https://github.com/mkhomutov/Persatrix/pull/420) | 2026-05-22 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
## Summary

v0.3.3 was tagged and the [GitHub Release "Idle Truly Idle"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.3) published 2026-05-22. This is the post-release docs sweep, mirroring [#403](https://github.com/mkhomutov/Persatrix/pull/403) (v0.3.2 post-release) — flips any remaining docs that still described v0.3.3 as unreleased work-in-progress, and rolls Phase 5 of the [v0.3.3 master plan](docs/v0.3.3-plan.md#phase-5--tag-and-post-release-follow-up) to closed.

### Changes

- **README.md** — roadmap row for v0.3.3 flips from 🚧 Release prep to ✅ Released.
- **ROADMAP.md** — refresh "Last updated" (post-tag context, links to the GitHub Release); backfill the **Merged PR History** table with the full v0.3.3 cycle ([#415](https://github.com/mkhomutov/Persatrix/pull/415) through [#420](https://github.com/mkhomutov/Persatrix/pull/420) — the table had stopped at [#414](https://github.com/mkhomutov/Persatrix/pull/414); every PR in the window is merged, none skipped). The "Current phase" / "Current milestone" lines and the Version Map v0.3.3 row already flipped to ✅ Released in release-prep PR 4 ([#420](https://github.com/mkhomutov/Persatrix/pull/420)).
- **docs/v0.3.3-release-checklist.md** — Status blurb flips to the pushed-tag/published-release state with the Release URL; tick the §5 GitHub Release procedure items and the §7 tag/release summary gates. "Attach binaries" left unchecked (none produced — matches the v0.3.2 / v0.3.1 / v0.3.0 pattern).
- **docs/v0.3.3-plan.md** — top-level Status flips from 🚧 In progress to ✅ Complete; add `Completed: 2026-05-22`; Master Progress Overview row 4 (release-prep execution) flips to ✅ Merged rolling in [#420](https://github.com/mkhomutov/Persatrix/pull/420), row 5 (post-release follow-up) flips to 🔀 PR open.
- **docs/v0.3.3-release-prep-plan.md** — Progress Overview PR 4 row flips from 🔀 PR open to ✅ Merged ([#420](https://github.com/mkhomutov/Persatrix/pull/420), 2026-05-22).
- **docs/manual-tests/README.md** — Execution Reports table: append the v0.3.3 row at ✅ Complete.

No code changes. No tests affected. `scripts/checks/file_size.py` grandfather list not touched — `docs/v0.3.3-execution-report.md` and `docs/v0.3.3-release-checklist.md` were already grandfathered in PR 4 ([#420](https://github.com/mkhomutov/Persatrix/pull/420)); the plan files stay under the 3000-word prose cap.

## Test plan

- [x] `python scripts/checks/file_size.py` — clean (all docs under cap)
- [x] Pre-commit hooks (filemap / go fmt / ruff / cargo fmt / doc links / doc status / file size) — 7/7 PASS at commit time
- [x] Reviewer spot-checks the [GitHub Release "Idle Truly Idle"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.3) URL renders in the checklist Status blockquote and the ROADMAP "Last updated" line
- [x] Reviewer confirms the Merged PR History backfill (#415–#420) has no gaps and the post-release PR itself is intentionally not self-listed (same as #403)
