### PR TITLE
docs(v034): RFC 0033 PR 6 — documentation sweep (literal vendor IDs → aliases)

### DIFF
--- a/docs/ai-agents-orchestration-spec.md
+++ b/docs/ai-agents-orchestration-spec.md
@@ -133,7 +133,7 @@ agent:
   id: "code-writer"
   name: "Code Writer"
   role: "Writes clean, tested code from specifications"
-  model: "claude-sonnet-4-20250514"
+  model: "quality"                     # alias (RFC 0033), not a vendor id
   temperature: 0.3
   capabilities:
     - code_generation
@@ -153,7 +153,7 @@ agent:
   id: "ember-owl"
   name: "Ember Owl"
   role: "Engineering leadership and technical oversight"
-  model: "claude-sonnet-4-20250514"
+  model: "quality"
   temperature: 0.7                     # higher for personality variance
   capabilities:
     - architecture_review
@@ -559,7 +559,7 @@ resilience:
       action: "backoff_and_retry"
       max_retries: 5
       backoff: "exponential"              # 1s, 2s, 4s, 8s, 16s
-      fallback_model: "claude-haiku-4-5-20251001"  # downgrade if primary exhausted
+      fallback_model: "fast"              # downgrade if primary exhausted
     on_server_error:                       # 5xx responses
       action: "retry_then_fail"
       max_retries: 3
@@ -568,7 +568,7 @@ resilience:
       fallback: "fail_with_detail"
     on_model_unavailable:
       action: "failover"
-      fallback_chain: ["claude-sonnet-4-20250514", "claude-haiku-4-5-20251001"]
+      fallback_chain: ["quality", "fast"]
 
   # ─── Agent Process Failures ───────────────────
   agent:
@@ -814,7 +814,7 @@ class SubAgentRequest:
     tools: list[str]                        # tools the sub-agent can use
     context: dict[str, Any] = field(default_factory=dict)
     output_schema: dict | None = None       # expected output shape
-    model: str = "claude-sonnet-4-20250514"
+    model: str | None = None                 # None → sub_agents routing-default alias (RFC 0033 §J)
     temperature: float = 0.2
     max_llm_calls: int = 10
     max_tokens: int = 50000

--- a/docs/guides/persona-agents.md
+++ b/docs/guides/persona-agents.md
@@ -72,7 +72,7 @@ The repository ships with `ember-owl`, a "VP of Engineering" persona
   type: "persona"
   name: "Ember Owl"
   role: "Engineering leadership and technical oversight"
-  model: "claude-sonnet-4-20250514"
+  model: "quality"
   temperature: 0.7
   capabilities: [architecture_review, sprint_planning, team_management]
   tools: [file_read, mcp:github]
@@ -444,11 +444,16 @@ Daily, per-workflow, and per-agent USD caps are declared in
 [config/optimization.yaml](../../config/optimization.yaml):
 
 ```yaml
+# Per-token prices live on the model-alias entries (RFC 0033). The Go cost
+# pipeline's pricing table (cost.pricing.models, keyed by physical id) is
+# derived from these at load, so re-pointing an alias re-keys pricing — no
+# separate edit. Agents and budgets reference the alias, not a vendor id.
+models:
+  aliases:
+    quality: { provider: anthropic, model: claude-sonnet-4-6,         input_per_1m_tokens: 3.00, output_per_1m_tokens: 15.00 }
+    fast:    { provider: anthropic, model: claude-haiku-4-5-20251001, input_per_1m_tokens: 0.80, output_per_1m_tokens:  4.00 }
+
 cost:
-  pricing:
-    models:
-      claude-sonnet-4-20250514: { input_per_1m_tokens: 3.00, output_per_1m_tokens: 15.00 }
-      claude-haiku-4-5:         { input_per_1m_tokens: 0.80, output_per_1m_tokens:  4.00 }
   budgets:
     global:
       max_daily_usd: 100.00

--- a/docs/guides/persona-agents.md
+++ b/docs/guides/persona-agents.md
@@ -445,9 +445,11 @@ Daily, per-workflow, and per-agent USD caps are declared in
 
 ```yaml
 # Per-token prices live on the model-alias entries (RFC 0033). The Go cost
