### PR TITLE
docs: require plain-English docs and comments

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -14,6 +14,14 @@ Be brief by default. Expand only when asked.
 - Status updates: 1–2 sentences.
 - Never add `Co-Authored-By: Claude` trailers or Claude attribution in PRs/commits.
 
+## Writing docs & comments
+
+Every new or changed doc and code comment must be readable by a non-programmer:
+plain English, as short as possible, leading with what it does in the real world
+and why it matters. Define jargon on first use or link the
+[glossary](../docs/ai-glossary.md). Full rules:
+[Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
+
 ## What is Persatrix
 
 Polyglot AI agent orchestration: **Go** orchestrator, **Python** agent runtime, **Rust** CLI, connected by protobuf/gRPC. DAG-based YAML workflows with Jinja2-like templating.

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -16,11 +16,8 @@ Be brief by default. Expand only when asked.
 
 ## Writing docs & comments
 
-Every new or changed doc and code comment must be readable by a non-programmer:
-plain English, as short as possible, leading with what it does in the real world
-and why it matters. Define jargon on first use or link the
-[glossary](../docs/ai-glossary.md). Full rules:
-[Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
+Plain English a non-programmer can follow — short, real-world purpose first.
+Full rules: [Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
 
 ## What is Persatrix
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,14 @@ Be brief by default. Expand only when asked.
 - Status updates: 1–2 sentences.
 - Prefer links to existing docs over embedding large guidance text.
 
+## Writing docs & comments
+
+Every new or changed doc and code comment must be readable by a non-programmer:
+plain English, as short as possible, leading with what it does in the real world
+and why it matters. Define jargon on first use or link the
+[glossary](../docs/ai-glossary.md). Full rules:
+[Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
+
 ## Architecture
 
 ```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,11 +16,8 @@ Be brief by default. Expand only when asked.
 
 ## Writing docs & comments
 
-Every new or changed doc and code comment must be readable by a non-programmer:
-plain English, as short as possible, leading with what it does in the real world
-and why it matters. Define jargon on first use or link the
-[glossary](../docs/ai-glossary.md). Full rules:
-[Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
+Plain English a non-programmer can follow — short, real-world purpose first.
+Full rules: [Documentation Guide § Writing Style](../docs/documentation-guide.md#writing-style).
 
 ## Architecture
 

--- a/.github/instructions/go-orchestrator.instructions.md
+++ b/.github/instructions/go-orchestrator.instructions.md
@@ -11,6 +11,7 @@ description: "Go orchestrator conventions: zap logging, testify tests, deny-by-d
 - Many `internal/` packages are TODO stubs for v0.2/v0.3. Implement the stub when its phase is active; don't remove the placeholder.
 - gRPC services defined in `proto/task.proto`. Run `make proto` after changing `.proto` files.
 - Entry point flags: `--config` (dir), `--port` (gRPC 9090), `--http-port` (REST 8080), `--env` (development|staging|production).
+- **Comments in plain English.** Write comments a non-programmer could follow — say what the code does and why it matters, briefly. Full rules: [Documentation Guide § Writing Style](../../docs/documentation-guide.md#writing-style).
 
 ## TDD (from v0.3.0 onward)
 

--- a/.github/instructions/python-agents.instructions.md
+++ b/.github/instructions/python-agents.instructions.md
@@ -17,6 +17,7 @@ description: "Python agent conventions: async-first, 3.11+ type hints, ruff lint
 - **Sub-agents** are ephemeral: spawned by parent agents via `orchestrator_client.spawn_sub_agent()` with inherited permissions.
 - **Platform awareness:** Guard `loop.add_signal_handler()` with `sys.platform != "win32"`.
 - **Dataclasses:** Use `field(default_factory=...)` for mutable defaults.
+- **Comments in plain English.** Write comments a non-programmer could follow — say what the code does and why it matters, briefly. Full rules: [Documentation Guide § Writing Style](../../docs/documentation-guide.md#writing-style).
 
 ## TDD (from v0.3.0 onward)
 

--- a/.github/instructions/rust-cli.instructions.md
+++ b/.github/instructions/rust-cli.instructions.md
@@ -11,6 +11,7 @@ description: "Rust CLI conventions: clap v4 derive, exhaustive match, tokio asyn
 - **Thin client:** CLI is a REST client to the orchestrator at `--server` (default `http://localhost:8080`). All business logic lives server-side.
 - **Output:** `tabled` for tables, `indicatif` for progress bars, `colored` for terminal colors.
 - **YAML:** `serde_yml` (maintained successor to `serde_yaml`).
+- **Comments in plain English.** Write comments a non-programmer could follow — say what the code does and why it matters, briefly. Full rules: [Documentation Guide § Writing Style](../../docs/documentation-guide.md#writing-style).
 
 ## TDD (from v0.3.0 onward)
 

--- a/.github/instructions/yaml-config.instructions.md
+++ b/.github/instructions/yaml-config.instructions.md
@@ -14,3 +14,4 @@ description: "YAML config conventions: JSON Schema validation, agent ID patterns
 - **Template references:** `extends: "templates/personas.yaml#anchor"` to inherit persona/sub-agent definitions.
 - **Environment overrides:** `config/environments/{development,staging,production}.yaml` for env-specific settings.
 - **Optimization profiles:** `cost_optimized`, `speed_optimized`, `quality_optimized`, `simulation_optimized` in `config/optimization.yaml`.
+- **Comments in plain English.** Write `#` comments a non-programmer could follow — say what the setting does and why it matters, briefly. Full rules: [Documentation Guide § Writing Style](../../docs/documentation-guide.md#writing-style).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,14 @@ For changes that affect architecture, cross-component interfaces, or introduce n
 - Exhaustive `match` on command enums (no catch-all `_`)
 - `tokio` async runtime
 
+### Documentation & Comments
+
+Write docs and comments so anyone can follow them — a developer new to the
+project, a founder evaluating it for their business, or a researcher using it
+for their work. Use plain English, keep it short, and lead with what the thing
+does in the real world and why it matters. Full rules:
+[Documentation Guide § Writing Style](docs/documentation-guide.md#writing-style).
+
 ### Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/):

--- a/docs/docs-consistency-checklist.md
+++ b/docs/docs-consistency-checklist.md
@@ -72,6 +72,7 @@ Use only the [standard status markers](./documentation-guide.md#status-markers):
 
 Before approving documentation changes:
 
+- [ ] Plain English — readable by a non-programmer; jargon defined or linked (see [Writing Style](./documentation-guide.md#writing-style))
 - [ ] Content is accurate and reflects current implementation
 - [ ] No single-source-of-truth violations (duplicate content)
 - [ ] Status markers are current

--- a/docs/documentation-guide.md
+++ b/docs/documentation-guide.md
@@ -4,6 +4,25 @@
 
 You are updating documentation for **Persatrix** — a polyglot AI agent orchestration framework built with Go (orchestrator), Python (agents), and Rust (CLI). The project maintains documentation across architecture, specs, and configuration.
 
+## Writing Style
+
+**Applies to every doc and every code comment — new or changed.**
+
+Persatrix is read by people who are not all programmers: developers at any
+level, founders sizing it up for a business, researchers using it for a study,
+and brand-new teammates on day one. Write so any of them can follow along.
+
+- **Plain English.** Short sentences, everyday words. Spell out a technical
+  term the first time you use it, or link the [glossary](ai-glossary.md).
+- **Lead with the point.** Say what the thing does and why it matters in the
+  real world before explaining how it works inside.
+- **Cut everything optional.** If a sentence still makes sense without a word,
+  delete the word. Drop filler like "simply", "just", "of course".
+- **Show it.** One real example or command beats a paragraph describing it.
+
+One test before you commit: *could someone who has never seen this code tell
+what it's for and why it's useful?* If not, rewrite.
+
 ## Core Principles
 
 When updating documentation:


### PR DESCRIPTION
@
## What

Adds one rule to the repo: **every doc and code comment must be readable by a non-programmer, kept short, and lead with what it does in the real world.**

The rule lives once in [`docs/documentation-guide.md` § Writing Style](docs/documentation-guide.md) (the source of truth). Everywhere else is a short pointer, so there is no duplicated guidance to keep in sync.

## Why

Lowers the barrier for the people we want to reach:

- developers at any level who want to contribute or experiment
- entrepreneurs evaluating it for a business
- scientists and social researchers using it for their work
- new teammates on day one
- the current maintainer(s), who keep an easy-to-reason-about project

## Changes

- `docs/documentation-guide.md` — new canonical **Writing Style** section (plain English, brevity, real-world-first, define jargon).
- `.github/CLAUDE.md`, `.github/copilot-instructions.md` — short pointer so AI assistants follow it.
- `CONTRIBUTING.md` — short pointer for human contributors.
- `.github/instructions/{go,python,rust,yaml}*.instructions.md` — one per-language bullet so the rule reaches code comments.
- `docs/docs-consistency-checklist.md` — reviewer checkpoint.

48 insertions, docs-only. Pre-commit doc-link, status-marker, and file-size checks pass.
@