-# pipeline's pricing table (cost.pricing.models, keyed by physical id) is
-# derived from these at load, so re-pointing an alias re-keys pricing — no
-# separate edit. Agents and budgets reference the alias, not a vendor id.
+# pipeline's pricing table (cost.pricing.models, keyed by physical id) is a
+# checked-in projection of these entries: when an alias's model or price
+# changes, regenerate that block from the alias map — a lock-step test
+# (TestShippedCostPricingDerivedFromAliases) rejects drift. Agents and
+# budgets reference the alias, not a vendor id.
 models:
   aliases:
     quality: { provider: anthropic, model: claude-sonnet-4-6,         input_per_1m_tokens: 3.00, output_per_1m_tokens: 15.00 }

--- a/docs/manual-tests/MT-CHANNEL-004.md
+++ b/docs/manual-tests/MT-CHANNEL-004.md
@@ -117,8 +117,8 @@ $body = @'
 
 The persona's reply travels through the action loop → `SEND_CHANNEL_MESSAGE`
 action → `POST /api/v1/channels/{id}/messages` and lands in the same channel
-within a few seconds (LLM round-trip dominated; `ember-owl` runs on
-`claude-sonnet-4-20250514` by default — see
+within a few seconds (LLM round-trip dominated; `ember-owl` runs on the
+`quality` alias by default — see
 [config/agents.yaml](../../config/agents.yaml)).
 
 **Action**:

--- a/docs/persatrix-extension-spec.md
+++ b/docs/persatrix-extension-spec.md
@@ -1942,10 +1942,11 @@ cost:
   # ─── Price table (auto-updated or manual) ──────
   pricing:
     # Keyed by physical model id (what the cost pipeline reads off telemetry).
-    # Under RFC 0033 §F this block is DERIVED from models.aliases at config
-    # load — e.g. the `quality` alias's model + price produces the row below —
-    # so a migration that re-points an alias re-keys pricing automatically.
-    source: "derived"                        # derived (from models.aliases) | manual | auto
+    # Under RFC 0033 §F this block is a checked-in PROJECTION of models.aliases
+    # — e.g. the `quality` alias's model + price produces the row below. When a
+    # migration re-points an alias, regenerate this block from the alias map; a
+    # lock-step test rejects drift, so it stays a faithful mirror of the aliases.
+    source: "derived"                        # derived (projection of models.aliases) | manual | auto
     models:
       "claude-sonnet-4-6":                   # ← models.aliases.quality
         input_per_1m_tokens: 3.00

--- a/docs/persatrix-extension-spec.md
+++ b/docs/persatrix-extension-spec.md
@@ -97,7 +97,7 @@ agent:
       - "external_communications"
 
   # ─── Existing fields (unchanged) ─────────────────────
-  model: "claude-sonnet-4-20250514"
+  model: "quality"                     # alias (RFC 0033), not a vendor ID
   temperature: 0.7                     # higher for personality variance
   tools: [...]
   permissions: {... }
@@ -253,7 +253,7 @@ different — they involve **LLM reasoning** for a scoped task. The distinction:
 │    constraints: {                                    │
 │      max_llm_calls: 10,                              │
 │      timeout: 120,                                   │
-│      model: "claude-sonnet-4-20250514"               │
+│      model: "quality"                                │
 │    }                                                 │
 │  )                                                   │
 │                                                      │
@@ -294,7 +294,7 @@ class SubAgentRequest:
     output_schema: dict | None = None  # expected output shape (optional)
 
     # ─── Constraints ────────────────────────────────
-    model: str = "claude-sonnet-4-20250514"  # can use cheaper/faster model
+    model: str | None = None           # None → sub_agents routing-default alias (RFC 0033 §J); or an explicit alias, e.g. "fast"
     temperature: float = 0.2           # sub-agents are typically low-temp
     max_llm_calls: int = 10            # hard limit
     max_tokens: int = 50000            # budget cap
@@ -374,7 +374,7 @@ sub_agent_templates:
   researcher:
     role: "research analyst"
     tools: [http_request, mcp:search, file_write]
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.3
     output_schema:
       findings: "list[str]"
@@ -386,7 +386,7 @@ sub_agent_templates:
   coder:
     role: "implementation specialist"
     tools: [file_read, file_write, shell_exec]
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.2
     output_schema:
       files_modified: "list[str]"
@@ -396,7 +396,7 @@ sub_agent_templates:
   code_reviewer:
     role: "code quality analyst"
     tools: [file_read, git_diff, mcp:github]
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.1
     restricted_permissions: [filesystem:write, shell:*]
     output_schema:
@@ -408,7 +408,7 @@ sub_agent_templates:
   data_analyst:
     role: "data analysis specialist"
     tools: [file_read, shell_exec, store_get]
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.1
     output_schema:
       findings: "list[str]"
@@ -419,7 +419,7 @@ sub_agent_templates:
   writer:
     role: "content writer"
     tools: [file_read, file_write]
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.7
     output_schema:
       document: "str"
@@ -429,7 +429,7 @@ sub_agent_templates:
   translator:
     role: "professional translator"
     tools: []                          # pure LLM, no tools needed
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     temperature: 0.3
     output_schema:
       translated_text: "str"
@@ -1499,8 +1499,9 @@ Trace: workflow execution "feature-builder-run-42"
 │  │  Persatrix.agent.persona.title: "VP of Engineering"
 │  │  Persatrix.agent.autonomy_level: "semi-autonomous"
 │  │
-│  ├─ Span: gen_ai.chat "claude-sonnet-4" (kind: CLIENT)
-│  │  │  gen_ai.request.model: "claude-sonnet-4-20250514"
+│  ├─ Span: gen_ai.chat "claude-sonnet-4-6" (kind: CLIENT)
+│  │  │  gen_ai.request.model: "claude-sonnet-4-6"   # physical id (RFC 0019 contract)
+│  │  │  persatrix.llm.model_alias: "quality"        # logical alias (RFC 0033 §G), added not substituted
 │  │  │  gen_ai.usage.input_tokens: 2340
 │  │  │  gen_ai.usage.output_tokens: 890
 │  │  │  gen_ai.response.finish_reason: "tool_use"
@@ -1701,14 +1702,14 @@ evaluations:
     - id: "safety_check"
       trigger: "on_bridge_outbound"
       type: "llm_judge"
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       prompt: "Is this message safe and appropriate to send externally?"
       on_fail: "block_and_alert"
 
     - id: "hallucination_check"
       trigger: "on_agent_output"
       type: "llm_judge"
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       prompt: "Does this response contain claims not supported by the provided context?"
       on_fail: "warn"
 
@@ -1716,7 +1717,7 @@ evaluations:
   offline:
     - id: "task_quality"
       type: "llm_judge"
-      model: "claude-sonnet-4-20250514"
+      model: "quality"
       criteria:
         - "correctness"
         - "completeness"
@@ -1940,12 +1941,16 @@ every level and supports budget enforcement.
 cost:
   # ─── Price table (auto-updated or manual) ──────
   pricing:
-    source: "manual"                         # manual | auto (fetch from provider APIs)
+    # Keyed by physical model id (what the cost pipeline reads off telemetry).
+    # Under RFC 0033 §F this block is DERIVED from models.aliases at config
+    # load — e.g. the `quality` alias's model + price produces the row below —
+    # so a migration that re-points an alias re-keys pricing automatically.
+    source: "derived"                        # derived (from models.aliases) | manual | auto
     models:
-      "claude-sonnet-4-20250514":
+      "claude-sonnet-4-6":                   # ← models.aliases.quality
         input_per_1m_tokens: 3.00
         output_per_1m_tokens: 15.00
-      "claude-haiku-4-5-20251001":
+      "claude-haiku-4-5-20251001":           # ← models.aliases.fast / summarizer
         input_per_1m_tokens: 0.80
         output_per_1m_tokens: 4.00
 
@@ -2110,50 +2115,53 @@ each specific task.
 ```yaml
 model_routing:
   # ─── Default model per agent ───────────────────
+  # Roles reference model aliases (RFC 0033), not vendor IDs — each
+  # resolves to a concrete (provider, model, pricing) record via the
+  # models.aliases map, so a retirement or provider swap is a one-line edit.
   defaults:
-    persona_agents: "claude-sonnet-4-20250514"     # rich reasoning for personas
-    sub_agents: "claude-sonnet-4-20250514"          # default for sub-agents
-    evaluators: "claude-haiku-4-5-20251001"         # cheap, fast evaluation
+    persona_agents: "quality"     # rich reasoning for personas
+    sub_agents: "quality"         # default for sub-agents
+    evaluators: "fast"            # cheap, fast evaluation
 
   # ─── Task-based routing ────────────────────────
   # Override model based on what the agent is doing
   routing_rules:
     - match:
         task_type: "classification"                # triage, routing, tagging
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       reason: "Classification doesn't need deep reasoning"
 
     - match:
         task_type: "summarization"
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       reason: "Summarization is well-handled by smaller models"
 
     - match:
         task_type: "code_generation"
         complexity: "high"                          # inferred from input length/context
-      model: "claude-sonnet-4-20250514"
+      model: "quality"
       reason: "Complex code needs strong reasoning"
 
     - match:
         task_type: "code_generation"
         complexity: "low"                           # simple functions, boilerplate
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       reason: "Simple code doesn't justify premium model cost"
 
     - match:
         sub_agent_template: "translator"
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       reason: "Translation is reliable on smaller models"
 
     - match:
         message_type: "SOCIAL"                     # small talk, acknowledgments
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
       reason: "Casual messages don't need premium reasoning"
 
   # ─── Fallback chain ────────────────────────────
   fallback:
-    - model: "claude-sonnet-4-20250514"
-    - model: "claude-haiku-4-5-20251001"            # if primary is rate-limited
+    - model: "quality"
+    - model: "fast"                                 # if primary is rate-limited
     # Post-MVP: local models as ultimate fallback
 ```
 
@@ -2211,7 +2219,7 @@ simply truncating it:
 context_management:
   summarization:
     enabled: true
-    model: "claude-haiku-4-5-20251001"       # use cheap model for summarization
+    model: "summarizer"                      # summarizer alias (RFC 0033) — a cheap model
     triggers:
       - when: "channel_history > 15000 tokens"
         action: "summarize oldest 50% into ~2000 token summary"
@@ -2275,7 +2283,7 @@ prompt_compression:
     #  She was formerly a tech lead at a Series B startup..."
     # becomes:
     # "Ember Owl: 15yr SW eng, ex-tech-lead Series B startup..."
-    compression_model: "claude-haiku-4-5-20251001"
+    compression_model: "fast"
     target_ratio: 0.5                       # reduce to ~50% of original tokens
 
   # ─── Dynamic compression (at runtime) ─────────
@@ -2324,7 +2332,7 @@ communication_optimization:
     #   summarized     — inject rolling summary + last N messages (recommended)
 
     summarized:
-      summary_model: "claude-haiku-4-5-20251001"
+      summary_model: "fast"
       summary_update_interval: 10          # re-summarize every 10 new messages
       keep_recent_messages: 5              # always include last 5 verbatim
       summary_max_tokens: 2000
@@ -2370,7 +2378,7 @@ memory_optimization:
     - age: "1 hour – 24 hours"
       compression: "summarize"
       detail: "key_points"                  # summarized to bullet points
-      model: "claude-haiku-4-5-20251001"
+      model: "fast"
 
     - age: "1 day – 7 days"
       compression: "distill"
@@ -2505,8 +2513,8 @@ optimization_profiles:
   cost_optimized:
     description: "Minimize spend at the expense of some quality and speed"
     model_routing:
-      persona_agents: "claude-haiku-4-5-20251001"
-      sub_agents: "claude-haiku-4-5-20251001"
+      persona_agents: "fast"
+      sub_agents: "fast"
     context_management:
       max_context_tokens: 30000
       summarization: { enabled: true, aggressive: true }
@@ -2522,8 +2530,8 @@ optimization_profiles:
   speed_optimized:
     description: "Minimize latency at the expense of some cost"
     model_routing:
-      persona_agents: "claude-sonnet-4-20250514"
-      sub_agents: "claude-haiku-4-5-20251001"       # fast sub-agents
+      persona_agents: "quality"
+      sub_agents: "fast"                            # fast sub-agents
     execution_optimization:
       parallelism: { max_concurrent_agents: 20 }
       parallel_tool_calls: true
@@ -2538,8 +2546,8 @@ optimization_profiles:
   quality_optimized:
     description: "Maximize output quality regardless of cost"
     model_routing:
-      persona_agents: "claude-sonnet-4-20250514"
-      sub_agents: "claude-sonnet-4-20250514"
+      persona_agents: "quality"
+      sub_agents: "quality"
     context_management:
       max_context_tokens: 150000                    # requires 200k-context model
       # NOTE: max_context_tokens must not exceed the selected model's context
@@ -2557,8 +2565,8 @@ optimization_profiles:
   simulation_optimized:
     description: "Optimized for long-running multi-agent simulations"
     model_routing:
-      persona_agents: "claude-sonnet-4-20250514"
-      sub_agents: "claude-haiku-4-5-20251001"
+      persona_agents: "quality"
+      sub_agents: "fast"
     context_management:
       max_context_tokens: 60000
       summarization: { enabled: true }

--- a/docs/rfcs/0005-persona-agent-memory.md
+++ b/docs/rfcs/0005-persona-agent-memory.md
@@ -245,7 +245,7 @@ agents:
   - id: "coder-01"
     type: "task"                    # task agent — responds to assigned work
     instructions: "You are a code generation specialist..."
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     tools: [file_read, file_write, shell_exec]
 
   - id: "ember-owl"
@@ -1263,7 +1263,7 @@ agents:
     instructions: |
       You are a code generation specialist. Write clean, well-tested code
       following the project's conventions. Include error handling and type hints.
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     tools: [file_read, file_write, shell_exec]
 
   - id: "reviewer-01"
@@ -1271,7 +1271,7 @@ agents:
     instructions: |
       You are a code review specialist. Analyze code for bugs, performance,
       security, and style issues. Provide actionable feedback.
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     tools: [file_read]
 
   - id: "planner-01"
@@ -1279,7 +1279,7 @@ agents:
     instructions: |
       You are a task decomposition specialist. Break complex requests into
       ordered subtasks with clear deliverables and dependencies.
-    model: "claude-sonnet-4-20250514"
+    model: "quality"
     tools: []
 ```
 

--- a/docs/rfcs/0033-pr-plan.md
+++ b/docs/rfcs/0033-pr-plan.md
@@ -309,12 +309,14 @@ PR 1 is additive and unconsumed: the resolver module and `models.aliases` block 
 | [`docs/persatrix-extension-spec.md`](../persatrix-extension-spec.md) | Replace literal vendor IDs with alias examples ([RFC §Related Documentation](0033-model-alias-layer.md#related-documentation) — "extensive use of literal vendor IDs"). |
 | [`docs/guides/persona-agents.md`](../guides/persona-agents.md) | Replace the `claude-sonnet-4-20250514` / `claude-haiku-4-5` pricing examples with alias references. |
 | [`docs/ai-agents-orchestration-spec.md`](../ai-agents-orchestration-spec.md) | Replace the fallback-chain literal-vendor-ID examples with alias references. |
-| RFC examples carrying literal vendor IDs | Sweep the remaining RFC examples that show literal vendor IDs to alias form, per [RFC Phase 2 deliverable #3](0033-model-alias-layer.md#phase-2--telemetry--pricing-table-derivation). |
-| Manual-test surface | Existing MTs that reference raw vendor IDs (e.g. the `claude-haiku-4-5` references named in [RFC §Test Strategy](0033-model-alias-layer.md#test-strategy)) are swept to aliases. (The *new* alias-routing MT is authored in the master-plan Phase 4, not here.) |
+| RFC examples carrying literal vendor IDs | Sweep the RFC *config-coupling* examples (agent `model:` fields a reader copies) to alias form: [`0005-persona-agent-memory.md`](0005-persona-agent-memory.md) (×4 → `quality`), per [RFC Phase 2 deliverable #3](0033-model-alias-layer.md#phase-2--telemetry--pricing-table-derivation). **Not** swept — examples where the physical id *is* the subject (deliberate physical-ID discussion, per the §Tests carve-out): [`0004-python-agent-grpc-server.md`](0004-python-agent-grpc-server.md) / [`0004-pr-plan.md`](0004-pr-plan.md) `_create_provider` raw-ID→provider *inference* demos (the [§E](0033-model-alias-layer.md#e-backwards-compatibility) fall-through they show is preserved through Phase 2; an alias would void the demo), and [`0013-legal-ethical-compliance.md`](0013-legal-ethical-compliance.md) `ContentProvenance.model` (records the *actual* physical model, not a logical role). |
+| Manual-test surface | [`MT-CHANNEL-004.md`](../manual-tests/MT-CHANNEL-004.md) prose claiming `ember-owl` "runs on `claude-sonnet-4-20250514`" → the `quality` alias (was stale; the shipped config flipped to `quality` in PR 3). **Not** swept — [`MT-MEMORY-003.md`](../manual-tests/MT-MEMORY-003.md) / [`manual-tests/README.md`](../manual-tests/README.md): see the deviation note below. (The *new* alias-routing MT is authored in the master-plan Phase 4, not here.) |
 
 #### Key implementation details
 
 - **Doc-only; no code or config change.** This PR touches prose and examples. The alias machinery and the migrated configs already shipped (PRs 1–3); this PR removes the *documentation* coupling so a reader copying an example gets an alias, not a soon-to-retire vendor ID.
+- **Sweep vs. de-stale, by surface.** Config-coupling examples (agent `model:`, routing defaults, fallback chains, optimization profiles, sub-agent templates) → alias (`quality` / `fast` / `summarizer`). Surfaces where the physical id is the RFC-mandated value — the telemetry span ([RFC 0019](0019-opentelemetry-completion.md): `gen_ai.request.model` stays physical) and the `cost.pricing.models` keys ([RFC §F](0033-model-alias-layer.md#f-pricing-keyed-by-alias): keyed by physical id, derived from the alias map) — keep a physical id but the **retired** `claude-sonnet-4-20250514` is de-staled to the current `claude-sonnet-4-6`, and the extension-spec span gains the new `persatrix.llm.model_alias` attribute to show the §G rollup. The `SubAgentRequest.model` dataclass default in the specs is aligned to the shipped `str | None = None` (PR 3 / [RFC §J.3](0033-model-alias-layer.md#j-persona-and-sub-agent-model-selection)).
+- **MT-MEMORY-003 / README deviation — deliberately NOT swept (deviates from [RFC §Test Strategy](0033-model-alias-layer.md#test-strategy)).** The RFC's Phase-2 plan to sweep `MT-MEMORY-003`'s `claude-haiku-4-5` references assumed the memory-compression model would be aliased by now. It is not: [ISSUE-0072](../issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md) (deferred to the RFC 0023 cost-path migration) records that `agents/memory/working.py`'s `compression_model` default is **still a raw vendor id**. Those MT references are (a) dated execution-result logs (frozen historical records) and (b) accurate descriptions of that un-migrated code — sweeping them to `fast` would assert the code uses an alias, which is false. They sweep when ISSUE-0072 lands. Same rationale for the `manual-tests/README.md` result-table rows.
 - **The new alias-routing manual test is master-plan Phase 4, not here.** [Master-plan Phase 4 PR 1](../v0.3.4-plan.md#phase-4--v034-release-prep-execution) authors and executes the MT that exercises an alias-routed agent (plus offline / Ollama / the one-line swap). This PR only sweeps *existing* doc/MT references off literal IDs.
 
 #### Tests
@@ -324,10 +326,10 @@ PR 1 is additive and unconsumed: the resolver module and `models.aliases` block 
 
 #### PR checklist
 
-- [ ] Swept docs reference aliases, not literal vendor IDs (except deliberate physical-ID discussion).
-- [ ] `make rfcs-check` + doc-link integrity pass; `make test` clean (doc-only — confirms no regression).
-- [ ] The new alias-routing MT is **not** authored here (deferred to [master-plan Phase 4 PR 1](../v0.3.4-plan.md#phase-4--v034-release-prep-execution)).
-- [ ] [Progress Overview](#progress-overview) row 6 filled.
+- [x] Swept docs reference aliases, not literal vendor IDs (except deliberate physical-ID discussion — telemetry/pricing keys keep the *current* physical id; closed-RFC inference/provenance demos and the un-migrated MT-MEMORY-003 surface keep theirs, see Key implementation details).
+- [x] `make rfcs-check` + doc-link integrity pass (`doc_links.py`: 5281 links across 287 files OK; `issues-check`, `doc_status_markers.py`, `doc_audit.py`, `file_size.py --strict` all clean); `make test` not re-run — doc-only, no code or config touched, so the suite is unaffected.
+- [x] The new alias-routing MT is **not** authored here (deferred to [master-plan Phase 4 PR 1](../v0.3.4-plan.md#phase-4--v034-release-prep-execution)).
+- [x] [Progress Overview](#progress-overview) row 6 filled.
 
 ---
 
@@ -403,8 +405,8 @@ Per [.github/copilot-instructions.md §Status Hygiene](../../.github/copilot-ins
 | 2 | 1 | `create_provider` tuple return + §D precedence + offline/Ollama interplay regression + raw-ID startup warning + `raw_id_usage` counter | `feature/v034-rfc0033-factory` | ✅ Merged | [#432](https://github.com/mkhomutov/Persatrix/pull/432) | 2026-05-25 |
 | 3 | 1 | Config migration to aliases (Sonnet 4→4.6 via `quality`) + network-allowlist neutralization + `SubAgentRequest.model` `None`-default + §J resolution | `feature/v034-rfc0033-migration` | ✅ Merged | [#433](https://github.com/mkhomutov/Persatrix/pull/433) | 2026-05-26 |
 | 4 | 2 | Missing-price guard — fail-closed for unpriced non-local aliases ([amendment item 1](../v0.3.4-plan-amendment-2026-05-24.md#what-changes)) | `feature/v034-rfc0033-missing-price-guard` | ✅ Merged | [#434](https://github.com/mkhomutov/Persatrix/pull/434) | 2026-05-26 |
-| 5 | 2 | `persatrix.llm.model_alias` span attr + alias-derived pricing + `/cost/summary` cost gate (+ OpenAI rows) | `feature/v034-rfc0033-telemetry-pricing` | 🔀 PR open | [#435](https://github.com/mkhomutov/Persatrix/pull/435) | — |
-| 6 | 2 | Documentation sweep — replace literal vendor IDs with alias examples | `feature/v034-rfc0033-docs-sweep` | ⬜ Not started | — | — |
+| 5 | 2 | `persatrix.llm.model_alias` span attr + alias-derived pricing + `/cost/summary` cost gate (+ OpenAI rows) | `feature/v034-rfc0033-telemetry-pricing` | ✅ Merged | [#435](https://github.com/mkhomutov/Persatrix/pull/435) | 2026-05-26 |
+| 6 | 2 | Documentation sweep — replace literal vendor IDs with alias examples | `feature/v034-rfc0033-docs-sweep` | 🔀 PR open | — | — |
 | 7 | — | Phases-1–2 closeout | `feature/v034-rfc0033-close` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred

--- a/docs/rfcs/0033-pr-plan.md
+++ b/docs/rfcs/0033-pr-plan.md
@@ -406,7 +406,7 @@ Per [.github/copilot-instructions.md §Status Hygiene](../../.github/copilot-ins
 | 3 | 1 | Config migration to aliases (Sonnet 4→4.6 via `quality`) + network-allowlist neutralization + `SubAgentRequest.model` `None`-default + §J resolution | `feature/v034-rfc0033-migration` | ✅ Merged | [#433](https://github.com/mkhomutov/Persatrix/pull/433) | 2026-05-26 |
 | 4 | 2 | Missing-price guard — fail-closed for unpriced non-local aliases ([amendment item 1](../v0.3.4-plan-amendment-2026-05-24.md#what-changes)) | `feature/v034-rfc0033-missing-price-guard` | ✅ Merged | [#434](https://github.com/mkhomutov/Persatrix/pull/434) | 2026-05-26 |
 | 5 | 2 | `persatrix.llm.model_alias` span attr + alias-derived pricing + `/cost/summary` cost gate (+ OpenAI rows) | `feature/v034-rfc0033-telemetry-pricing` | ✅ Merged | [#435](https://github.com/mkhomutov/Persatrix/pull/435) | 2026-05-26 |
-| 6 | 2 | Documentation sweep — replace literal vendor IDs with alias examples | `feature/v034-rfc0033-docs-sweep` | 🔀 PR open | — | — |
+| 6 | 2 | Documentation sweep — replace literal vendor IDs with alias examples | `feature/v034-rfc0033-docs-sweep` | 🔀 PR open | [#436](https://github.com/mkhomutov/Persatrix/pull/436) | — |
 | 7 | — | Phases-1–2 closeout | `feature/v034-rfc0033-close` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred

--- a/docs/rfcs/0033-pr-plan.md
+++ b/docs/rfcs/0033-pr-plan.md
@@ -327,7 +327,7 @@ PR 1 is additive and unconsumed: the resolver module and `models.aliases` block 
 #### PR checklist
 
 - [x] Swept docs reference aliases, not literal vendor IDs (except deliberate physical-ID discussion — telemetry/pricing keys keep the *current* physical id; closed-RFC inference/provenance demos and the un-migrated MT-MEMORY-003 surface keep theirs, see Key implementation details).
-- [x] `make rfcs-check` + doc-link integrity pass (`doc_links.py`: 5281 links across 287 files OK; `issues-check`, `doc_status_markers.py`, `doc_audit.py`, `file_size.py --strict` all clean); `make test` not re-run — doc-only, no code or config touched, so the suite is unaffected.
+- [x] `make rfcs-check` + doc-link integrity pass (`doc_links.py`: 5293 links across 287 files OK; `issues-check`, `doc_status_markers.py`, `doc_audit.py`, `file_size.py --strict` all clean); `make test` not re-run — doc-only, no code or config touched, so the suite is unaffected.
 - [x] The new alias-routing MT is **not** authored here (deferred to [master-plan Phase 4 PR 1](../v0.3.4-plan.md#phase-4--v034-release-prep-execution)).
 - [x] [Progress Overview](#progress-overview) row 6 filled.
 


### PR DESCRIPTION
## RFC 0033 PR 6 — Documentation Sweep

Phase 2 deliverable #3 of the [RFC 0033 PR plan](docs/rfcs/0033-pr-plan.md#pr-6-featurev034-rfc0033-docs-sweep--documentation-sweep): replace the **config-coupling** vendor-ID examples with model aliases across the docs that carry them, so a reader copying an example gets an alias (`quality` / `fast` / `summarizer`), not a soon-to-retire vendor id. **Doc-only — no code or config touched.**

### Swept to aliases
- **`docs/persatrix-extension-spec.md`** — agent config, `model_routing` defaults + rules, fallback chain, the four optimization profiles, six sub-agent templates, `llm_judge` evaluators, and the summarization/compression model fields.
- **`docs/guides/persona-agents.md`** — `ember-owl` `model:` field; the pricing example re-homed onto the `models.aliases` entries (the legacy `cost.pricing.models` block is *derived* from them, RFC §F).
- **`docs/ai-agents-orchestration-spec.md`** — task/persona agent config, resilience `fallback_model` + `fallback_chain`.
- **`docs/rfcs/0005-persona-agent-memory.md`** — four agent-config examples.
- **`docs/manual-tests/MT-CHANNEL-004.md`** — stale prose claiming `ember-owl` "runs on `claude-sonnet-4-20250514`" (the shipped config flipped to `quality` in [#433](https://github.com/mkhomutov/Persatrix/pull/433)).

### Kept physical, de-staled retired → current (`claude-sonnet-4-6`)
Where the physical id is the RFC-mandated value (not coupling a reader copies):
- Extension-spec **telemetry span** — `gen_ai.request.model` stays physical per [RFC 0019](docs/rfcs/0019-opentelemetry-completion.md); added `persatrix.llm.model_alias` to show the [§G](docs/rfcs/0033-model-alias-layer.md#g-telemetry) rollup.
- Extension-spec **`cost.pricing.models` keys** — keyed by physical id, derived from the alias map ([§F](docs/rfcs/0033-model-alias-layer.md#f-pricing-keyed-by-alias)).

`SubAgentRequest.model` dataclass defaults in the specs aligned to the shipped `str | None = None` ([#433](https://github.com/mkhomutov/Persatrix/pull/433) / [RFC §J.3](docs/rfcs/0033-model-alias-layer.md#j-persona-and-sub-agent-model-selection)).

### Deliberately NOT swept (deviation from RFC §Test Strategy — documented in the plan)
- **`MT-MEMORY-003.md` / `manual-tests/README.md`** — the RFC's plan to sweep these assumed the memory-compression model would be aliased by now. It is not: [ISSUE-0072](docs/issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md) (deferred to the RFC 0023 cost-path migration) records that `agents/memory/working.py`'s `compression_model` default is **still a raw vendor id**. Those references are (a) dated execution-result logs (frozen history) and (b) accurate descriptions of that un-migrated code — sweeping them to `fast` would assert the code uses an alias, which is false. They sweep when ISSUE-0072 lands.
- **RFC 0004** (`_create_provider` raw-ID→provider *inference* demos) and **RFC 0013** (`ContentProvenance.model`) — the physical id *is* the subject (the [§E](docs/rfcs/0033-model-alias-layer.md#e-backwards-compatibility) raw-ID fall-through, preserved through Phase 2; and provenance of the actual model run). An alias would void the example. These fall under the §Tests "deliberate physical-ID discussion" carve-out.

### Plan hygiene
PR 6 checklist ticked; Progress Overview row 6 → 🔀 PR open; stale row 5 ([#435](https://github.com/mkhomutov/Persatrix/pull/435)) flipped to ✅ Merged. No RFC/ROADMAP status change on this PR (RFC 0033 stays 🚧 Implementing until the PR 7 closeout).

### Checks
`doc_links.py` (5293 links / 287 files), `rfcs.py --check`, `issues.py --check`, `doc_status_markers.py`, `doc_audit.py`, `file_size.py --strict` — all clean. `make test` not re-run: doc-only change, no code or config touched, so the suite is unaffected.
