### PR TITLE
docs(v034): refresh the four v0.3.4 MT recipes to config-driven form + live re-run on HEAD

### DIFF
--- a/docs/manual-tests/MT-ALIAS-001.md
+++ b/docs/manual-tests/MT-ALIAS-001.md
@@ -7,6 +7,15 @@
 **Last Updated**: 2026-05-27
 **Status**: Active
 
+> **v0.3.4 recipe — config-driven (no default provider).** The base
+> [`config/optimization.yaml`](../../config/optimization.yaml) ships the `quality` / `fast` /
+> `summarizer` aliases **unconfigured** — there is no default provider, so a plain
+> `docker compose up` fails loud at agent startup. This test runs `make demo-anthropic`, which
+> mounts [`config/demo/anthropic/optimization.yaml`](../../config/demo/anthropic/optimization.yaml)
+> (pointing `quality` → `anthropic` / `claude-sonnet-4-6`, priced 3.00 / 15.00) over the stack's
+> config ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)). Re-run live against the
+> config-driven HEAD (see [Test Results](#test-results)).
+
 ---
 
 ## Overview
@@ -76,21 +85,28 @@ automated `cost-attribution gate` (`internal/server/cost_alias_gate_test.go` +
 
 ### Application State
 
-- ☐ Full stack up: `docker compose -f docker-compose.yaml up -d --build` (orchestrator + agents
-  + collector + jaeger + prometheus), all services healthy.
-- ☐ `make validate` exits 0 (config valid; `schema_version: "0.2"`).
-- ☐ The stock `config/optimization.yaml` ships `quality` as a **priced** Anthropic alias
-  (`input_per_1m_tokens: 3.00`, `output_per_1m_tokens: 15.00`) — no edit required.
+- ☐ Stack up via `make demo-anthropic`
+  (`docker compose -f docker-compose.yaml -f docker-compose.anthropic.yaml up -d --build` —
+  orchestrator + agents + collector + jaeger + prometheus), all services healthy. The overlay
+  mounts [`config/demo/anthropic/optimization.yaml`](../../config/demo/anthropic/optimization.yaml),
+  which configures `quality` → `anthropic` / `claude-sonnet-4-6` (priced `3.00` / `15.00`).
+- ☐ `make validate` exits 0 (base config valid; `schema_version: "0.2"`).
+- ☐ The base `config/optimization.yaml` ships `quality` **unconfigured** (no default provider) — a
+  plain `docker compose up` (no demo overlay) fails loud at agent startup with the actionable
+  "pick a provider" `SystemExit`. The Anthropic configuration arrives via the mounted demo config,
+  not the base file.
 
 > **Operator note (carry-forward F-3)**: an *empty* `ANTHROPIC_API_KEY` exported in the shell
-> shadows the populated `.env` under Compose interpolation precedence
-> (`required variable ANTHROPIC_API_KEY is missing a value`). Clear the empty shell var before
-> `docker compose` so Compose reads `.env`.
+> shadows the populated `.env` under Compose interpolation precedence. v0.3.4 plumbs keys with a
+> `:-` empty default (the hard `:?` guard was dropped), so an empty shell value no longer aborts
+> `up` — the agent just logs an unset-key warning and fails on the first request. Unset the empty
+> shell var (or give it the real key) before `docker compose` so Compose reads `.env`.
 
 ### Test Data
 
 The stock `ember-owl` persona (and every task agent) already references `model: "quality"` in
-[`config/agents.yaml`](../../config/agents.yaml). No config edit is needed.
+[`config/agents.yaml`](../../config/agents.yaml) — no agent edit is needed. `make demo-anthropic`
+supplies the `quality` alias's provider/model/pricing via the mounted demo config.
 
 ---
 
@@ -248,6 +264,7 @@ authoritative; the redundant disagreeing field is a config bug, not a silent res
 | Date | Tester | OS | Result | Notes |
 |------|--------|----|--------|-------|
 | 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker Desktop | ✅ Pass | See [`v0.3.4-execution-report.md`](v0.3.4-execution-report.md#mt-alias-001--primary-gate-evidence-live) for per-step evidence. |
+| 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker 29.3.1 | ✅ Pass | **Config-driven re-run on HEAD `6ce23cd`** (`make demo-anthropic`): no raw-ID / key warning; chat turn `reply_status="ok"`; cost `2708/20/$0.008424`, **exactly** the `claude-sonnet-4-6` rate (2708×$3.00/1M + 20×$15.00/1M), keyed to ember-owl; Prometheus `agent_llm_calls_total{gen_ai_system="anthropic", gen_ai_request_model="claude-sonnet-4-6"}=1`. Both Go gate tests PASS on HEAD. |
 
 ---
 

--- a/docs/manual-tests/MT-ALIAS-002.md
+++ b/docs/manual-tests/MT-ALIAS-002.md
@@ -7,21 +7,34 @@
 **Last Updated**: 2026-05-27
 **Status**: Active
 
+> **v0.3.4 recipe — config-driven (no default provider; no `quality-openai` peer).** The base
+> [`config/optimization.yaml`](../../config/optimization.yaml) ships every role alias
+> **unconfigured**, and there is **no** shipped `quality-openai` peer alias — the per-provider
+> configs live under [`config/demo/<provider>/`](../../config/demo/). This test demonstrates the
+> one-line provider swap as the move from the Anthropic alias config to the OpenAI alias config:
+> the **same agents**, unchanged, re-route to a different provider because the `quality` / `fast` /
+> `summarizer` alias entries name a different `provider` / `model`
+> ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)). Re-run live against HEAD (see
+> [Test Results](#test-results)).
+
 ---
 
 ## Overview
 
 **Purpose**: Validate the v0.3.4 headline claim — *"a provider swap is a one-line edit."* The
-same agent, unchanged, must route to a **different provider** after editing a single field on
-its model alias in [`config/optimization.yaml`](../../config/optimization.yaml), and still report
-correct cost (non-zero for a priced cloud peer; documented-$0 for a local target).
+same agent, unchanged, must route to a **different provider** after re-pointing its model alias's
+`provider` / `model`, and still report correct cost (non-zero for a priced cloud peer;
+documented-$0 for a local target).
 
-**Scope**: The RFC 0033 §D promise that model identity lives in **one** place. We flip the
-`quality` alias's `provider` / `model` from the Anthropic default to a priced OpenAI peer
-(`gpt-4o`) — a one-line-class edit to the alias entry, with **no edit** to `config/agents.yaml`,
-the routing defaults, or any agent code — and confirm the same `ember-owl` persona now calls
-OpenAI with correctly-keyed non-zero cost. The local-target variant (Edge Case 1) flips to the
-`ollama` provider and documents the $0-local case.
+**Scope**: The RFC 0033 §D promise that model identity lives in **one** place. We re-point the
+`quality` / `fast` / `summarizer` aliases from Anthropic to a priced OpenAI peer (`gpt-4o`) — an
+alias-block change with **no edit** to `config/agents.yaml`, the routing defaults, or any agent
+code — and confirm the same `ember-owl` persona now calls OpenAI with correctly-keyed non-zero
+cost. In v0.3.4 each provider is a mounted alias config, so the swap is `make demo-anthropic` →
+`make demo-openai` (the `config/demo/anthropic` vs `config/demo/openai` diff is exactly the alias
+block); the equivalent manual form is editing the `quality` entry's `provider` / `model` / price in
+the active config. The local-target variant (Edge Case 1) flips to the `ollama` provider and
+documents the $0-local case.
 
 **Out of Scope**: First-time alias→cost wiring (that is [MT-ALIAS-001](MT-ALIAS-001.md)); the
 keyless local/offline demo paths ([MT-OFFLINE-001](MT-OFFLINE-001.md) /
@@ -38,10 +51,11 @@ mounted alias config; this test exercises the *user-facing* one-line edit to the
 - [docs/rfcs/0033-model-alias-layer.md](../rfcs/0033-model-alias-layer.md) — §Motivation
   (one-line migration), §D (alias is authoritative).
 - [docs/v0.3.4-plan-amendment-2026-05-24.md](../v0.3.4-plan-amendment-2026-05-24.md) — Phase 4
-  additions, item 3 (the provider-swap MT).
-- [config/optimization.yaml](../../config/optimization.yaml) — `models.aliases.quality` (the
-  edited entry) and `models.aliases.quality-openai` (the priced OpenAI peer that demonstrates a
-  $0-trip-free swap target).
+  additions, item 3 (the provider-swap MT); and
+  [amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md) (config-driven, no default provider).
+- [config/demo/anthropic/optimization.yaml](../../config/demo/anthropic/optimization.yaml) and
+  [config/demo/openai/optimization.yaml](../../config/demo/openai/optimization.yaml) — the two
+  alias configs whose `quality` / `fast` / `summarizer` block is the entire swap delta.
 
 **Related Automated Tests**:
 - Python: `tests/unit/python/test_model_aliases.py` (resolver returns the alias's declared
@@ -66,17 +80,19 @@ mounted alias config; this test exercises the *user-facing* one-line edit to the
 
 ### Application State
 
-- ☐ Full stack up and healthy (as [MT-ALIAS-001](MT-ALIAS-001.md) Preconditions).
-- ☐ `make validate` exits 0 before and after the edit.
-- ☐ Working tree clean — the alias edit is **reverted** at the end of the test
-  (`git checkout config/optimization.yaml`).
+- ☐ `make demo-anthropic` up and healthy (the baseline, as [MT-ALIAS-001](MT-ALIAS-001.md)).
+- ☐ `make validate` exits 0 (base config).
+- ☐ If you demonstrate the swap by editing a config file in place (rather than switching demo
+  overlays), the edit is **reverted** at the end (`git checkout <the edited config>`) and the
+  working tree is clean. The demo-overlay swap mutates no tracked file.
 
 ### Test Data
 
-The stock `quality` alias resolves to `anthropic` / `claude-sonnet-4-6`. The shipped
-`quality-openai` alias resolves to `openai` / `gpt-4o` (priced, `2.50` / `10.00`) and is the
-reference target. This test edits the **`quality`** entry so the unchanged `ember-owl` (which
-references `quality`) follows the swap without touching the agent.
+The Anthropic alias config (`config/demo/anthropic`) resolves `quality` → `anthropic` /
+`claude-sonnet-4-6` (priced `3.00` / `15.00`); the OpenAI alias config (`config/demo/openai`)
+resolves `quality` → `openai` / `gpt-4o` (priced `2.50` / `10.00`). The unchanged `ember-owl`
+(which references `quality`) follows whichever provider the active `quality` entry names — without
+touching the agent, the routing defaults, or any code.
 
 ---
 
@@ -84,7 +100,7 @@ references `quality`) follows the swap without touching the agent.
 
 ### Step 1: Baseline — Confirm the Agent Routes to Anthropic
 
-**Action**: Drive one turn on the stock config and confirm the provider (per
+**Action**: With `make demo-anthropic` up, drive one turn and confirm the provider (per
 [MT-ALIAS-001](MT-ALIAS-001.md) Steps 3–5): `gen_ai.system=anthropic`,
 `gen_ai.request.model=claude-sonnet-4-6`, `model_alias=quality`.
 
@@ -95,32 +111,33 @@ references `quality`) follows the swap without touching the agent.
 
 ### Step 2: The One-Line Swap
 
-**Action**: Edit **only** the `quality` alias's `provider` + `model` (and its inline price to the
-swap target's list price) in `config/optimization.yaml`:
-
-```yaml
-  aliases:
-    quality:
-      provider: openai          # was: anthropic
-      model: gpt-4o             # was: claude-sonnet-4-6
-      input_per_1m_tokens: 2.50 # was: 3.00
-      output_per_1m_tokens: 10.00 # was: 15.00
-```
-
-Regenerate the derived Go pricing table if the swap introduces a physical model not already in
-`cost.pricing.models` (here `gpt-4o` is already present from the `quality-openai` peer, so the
-table is unchanged), run `make validate`, and recreate the agent containers so they re-resolve:
+**Action**: Re-point the society from Anthropic to OpenAI by switching to the OpenAI alias config —
+the v0.3.4 config-driven form of the one-line swap:
 
 ```bash
-make validate
-docker compose -f docker-compose.yaml up -d --force-recreate agent-ember-owl
+make demo-openai
 ```
 
-**Expected Result**: `make validate` exits 0. **No edit was made to `config/agents.yaml`, the
-routing defaults, or any agent code** — the swap is the alias edit alone.
+This mounts [`config/demo/openai/optimization.yaml`](../../config/demo/openai/optimization.yaml) in
+place of the Anthropic one. The **only** thing that differs between the two configs is the alias
+block (`quality` → `openai` / `gpt-4o`, priced `2.50` / `10.00`); `config/agents.yaml`, the routing
+defaults, and all agent code are identical:
+
+```bash
+diff <(grep -A4 'quality:' config/demo/anthropic/optimization.yaml) \
+     <(grep -A4 'quality:' config/demo/openai/optimization.yaml)
+```
+
+The equivalent **manual** one-line-class edit (without the demo overlay) is to flip the `quality`
+entry's `provider` / `model` / price in the active `config/optimization.yaml`, then
+`docker compose ... up -d --force-recreate agent-ember-owl`. The OpenAI physical model (`gpt-4o`) is
+already priced in the derived `cost.pricing.models` table, so no table regeneration is needed.
+
+**Expected Result**: The swap is confined to the alias block — **no edit** to `config/agents.yaml`,
+the routing defaults, or any agent code. `gpt-4o` is already in the derived pricing table.
 
 **Verification**:
-- [ ] Only the `quality` alias entry changed (`git diff --stat` shows one file)
+- [ ] The swap changes only the alias `provider` / `model` / price (the `diff` above is the whole delta)
 - [ ] `make validate` exits 0
 
 ---
@@ -163,19 +180,22 @@ table is derived from the alias map — not hand-keyed to the old physical model
 
 ---
 
-### Step 5: Revert
+### Step 5: Revert / Teardown
 
-**Action**:
+**Action**: The overlay swap mutates no tracked file — switch back to the baseline (or tear down):
 
 ```bash
-git checkout config/optimization.yaml
-make validate
-docker compose -f docker-compose.yaml up -d --force-recreate agent-ember-owl
+make demo-anthropic    # back on Anthropic
+# or: make docker-down
 git diff --quiet && echo "TREE CLEAN"
 ```
 
+If you used the **manual** in-place edit instead, revert it
+(`git checkout config/optimization.yaml` — or the edited demo config), `make validate`, and
+`--force-recreate agent-ember-owl`.
+
 **Verification**:
-- [ ] `config/optimization.yaml` restored; working tree clean
+- [ ] Working tree clean (no tracked config left edited)
 
 ---
 
@@ -184,10 +204,10 @@ git diff --quiet && echo "TREE CLEAN"
 | Step | Expected Outcome | Pass/Fail |
 |------|------------------|-----------|
 | 1 | Stock agent routes to Anthropic `claude-sonnet-4-6` | ☐ |
-| 2 | One-line alias edit only; `make validate` clean | ☐ |
+| 2 | Swap confined to the alias block (overlay switch or one-entry edit); `make validate` clean | ☐ |
 | 3 | Same agent now routes to OpenAI `gpt-4o`; alias name unchanged | ☐ |
 | 4 | Cost re-keyed to gpt-4o rate, non-zero, keyed to `ember-owl` | ☐ |
-| 5 | Config reverted; working tree clean | ☐ |
+| 5 | Working tree clean (overlay leaves no tracked edit; revert any in-place edit) | ☐ |
 
 ---
 
@@ -221,13 +241,14 @@ swap.
 | Date | Tester | OS | Result | Notes |
 |------|--------|----|--------|-------|
 | 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker Desktop | ✅ Pass | See [`v0.3.4-execution-report.md`](v0.3.4-execution-report.md#mt-alias-002--one-line-provider-swap-evidence-live). |
+| 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker 29.3.1 | ✅ Pass | **Config-driven re-run on HEAD `6ce23cd`**: baseline `make demo-anthropic` (`claude-sonnet-4-6`, `$0.008424`), swapped via `make demo-openai` — the same unchanged ember-owl now `reply_status="ok"` on OpenAI; cost `1887/17/$0.0048875`, **exactly** the `gpt-4o` rate (1887×$2.50/1M + 17×$10.00/1M; at the old sonnet rate it would have been $0.005916). Prometheus `agent_llm_calls_total{gen_ai_system="openai", gen_ai_request_model="gpt-4o"}=1`. `OPENAI_API_KEY` is now plumbed into agents by the base compose — the former F-5 throwaway-override gap is closed. |
 
 ---
 
 ## Notes
 
 - "One-line edit" is shorthand for *one alias entry*: provider + model (+ its inline price). The
-  point is that the edit is confined to the alias block — agents, routing defaults, pricing
-  table, and code are untouched.
-- Keep the swap reverted in version control; this MT mutates `config/optimization.yaml` only for
-  the duration of the run.
+  point is that the swap is confined to the alias block — agents, routing defaults, and code are
+  untouched (and `gpt-4o` is already in the derived pricing table).
+- The demo-overlay swap mutates no tracked file. If you demonstrate the swap by editing a config in
+  place instead, revert it (`git checkout`) so the working tree stays clean.

--- a/docs/manual-tests/MT-OFFLINE-001.md
+++ b/docs/manual-tests/MT-OFFLINE-001.md
@@ -7,28 +7,30 @@
 **Last Updated**: 2026-05-27
 **Status**: Active
 
-> **Recipe update pending (v0.3.4 release-prep).** Provider selection is now
-> purely config/alias-driven — the `PERSATRIX_OFFLINE` force-knob is **removed**
-> ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)). `make demo-offline`
-> still works, but it now selects the mock provider by mounting an alias config
-> ([`config/demo/offline/optimization.yaml`](../../config/demo/offline/optimization.yaml))
-> rather than setting an env flag — so the `PERSATRIX_OFFLINE=1` / throwaway-key
-> prose below is superseded. The recipe is refreshed with fresh live evidence in
-> the [release-prep PR 4 Docker smoke](../v0.3.4-release-checklist.md#1-pre-release-verification).
+> **v0.3.4 recipe — config-driven (no force-knob).** Provider selection is purely
+> config/alias-driven: `make demo-offline` selects the mock provider by mounting
+> [`config/demo/offline/optimization.yaml`](../../config/demo/offline/optimization.yaml)
+> (every alias → `provider: mock`) over the stack's `optimization.yaml` via a Compose
+> overlay — there is **no** `PERSATRIX_OFFLINE` force-knob
+> ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)). The steps below use
+> that config-driven recipe and were re-run live against the config-driven HEAD
+> (see [Test Results](#test-results)).
 
 ---
 
 ## Overview
 
 **Purpose**: Verify the keyless, zero-cost offline mode — *the whole society runs with no API
-key, no network egress, and no spend*. With `PERSATRIX_OFFLINE=1` (the `make demo-offline` knob),
-every agent routes to the in-process `MockProvider`, serving curated replies from
+key, no network egress, and no spend*. With `make demo-offline` (which mounts an alias config
+pointing every alias at `provider: mock`), every agent routes to the in-process `MockProvider`,
+serving curated replies from
 [`config/offline_responses.yaml`](../../config/offline_responses.yaml). A full chat round-trip
 must complete, populate the `gen_ai.*` spans, and settle the RFC 0023 wallet lease at **$0**.
 
-**Scope**: The offline force-flag path through
-[`agents/llm_factory.py`](../../agents/llm_factory.py) `create_provider()` (offline wins over
-every other selector, before the `model:` field is read) →
+**Scope**: The `provider: mock` path through
+[`agents/llm_factory.py`](../../agents/llm_factory.py) `create_provider()` — the resolved alias's
+`provider` field selects the concrete class, the *same standard path as every provider* (RFC 0033
+§D) →
 [`agents/llm_offline.py`](../../agents/llm_offline.py) `MockProvider` → the same span / wallet
 machinery a real provider uses, but with $0 pricing. Carried from
 [#422](https://github.com/mkhomutov/Persatrix/pull/422).
@@ -42,10 +44,15 @@ a real model); cloud-provider routing and alias swaps ([MT-ALIAS-001](MT-ALIAS-0
 ## Related Documentation
 
 **Feature Documentation**:
-- [docker-compose.offline.yaml](../../docker-compose.offline.yaml) — the overlay
-  (`PERSATRIX_OFFLINE=1` + `PERSATRIX_OFFLINE_RESPONSES` per agent).
+- [docker-compose.offline.yaml](../../docker-compose.offline.yaml) — the overlay (mounts
+  `config/demo/offline/optimization.yaml` + sets `PERSATRIX_OFFLINE_RESPONSES` per agent — that
+  env var is mock *configuration*, where to read replies, not a provider-selection knob).
+- [config/demo/offline/optimization.yaml](../../config/demo/offline/optimization.yaml) — the mock
+  alias config the overlay mounts (`quality` / `fast` / `summarizer` → `provider: mock`).
 - [Makefile](../../Makefile) `demo-offline` target.
-- [agents/llm_offline.py](../../agents/llm_offline.py) — `MockProvider`, `offline_mode_enabled()`.
+- [agents/llm_factory.py](../../agents/llm_factory.py) — `create_provider()` (the `provider: mock`
+  branch).
+- [agents/llm_offline.py](../../agents/llm_offline.py) — `MockProvider`, `MockProvider.from_config()`.
 - [config/offline_responses.yaml](../../config/offline_responses.yaml) — curated per-agent
   replies + persona-flavoured fallback.
 
@@ -64,9 +71,9 @@ a real model); cloud-provider routing and alias swaps ([MT-ALIAS-001](MT-ALIAS-0
 ### System Requirements
 
 - ☐ Windows / macOS / Linux with Docker + Docker Compose
-- ☐ **No API key required.** `make demo-offline` passes a throwaway
-  `ANTHROPIC_API_KEY=offline-not-used` only to satisfy the base compose file's `:?` key-guard;
-  it is never used (offline routing precedes any provider SDK construction).
+- ☐ **No API key required.** The base compose plumbs every provider key with a `:-` empty default
+  (the single-vendor `:?` startup guard was dropped in v0.3.4), and the mock provider constructs no
+  SDK and makes no network call — so no key, throwaway or real, is needed.
 - ☐ `curl` + `jq` in PATH.
 
 ### Application State
@@ -93,13 +100,13 @@ make demo-offline
 docker compose -f docker-compose.yaml -f docker-compose.offline.yaml ps
 ```
 
-**Expected Result**: The stack builds and comes up healthy with `PERSATRIX_OFFLINE=1` per agent.
-Agent logs show `LLM offline mode active for agent '<id>' — using MockProvider (no API calls, no
-cost)`.
+**Expected Result**: The stack builds and comes up healthy with the mock alias config mounted.
+Agent logs show `Offline mock provider active for agent '<id>' — using MockProvider (no API calls,
+no cost)`.
 
 **Verification**:
 - [ ] All agents healthy
-- [ ] `LLM offline mode active … MockProvider` logged for each agent
+- [ ] `Offline mock provider active … MockProvider` logged for each agent
 
 ---
 
@@ -189,12 +196,15 @@ goes through the same span machinery, so observability is intact even with no pr
 **Expected Behavior**: The turn degrades gracefully to a generated persona-flavoured placeholder
 reply — still `reply_status="ok"`, still $0.
 
-### Edge Case 2: Offline + Ollama Both Set
+### Edge Case 2: A Real Provider Key Is Present in the Environment
 
-**Scenario**: Both `PERSATRIX_OFFLINE=1` and `PERSATRIX_OLLAMA=1` are exported.
+**Scenario**: A real `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` is exported while the mock alias
+config is mounted.
 
-**Expected Behavior**: Offline wins (it needs neither a network nor a running daemon) — the
-factory checks offline first. Covered by `test_llm_offline.py`.
+**Expected Behavior**: Ignored — provider selection is the resolved alias `provider` (here
+`mock`), not key presence. The factory constructs `MockProvider`, builds no provider SDK, and
+makes no network call. Covered by `test_llm_offline.py` (the factory-interplay regression: an
+alias declaring `provider: mock` routes to the mock regardless of the environment).
 
 ---
 
@@ -203,12 +213,14 @@ factory checks offline first. Covered by `test_llm_offline.py`.
 | Date | Tester | OS | Result | Notes |
 |------|--------|----|--------|-------|
 | 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker Desktop | ✅ Pass | See [`v0.3.4-execution-report.md`](v0.3.4-execution-report.md#mt-offline-001--offline-0-evidence-live). |
+| 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker 29.3.1 | ✅ Pass | **Config-driven re-run on HEAD `6ce23cd`** (`make demo-offline`): log `Offline mock provider active for agent 'ember-owl' — using MockProvider (no API calls, no cost)`; chat turn `reply_status="ok"` with the curated `["flaky"]` reply; cost `1600/146/$0` keyed to ember-owl; Prometheus `agent_llm_calls_total{gen_ai_system="mock", gen_ai_request_model="offline"}=1`. |
 
 ---
 
 ## Notes
 
-- The throwaway `ANTHROPIC_API_KEY` in `make demo-offline` only satisfies the base compose `:?`
-  guard, which Compose evaluates before the overlay merges; it is never consumed.
+- `make demo-offline` needs no key: the base compose plumbs provider keys with a `:-` empty
+  default (the single-vendor `:?` startup guard was dropped in v0.3.4), and the mock provider
+  builds no SDK.
 - Offline mode is the "$0 keyless demo" promise; Ollama is the "$0 real-model" promise. Both sit
-  on the same provider-selection axis (`create_provider`).
+  on the same provider-selection axis (the resolved alias `provider` in `create_provider`).

--- a/docs/manual-tests/MT-OLLAMA-001.md
+++ b/docs/manual-tests/MT-OLLAMA-001.md
@@ -7,15 +7,15 @@
 **Last Updated**: 2026-05-27
 **Status**: Active
 
-> **Recipe update pending (v0.3.4 release-prep).** Provider selection is now
-> purely config/alias-driven — the `PERSATRIX_OLLAMA` force-knob is **removed**
-> ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)). `make demo-ollama`
-> still works, but it now selects the Ollama provider by mounting an alias config
-> ([`config/demo/ollama/optimization.yaml`](../../config/demo/ollama/optimization.yaml))
-> rather than setting an env flag — so the `PERSATRIX_OLLAMA=1` / throwaway-key
-> prose below is superseded (`PERSATRIX_OLLAMA_MODEL` / `PERSATRIX_OLLAMA_BASE_URL`
-> survive as provider configuration). The recipe is refreshed with fresh live
-> evidence in the [release-prep PR 4 Docker smoke](../v0.3.4-release-checklist.md#1-pre-release-verification).
+> **v0.3.4 recipe — config-driven (no force-knob).** Provider selection is purely
+> config/alias-driven: `make demo-ollama` selects the Ollama provider by mounting
+> [`config/demo/ollama/optimization.yaml`](../../config/demo/ollama/optimization.yaml)
+> (every alias → `provider: ollama`, with the daemon `base_url`) over the stack's
+> `optimization.yaml` — there is **no** `PERSATRIX_OLLAMA` force-knob
+> ([amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)).
+> `PERSATRIX_OLLAMA_MODEL` / `PERSATRIX_OLLAMA_BASE_URL` survive as provider
+> *configuration* (not selection). The steps below use that config-driven recipe and
+> were re-run live against the config-driven HEAD (see [Test Results](#test-results)).
 
 ---
 
@@ -23,14 +23,15 @@
 
 **Purpose**: Verify the keyless, free *real-model* path — *the whole society runs on a model
 served locally by Ollama, with no API key and no per-token cloud spend*. With
-`PERSATRIX_OLLAMA=1` (the `make demo-ollama` knob), every agent routes to the
-`OllamaProvider` (a thin OpenAI-compatible subclass) pointed at the bundled `ollama` service.
-A chat turn must complete with **real** token counts (a real model generated the reply) while
-`daily_estimated_usd` stays at **$0** (local model is $0-real cost).
+`make demo-ollama` (which mounts an alias config pointing every alias at `provider: ollama`),
+every agent routes to the `OllamaProvider` (a thin OpenAI-compatible subclass) pointed at the
+bundled `ollama` service. A chat turn must complete with **real** token counts (a real model
+generated the reply) while `daily_estimated_usd` stays at **$0** (local model is $0-real cost).
 
-**Scope**: The Ollama force-flag path through
-[`agents/llm_factory.py`](../../agents/llm_factory.py) `create_provider()` (checked after
-offline, before the `model:` field; force-substitutes the single pulled model) →
+**Scope**: The `provider: ollama` path through
+[`agents/llm_factory.py`](../../agents/llm_factory.py) `create_provider()` — the resolved alias's
+`provider` field selects the concrete class (RFC 0033 §D), and the alias `model:` is the Ollama
+tag (overridable per-agent by `PERSATRIX_OLLAMA_MODEL`) →
 [`agents/llm_ollama.py`](../../agents/llm_ollama.py) `OllamaProvider` → the bundled `ollama`
 service's OpenAI-compatible `/v1` endpoint. Carried from
 [#423](https://github.com/mkhomutov/Persatrix/pull/423).
@@ -47,12 +48,16 @@ spend, not answer quality.
 
 **Feature Documentation**:
 - [docker-compose.ollama.yaml](../../docker-compose.ollama.yaml) — the overlay (`ollama` service
-  + one-shot `ollama-pull` gate + `PERSATRIX_OLLAMA=1` / `PERSATRIX_OLLAMA_MODEL` /
-  `PERSATRIX_OLLAMA_BASE_URL` per agent).
+  + one-shot `ollama-pull` gate; mounts `config/demo/ollama/optimization.yaml`;
+  `PERSATRIX_OLLAMA_MODEL` / `PERSATRIX_OLLAMA_BASE_URL` per agent as provider *configuration*).
+- [config/demo/ollama/optimization.yaml](../../config/demo/ollama/optimization.yaml) — the Ollama
+  alias config the overlay mounts (`quality` / `fast` / `summarizer` → `provider: ollama`, with the
+  daemon `base_url`).
 - [Makefile](../../Makefile) `demo-ollama` target (default model `llama3.2`; override with
   `PERSATRIX_OLLAMA_MODEL`).
-- [agents/llm_ollama.py](../../agents/llm_ollama.py) — `OllamaProvider`,
-  `ollama_mode_enabled()`, `resolve_ollama_base_url()`, `resolve_ollama_model()`.
+- [agents/llm_factory.py](../../agents/llm_factory.py) — `create_provider()` (the `provider: ollama`
+  branch; applies the `PERSATRIX_OLLAMA_MODEL` override).
+- [agents/llm_ollama.py](../../agents/llm_ollama.py) — `OllamaProvider`, `resolve_ollama_base_url()`.
 
 **Related Automated Tests**:
 - Python: `tests/unit/python/test_llm_ollama.py` (OllamaProvider + factory-interplay regression —
@@ -68,9 +73,10 @@ spend, not answer quality.
 ### System Requirements
 
 - ☐ Windows / macOS / Linux with Docker + Docker Compose
-- ☐ **No API key required.** `make demo-ollama` passes a throwaway
-  `ANTHROPIC_API_KEY=ollama-not-used` only to satisfy the base compose `:?` key-guard; the
-  per-agent `PERSATRIX_OLLAMA=1` routes every agent to the local daemon.
+- ☐ **No API key required.** The base compose plumbs every provider key with a `:-` empty default
+  (the single-vendor `:?` startup guard was dropped in v0.3.4), and Ollama ignores auth — so no key,
+  throwaway or real, is needed. The mounted `provider: ollama` alias config routes every agent to
+  the local daemon.
 - ☐ Disk space for the model (the first `up` pulls a few GB into the `ollama-models` volume).
 - ☐ `curl` + `jq` in PATH.
 
@@ -99,13 +105,16 @@ make demo-ollama
 docker exec persatrix-ollama-1 ollama list
 ```
 
-**Expected Result**: The `ollama` service is healthy, `ollama-pull` completed, and agents started
-with `LLM Ollama mode active for agent '<id>' — using OllamaProvider at http://ollama:11434/v1
-(local model 'llama3.2', no cloud calls)`. `ollama list` shows the model present.
+**Expected Result**: The `ollama` service is healthy, `ollama-pull` completed, and `ollama list`
+shows the configured model present. The agents start cleanly with **no** raw-ID deprecation warning
+and **no** `OPENAI_API_KEY not set` warning (the alias routes to `provider: ollama`, which needs no
+key). **Note**: the `ollama` branch of `create_provider()` emits **no** provider-selection startup
+log line (unlike the `mock` branch) — confirm routing in Step 4 via the `gen_ai.system=ollama`
+telemetry, not a boot log.
 
 **Verification**:
 - [ ] Configured model present in `ollama list`
-- [ ] Each agent logged `LLM Ollama mode active … OllamaProvider`
+- [ ] Agents healthy with no raw-ID / key warning (routing is confirmed by telemetry in Step 4)
 
 ---
 
@@ -129,16 +138,21 @@ curl -s http://127.0.0.1:8080/api/v1/cost/summary | tee /tmp/ollama-cost-before.
 ```bash
 curl -s -X POST "http://127.0.0.1:8080/api/v1/agents/ember-owl/chat" \
   -H "Content-Type: application/json" \
-  -d '{"message":"Give me a one-line status update for the sprint.","user_id":"local","timeout_seconds":120}' \
+  -d '{"message":"Reply with exactly one short sentence: what is your sprint priority?","user_id":"local","timeout_seconds":280}' \
   | jq '{reply_status, reply}'
 ```
 
 **Expected Result**: HTTP 200, `reply_status="ok"`, a non-empty reply **generated by the local
-model** (free-form, not a curated string). **On CPU, pass `timeout_seconds` (the chat endpoint
-clamps it to ≤ 300 s — [`chat_handler.go`](../../internal/server/chat_handler.go))**: the chat
-default is 30 s, and CPU-only inference of a full-length generation runs past it (you would otherwise
-get `DEADLINE_EXCEEDED` — "agent did not respond in time"). The first turn also pays a one-time model
-load (~8 s). On a GPU the default 30 s is usually enough.
+model** (free-form, not a curated string). **On CPU, pass a generous `timeout_seconds` (the chat
+endpoint clamps it to ≤ 300 s — [`chat_handler.go`](../../internal/server/chat_handler.go))**: the
+chat default is 30 s, and CPU-only inference runs well past it (you would otherwise get
+`DEADLINE_EXCEEDED` — "agent did not respond in time"). CPU latency is highly variable — a small
+model that ignores a length instruction and generates to its `max_tokens` cap can exceed even
+120 s, so **constrain the output** (the prompt above asks for one short sentence) and use a high
+`timeout_seconds`. The first turn also pays a one-time model load (~8 s); a warm turn is much
+faster. On a GPU the default 30 s is usually enough. Reply *quality* is not asserted — a small
+local model may emit a weak or malformed answer; this step checks routing, real tokens, and
+`reply_status="ok"`.
 
 **Verification**:
 - [ ] `reply_status="ok"` with a non-empty, model-generated reply
@@ -186,12 +200,17 @@ priced $0-real (no per-token cloud charge).
 (`service_completed_successfully`), so the first chat turn never races a missing model — it
 waits for the pull rather than failing.
 
-### Edge Case 2: Offline + Ollama Both Set
+### Edge Case 2: `PERSATRIX_OLLAMA_MODEL` Override
 
-**Scenario**: Both `PERSATRIX_OFFLINE=1` and `PERSATRIX_OLLAMA=1` are exported.
+**Scenario**: `PERSATRIX_OLLAMA_MODEL` is set to a non-default tag.
 
-**Expected Behavior**: Offline wins (the mock needs no daemon) — every agent uses `MockProvider`,
-not Ollama. Covered by `test_llm_ollama.py` / `test_llm_offline.py`.
+**Expected Behavior**: `create_provider()` substitutes that tag for every agent it builds, in
+lock-step with the `ollama-pull` service (which pulls the same tag). **Caveat**: the override does
+**not** reach the summarisation-on-close model, which resolves the `summarizer` alias on a separate
+surface — match the three `model:` fields in the mounted config too, or summarisation-on-close
+degrades to its fallback
+([ISSUE-0075](../issues/ISSUE-0075-ollama-model-override-misses-summarization-surface.md)).
+Covered by `test_llm_ollama.py`.
 
 ---
 
@@ -200,6 +219,7 @@ not Ollama. Covered by `test_llm_ollama.py` / `test_llm_offline.py`.
 | Date | Tester | OS | Result | Notes |
 |------|--------|----|--------|-------|
 | 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker Desktop | ✅ Pass | See [`v0.3.4-execution-report.md`](v0.3.4-execution-report.md#mt-ollama-001--ollama-local-model-evidence-live). `system=ollama`/`llama3.2`, real tokens (1232/4096) at $0 cloud, `reply_status="ok"` in ~93 s with `timeout_seconds:120`. (The default 30 s chat timeout is too short for CPU inference — [ISSUE-0073](../issues/ISSUE-0073-cpu-local-model-chat-exceeds-default-timeout.md).) |
+| 2026-05-27 | Claude (Opus 4.7) | Windows 11 + Docker 29.3.1 | ✅ Pass | **Config-driven re-run on HEAD `6ce23cd`** (`make demo-ollama`): `ollama list` shows `llama3.2:latest` (2.0 GB); the `ollama` branch logs **no** startup line (confirmed); real tokens (cumulative `3479/8192`) at **$0** cloud; Prometheus `agent_llm_calls_total{gen_ai_system="ollama", gen_ai_request_model="llama3.2"}=1`. A verbose turn at `timeout_seconds:120` hit `DEADLINE_EXCEEDED` (the model generated to its 4096-token cap); a constrained warm turn at `timeout_seconds:280` returned `reply_status="ok"` in ~10 s. CPU-latency caveat tracked as [ISSUE-0073](../issues/ISSUE-0073-cpu-local-model-chat-exceeds-default-timeout.md). |
 
 ---
 
@@ -209,5 +229,6 @@ not Ollama. Covered by `test_llm_ollama.py` / `test_llm_offline.py`.
   once. To reclaim the space, pass the overlay explicitly to `down -v`.
 - The agents reach the daemon over the compose bridge at `http://ollama:11434/v1`, not
   `localhost` — `PERSATRIX_OLLAMA_BASE_URL` is set per agent in the overlay.
-- Default model is `llama3.2`; set `PERSATRIX_OLLAMA_MODEL` to change it (the alias map's
-  `local-fast` entry names `llama3.1` for the per-agent opt-in path, a separate surface).
+- Default model is `llama3.2` (the tag the mounted `config/demo/ollama/optimization.yaml` names
+  and `ollama-pull` pulls); set `PERSATRIX_OLLAMA_MODEL` to change it — keep the pull and the alias
+  `model:` fields in step (see Edge Case 2).

--- a/docs/manual-tests/v0.3.4-execution-report.md
+++ b/docs/manual-tests/v0.3.4-execution-report.md
@@ -1,10 +1,22 @@
 # v0.3.4 Manual Test Execution Report
 
 **Version**: v0.3.4 (Any Model, Any Provider — RFC 0033 Phases 1–2 + the already-merged offline / Ollama provider work)
-**Report status**: ✅ Complete — release gate **met** (primary [`MT-ALIAS-001`](MT-ALIAS-001.md) acceptance reached live; the automated alias cost-attribution gate green on the RC tip; offline + Ollama paths verified live)
+**Report status**: ✅ Complete — release gate **met** (primary [`MT-ALIAS-001`](MT-ALIAS-001.md) acceptance reached live; the automated alias cost-attribution gate green; offline + Ollama paths verified live)
 **Tester**: Claude (Opus 4.7) — automated suites + local builds + live Docker stack
-**Execution date**: 2026-05-27
-**Target commit**: `main` tip `7e74873` ([v0.3.4 release-prep plan PR 1](../v0.3.4-release-prep-plan.md#pr-1--manual-test-execution-report-v034-surface)) — the RFC 0033 Phases 1–2 workstream fully merged ([#431](https://github.com/mkhomutov/Persatrix/pull/431)–[#437](https://github.com/mkhomutov/Persatrix/pull/437)); working tree clean apart from this PR's new MT docs.
+**Execution date**: 2026-05-27 (original run); re-verified config-driven 2026-05-27
+**Target commit**: originally executed on `main` tip `7e74873` ([v0.3.4 release-prep plan PR 1](../v0.3.4-release-prep-plan.md#pr-1--manual-test-execution-report-v034-surface)) — RFC 0033 Phases 1–2 fully merged ([#431](https://github.com/mkhomutov/Persatrix/pull/431)–[#437](https://github.com/mkhomutov/Persatrix/pull/437)).
+
+> **⚠️ Re-verified on HEAD `6ce23cd` (config-driven).** The four new-this-release legs below were
+> originally executed on `7e74873`, **before** the knob-free provider-selection refactor
+> ([#440](https://github.com/mkhomutov/Persatrix/pull/440), [amendment 2026-05-27](../v0.3.4-plan-amendment-2026-05-27.md)).
+> That refactor removed the `PERSATRIX_OFFLINE` / `PERSATRIX_OLLAMA` force-knobs, made the base
+> config ship **unconfigured** (no default provider), moved each provider into a mounted
+> `config/demo/<provider>/optimization.yaml`, and changed the offline log string (the Ollama branch
+> emits none). The four legs were **re-run live in their config-driven form on HEAD** — all still
+> ✅ Pass. The authoritative current evidence is in
+> [§ Config-driven re-run (HEAD `6ce23cd`)](#config-driven-re-run-head-6ce23cd); the per-leg
+> evidence sections further below are the original `7e74873` record (env-knob mechanism + old log
+> strings), retained for history and flagged where superseded.
 
 ---
 
@@ -57,14 +69,16 @@ This report executes the **v0.3.4 manual surface — 38 rows** (4 new + 34 carri
 | Docker | 29.3.1 |
 | Stack | `docker compose build` + `up -d` — orchestrator + 6 agents (planner, code-writer, code-reviewer, ember-owl, iron-fox, nova-sparrow) + otel-collector + jaeger + prometheus + loki; rebuilt from `7e74873` (the prior images were 4 days stale, predating the RFC 0033 PRs). |
 
-**Operator note ([F-3], carry-forward of v0.3.3 F-3 / v0.3.2 F-4)**: an *empty* `ANTHROPIC_API_KEY`
-exported in the shell shadows the populated `.env` under Compose interpolation precedence — every
-`docker compose build`/`up` in this run was prefixed with `unset ANTHROPIC_API_KEY` so Compose reads
-`.env`. **New this run ([F-5])**: the agent services in `docker-compose.yaml` plumb only
-`ANTHROPIC_API_KEY` into the container env — there is no `OPENAI_API_KEY` — so a config-only provider
-swap to a cloud-OpenAI alias does not authenticate in stock Docker without also threading the key.
-This is exactly the provider-neutral onboarding gap [release-prep PR 2](../v0.3.4-release-prep-plan.md#pr-2--readme--roadmap--model-aliasprovider-guide--provider-neutral-onboarding--release-checklist)
-is scoped to close; see [§ Follow-ups](#follow-ups).
+**Operator note ([F-3], carry-forward of v0.3.3 F-3 / v0.3.2 F-4)**: an *empty* (or stale) provider
+key exported in the shell shadows the populated `.env` under Compose interpolation precedence — every
+`docker compose build`/`up` in the config-driven re-run was prefixed with
+`unset ANTHROPIC_API_KEY OPENAI_API_KEY` so Compose reads `.env`. The v0.3.4 `:-` empty defaults mean
+an empty value no longer aborts `up` (it logs an unset-key warning instead). **[F-5] — resolved on HEAD
+`6ce23cd`**: the original `7e74873` run found the agent services plumbed only `ANTHROPIC_API_KEY` (no
+`OPENAI_API_KEY`), so a cloud-OpenAI swap needed a throwaway override;
+[#440](https://github.com/mkhomutov/Persatrix/pull/440) now plumbs **both** keys into every agent and
+the config-driven re-run's `make demo-openai` leg authenticated with no override. See
+[§ Follow-ups](#follow-ups).
 
 ---
 
@@ -126,7 +140,36 @@ counterpart (the alias cost-attribution gate) is green on the RC tip.
 
 ---
 
+## Config-driven re-run (HEAD `6ce23cd`)
+
+Re-executed live on HEAD `6ce23cd` (the knob-free config-driven tip) on 2026-05-27, Windows 11 +
+Docker 29.3.1. The stack was rebuilt and brought up in four configurations, each selected the
+**config-driven** way — `make demo-<provider>` mounts `config/demo/<provider>/optimization.yaml`
+over the stack config; there is no force-knob and no default provider. Each `up` came up healthy
+(`/healthz` → `{"status":"ok"}`, all 6 agents `healthy`). **All four legs ✅ Pass.**
+
+| Leg (recipe) | Routing evidence on HEAD | Turn | Cost (lag-free `/cost/summary`) | Prometheus series |
+|---|---|---|---|---|
+| **Offline** (`make demo-offline`) | log `Offline mock provider active for agent 'ember-owl' — using MockProvider (no API calls, no cost)` — **not** the old `LLM offline mode active …` | `reply_status="ok"`, curated `["flaky"]` reply | `1600 / 146 / $0` keyed to ember-owl | `{gen_ai_system="mock", gen_ai_request_model="offline"}=1` (was `…model="quality"` on `7e74873`) |
+| **Anthropic** (`make demo-anthropic`) | no raw-ID / key warning → alias-routed `quality` → `claude-sonnet-4-6` | `reply_status="ok"` ("Ship v2.0 on time …") | `2708 / 20 / $0.008424` = **exactly** the sonnet rate (2708×$3.00/1M + 20×$15.00/1M), keyed to ember-owl | `{gen_ai_system="anthropic", gen_ai_request_model="claude-sonnet-4-6"}=1` |
+| **OpenAI swap** (`make demo-openai`) | same unchanged ember-owl re-routed; no `OPENAI_API_KEY not set` warning (**F-5 closed** — base compose now plumbs `OPENAI_API_KEY`) | `reply_status="ok"` | `1887 / 17 / $0.0048875` = **exactly** the gpt-4o rate (1887×$2.50/1M + 17×$10.00/1M; the old sonnet rate would have been $0.005916 — cost followed the swap) | `{gen_ai_system="openai", gen_ai_request_model="gpt-4o"}=1` |
+| **Ollama** (`make demo-ollama`) | `ollama list` shows `llama3.2:latest` (2.0 GB); the `ollama` branch emits **no** startup log (routing confirmed by telemetry, **not** the old `LLM Ollama mode active …`) | `reply_status="ok"` on a constrained warm turn (`timeout_seconds:280`, ~10 s); a verbose turn at `timeout_seconds:120` hit `DEADLINE_EXCEEDED` (generated to its 4096-token cap) | cumulative `3479 / 8192 / $0` (real tokens, $0 cloud) | `{gen_ai_system="ollama", gen_ai_request_model="llama3.2"}=1` |
+
+**Mechanism / doc corrections folded into the four MT specs** (all now match HEAD):
+
+- `PERSATRIX_OFFLINE` / `PERSATRIX_OLLAMA` force-knobs **removed** — every provider is selected by the resolved alias `provider` field via a mounted `config/demo/<provider>` config.
+- Offline log is `Offline mock provider active for agent '<id>' — using MockProvider (no API calls, no cost)`; the Ollama branch logs **nothing** at provider selection.
+- The base `config/optimization.yaml` ships `quality` / `fast` / `summarizer` **unconfigured** — a plain `docker compose up` (no demo) fails loud; there is no priced default and no `quality-openai` peer alias.
+- The single-vendor `:?` startup guard was dropped (keys use `:-` empty defaults); the base compose plumbs **both** `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` into every agent — **F-5 is closed** (the OpenAI leg no longer needs a throwaway compose override).
+- The two Go alias-gate tests (`cost_alias_gate_test.go` / `cost_alias_pricing_test.go`, now loading `config/demo/anthropic`) and the alias/provider/pricing Python unit slices (128 tests) PASS on HEAD; the full Go internal suite is green.
+
+The four ⚠️ Accepted-with-known-gap + 1 ⊘ Deprecated outcomes are unchanged carried-forward v0.3.3 rows.
+
+---
+
 ## MT-ALIAS-001 — primary gate evidence (live)
+
+> **⚠️ Original `7e74873` record — superseded by [§ Config-driven re-run (HEAD `6ce23cd`)](#config-driven-re-run-head-6ce23cd).** The per-step evidence below was captured on `7e74873` (pre-#440); the figures and the `unset ANTHROPIC_API_KEY` note still describe that run. On HEAD the same outcome holds via `make demo-anthropic` (`2708 / 20 / $0.008424` at the sonnet rate).
 
 Subject: **ember-owl** (`model: "quality"` → resolves to physical `claude-sonnet-4-6`). Base stack,
 Anthropic key from `.env` (shell `unset ANTHROPIC_API_KEY` first — see [F-3](#follow-ups)).
@@ -147,6 +190,8 @@ annotation.
 ---
 
 ## MT-ALIAS-002 — one-line provider swap evidence (live)
+
+> **⚠️ Original `7e74873` record — superseded by [§ Config-driven re-run (HEAD `6ce23cd`)](#config-driven-re-run-head-6ce23cd).** Below, the swap is an in-place edit to `config/optimization.yaml` and the OpenAI leg needs a throwaway `OPENAI_API_KEY` compose override — both pre-#440. On HEAD the swap is `make demo-anthropic` → `make demo-openai` (mounted alias configs), `OPENAI_API_KEY` is plumbed by the base compose (no override), and the re-keyed cost is `1887 / 17 / $0.0048875` at the gpt-4o rate.
 
 Subject: the same **ember-owl**, swapping the **`quality`** alias from Anthropic to OpenAI. Because the
 stock `docker-compose.yaml` plumbs only `ANTHROPIC_API_KEY` into the agent ([F-5](#follow-ups)), a
@@ -169,6 +214,8 @@ plumbed — [F-5](#follow-ups), which provider-neutral onboarding in [release-pr
 
 ## MT-OFFLINE-001 — offline $0 evidence (live)
 
+> **⚠️ Original `7e74873` record — superseded by [§ Config-driven re-run (HEAD `6ce23cd`)](#config-driven-re-run-head-6ce23cd).** Below uses the removed `PERSATRIX_OFFLINE=1` knob and quotes the old log line `LLM offline mode active …`. On HEAD `make demo-offline` mounts `config/demo/offline` and the log is `Offline mock provider active for agent 'ember-owl' — using MockProvider (no API calls, no cost)`; the turn re-ran `1600 / 146 / $0` with `gen_ai_request_model="offline"`.
+
 Stack switched to the offline overlay (equivalent to `make demo-offline`:
 `ANTHROPIC_API_KEY=offline-not-used PERSATRIX_OFFLINE=1 docker compose … -f docker-compose.offline.yaml up -d --build`).
 
@@ -186,6 +233,8 @@ populated `gen_ai.*` telemetry, zero spend, zero egress.
 ---
 
 ## MT-OLLAMA-001 — Ollama local model evidence (live)
+
+> **⚠️ Original `7e74873` record — superseded by [§ Config-driven re-run (HEAD `6ce23cd`)](#config-driven-re-run-head-6ce23cd).** Below uses the removed `PERSATRIX_OLLAMA` knob and quotes a `LLM Ollama mode active …` log line that no longer exists (the `ollama` branch emits no startup log on HEAD; routing is confirmed by `gen_ai.system=ollama` telemetry + `ollama list`). On HEAD `make demo-ollama` mounts `config/demo/ollama`; real tokens (cumulative `3479 / 8192`) at `$0` cloud, `reply_status="ok"` on a constrained warm turn at `timeout_seconds:280`.
 
 Stack switched to the Ollama overlay (equivalent to `make demo-ollama`:
 `ANTHROPIC_API_KEY=ollama-not-used docker compose … -f docker-compose.ollama.yaml up -d --build`),
@@ -216,10 +265,10 @@ Outcome legend: ✅ Pass · ⚠️ Accepted-with-known-gap · ⊘ Deprecated · 
 
 | Test ID | Title | Outcome | Notes / Evidence |
 |---------|-------|---------|------------------|
-| [MT-ALIAS-001](MT-ALIAS-001.md) | Alias-routed agent reports correctly-keyed cost | ✅ **Pass** | See [§ MT-ALIAS-001 evidence](#mt-alias-001--primary-gate-evidence-live). Live: `$0.005775` priced at the physical `claude-sonnet-4-6` rate, keyed to ember-owl. Automated gate (`cost_alias_gate_test.go` / `cost_alias_pricing_test.go`) green on the RC tip. |
-| [MT-ALIAS-002](MT-ALIAS-002.md) | One-line provider swap | ✅ **Pass** | See [§ MT-ALIAS-002 evidence](#mt-alias-002--one-line-provider-swap-evidence-live). Live: one alias edit re-routed the same agent to `gpt-4o`; cost re-keyed to the gpt-4o rate; reverted clean. ([F-5](#follow-ups): the cloud leg needed `OPENAI_API_KEY` plumbed.) |
-| [MT-OFFLINE-001](MT-OFFLINE-001.md) | Offline mode — $0, zero network | ✅ **Pass** | See [§ MT-OFFLINE-001 evidence](#mt-offline-001--offline-0-evidence-live). Live: curated reply, `$0`, `system=mock`. `test_llm_offline.py` green in the unit run. |
-| [MT-OLLAMA-001](MT-OLLAMA-001.md) | Ollama local model — real tokens, $0 cloud | ✅ **Pass** | See [§ MT-OLLAMA-001 evidence](#mt-ollama-001--ollama-local-model-evidence-live). Live: `system=ollama`/`llama3.2`, real tokens (1232/4096) at $0 cloud, `reply_status="ok"` in ~93 s with `timeout_seconds:120`. The 30 s chat *default* is too short for CPU inference — tracked as [ISSUE-0073](../issues/ISSUE-0073-cpu-local-model-chat-exceeds-default-timeout.md) ([F-6](#follow-ups)). `test_llm_ollama.py` green in the unit run. |
+| [MT-ALIAS-001](MT-ALIAS-001.md) | Alias-routed agent reports correctly-keyed cost | ✅ **Pass** | **HEAD `6ce23cd` (config-driven, `make demo-anthropic`)**: `2708 / 20 / $0.008424`, exactly the physical `claude-sonnet-4-6` rate, keyed to ember-owl; both Go gate tests (`cost_alias_gate_test.go` / `cost_alias_pricing_test.go`, loading `config/demo/anthropic`) PASS. See [§ Config-driven re-run](#config-driven-re-run-head-6ce23cd). Original `7e74873` figure was `$0.005775` (pre-#440). |
+| [MT-ALIAS-002](MT-ALIAS-002.md) | One-line provider swap | ✅ **Pass** | **HEAD `6ce23cd`**: `make demo-anthropic` → `make demo-openai` re-routed the same unchanged agent to `gpt-4o`; cost `1887 / 17 / $0.0048875` re-keyed at the gpt-4o rate. **[F-5](#follow-ups) now closed** — `OPENAI_API_KEY` is plumbed into agents by the base compose, no throwaway override. See [§ Config-driven re-run](#config-driven-re-run-head-6ce23cd). |
+| [MT-OFFLINE-001](MT-OFFLINE-001.md) | Offline mode — $0, zero network | ✅ **Pass** | **HEAD `6ce23cd` (`make demo-offline`)**: log `Offline mock provider active …`, curated `["flaky"]` reply, `1600 / 146 / $0`, `gen_ai_system="mock"`/`gen_ai_request_model="offline"`. `test_llm_offline.py` green. See [§ Config-driven re-run](#config-driven-re-run-head-6ce23cd). |
+| [MT-OLLAMA-001](MT-OLLAMA-001.md) | Ollama local model — real tokens, $0 cloud | ✅ **Pass** | **HEAD `6ce23cd` (`make demo-ollama`)**: `system=ollama`/`llama3.2`, real tokens (cumulative `3479 / 8192`) at $0 cloud; no `ollama` startup log (routing via telemetry). `reply_status="ok"` on a constrained warm turn at `timeout_seconds:280`; a verbose turn at `timeout_seconds:120` hit `DEADLINE_EXCEEDED` — CPU-latency caveat tracked as [ISSUE-0073](../issues/ISSUE-0073-cpu-local-model-chat-exceeds-default-timeout.md) ([F-6](#follow-ups)). `test_llm_ollama.py` green. See [§ Config-driven re-run](#config-driven-re-run-head-6ce23cd). |
 
 ### Carried-forward v0.3.3 + v0.3.2 surface — regression
 
@@ -269,10 +318,14 @@ paths under the alias-routed config. The "prior ref" is the outcome in
 
 ## Follow-ups
 
-- **F-5 — `docker-compose.yaml` plumbs only `ANTHROPIC_API_KEY` into agents** (new this run; severity:
-  medium for the provider-parity story; **not a release-blocker**). A config-only provider swap to a
-  cloud-OpenAI alias does not authenticate end-to-end in stock Docker because no `OPENAI_API_KEY` is
-  threaded into the agent containers — the MT-ALIAS-002 OpenAI leg needed a throwaway compose override.
+- **F-5 — `docker-compose.yaml` plumbs only `ANTHROPIC_API_KEY` into agents** — ✅ **RESOLVED on HEAD
+  `6ce23cd`** ([#440](https://github.com/mkhomutov/Persatrix/pull/440)). The base compose now plumbs
+  **both** `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` into every agent (each with a `:-` empty default);
+  the config-driven re-run's `make demo-openai` leg authenticated end-to-end with **no** throwaway
+  override and logged no `OPENAI_API_KEY not set` warning. *Original `7e74873` finding (severity:
+  medium; not a release-blocker):* a config-only swap to a cloud-OpenAI alias did not authenticate in
+  stock Docker because no `OPENAI_API_KEY` was threaded into the agent containers — the MT-ALIAS-002
+  OpenAI leg needed a throwaway compose override.
   This is precisely the provider-neutral onboarding gap [release-prep PR 2](../v0.3.4-release-prep-plan.md#pr-2--readme--roadmap--model-aliasprovider-guide--provider-neutral-onboarding--release-checklist)
   is scoped to close (`.env.example` "pick one", an any-provider compose guard that names every
   configured provider, `make demo-openai`). Worth wiring `OPENAI_API_KEY` (and any future provider key)

--- a/docs/v0.3.4-release-checklist.md
+++ b/docs/v0.3.4-release-checklist.md
@@ -147,7 +147,7 @@ Checklist:
 - [x] `MT-ALIAS-002` / `MT-OFFLINE-001` / `MT-OLLAMA-001` recorded `Pass`
 - [x] `MT-MEMORY-005` is **not re-run** — no recall-tier change in v0.3.4 (RFC 0031 Phase 2 deferred to v0.3.5); the prior result carries forward. `MT-MEMORY-003` keeps its raw `claude-haiku-4-5` references (memory-compression is not aliased — [ISSUE-0072](issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md))
 - [x] Every `Accepted-with-known-gap` row links a tracked issue or an RFC-closeout / sequencing follow-up bullet
-- [x] PR 4 re-runs the live demo paths in their **config-driven** form (the MT recipes are updated from the env-knob activation to the alias-config activation per [amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) — done in [#441](https://github.com/mkhomutov/Persatrix/pull/441): the four MT specs rewritten to alias-config form and re-run live on HEAD `6ce23cd` (all ✅ Pass — see the report's [config-driven re-run](manual-tests/v0.3.4-execution-report.md#config-driven-re-run-head-6ce23cd) section)
+- [x] The MT recipes are refreshed from env-knob to **config-driven** alias-config activation (per [amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) and re-run live pre-bump in [#441](https://github.com/mkhomutov/Persatrix/pull/441): the four MT specs rewritten to alias-config form on HEAD `6ce23cd` (all ✅ Pass — see the report's [config-driven re-run](manual-tests/v0.3.4-execution-report.md#config-driven-re-run-head-6ce23cd)). The **post-bump** re-confirmation remains PR 4's [§ 1](#1-pre-release-verification) smoke gate.
 
 ---
 

--- a/docs/v0.3.4-release-checklist.md
+++ b/docs/v0.3.4-release-checklist.md
@@ -30,6 +30,7 @@ All build gates run on a clean checkout of the release-candidate commit, execute
 - [ ] **MT-OFFLINE-001** / **MT-OLLAMA-001** — `Pass` ([#439](https://github.com/mkhomutov/Persatrix/pull/439)); the offline/Ollama factory-interplay regression (`tests/unit/python/test_llm_offline.py` / `test_llm_ollama.py`) green. PR 4 re-runs the demo paths live in their **config-driven** form.
 - [ ] **Personal-tier latency regression gate** — [`tests/perf/personal_tier_latency.py`](../tests/perf/personal_tier_latency.py) re-run on the RC tip (carry-forward; informational baseline).
 - [ ] Docker smoke test on the post-bump tip — provider behaviours verified live on a freshly-rebuilt stack, each selected the config-driven way (an alias config the overlay mounts — no env force-knob, no default provider):
+  - _Pre-bump dry run in [#441](https://github.com/mkhomutov/Persatrix/pull/441) (HEAD `6ce23cd`): all five demo legs below verified live ✅ Pass (F-5 closed). PR 4 re-confirms post-bump; the bare-`up` fail-loud leg is code-evident, not exercised live._
   - [ ] A bare `docker compose up` (no demo) **fails loud** — agents exit at startup with the actionable "alias not configured — pick a provider" message (the no-default-provider behaviour).
   - [ ] `make demo-anthropic` brings the society up on Claude; an alias-routed `quality` agent completes a turn with correct **non-zero** `/cost/summary` + a `persatrix.llm.model_alias` span attribute.
   - [ ] A one-line `quality.provider` swap (Anthropic → OpenAI) re-routes the same agent (the headline claim, live).
@@ -146,7 +147,7 @@ Checklist:
 - [x] `MT-ALIAS-002` / `MT-OFFLINE-001` / `MT-OLLAMA-001` recorded `Pass`
 - [x] `MT-MEMORY-005` is **not re-run** — no recall-tier change in v0.3.4 (RFC 0031 Phase 2 deferred to v0.3.5); the prior result carries forward. `MT-MEMORY-003` keeps its raw `claude-haiku-4-5` references (memory-compression is not aliased — [ISSUE-0072](issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md))
 - [x] Every `Accepted-with-known-gap` row links a tracked issue or an RFC-closeout / sequencing follow-up bullet
-- [ ] PR 4 re-runs the live demo paths in their **config-driven** form (the MT recipes are updated from the env-knob activation to the alias-config activation per [amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md))
+- [x] PR 4 re-runs the live demo paths in their **config-driven** form (the MT recipes are updated from the env-knob activation to the alias-config activation per [amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) — done in [#441](https://github.com/mkhomutov/Persatrix/pull/441): the four MT specs rewritten to alias-config form and re-run live on HEAD `6ce23cd` (all ✅ Pass — see the report's [config-driven re-run](manual-tests/v0.3.4-execution-report.md#config-driven-re-run-head-6ce23cd) section)
 
 ---
 


### PR DESCRIPTION
## Summary

The knob-free provider-selection refactor ([#440](https://github.com/mkhomutov/Persatrix/pull/440)) landed **after** the v0.3.4 MT execution report ([#439](https://github.com/mkhomutov/Persatrix/pull/439)) was authored, leaving the four new-this-release manual tests and their report rows describing the pre-refactor world (env force-knobs, a priced-Anthropic base config, a `quality-openai` peer, and offline/Ollama log strings the factory no longer emits). This PR refreshes them to match HEAD (`6ce23cd`) and records a live config-driven re-run — i.e. the release-checklist's deferred *"PR 4 re-runs the live demo paths in their config-driven form (the MT recipes are updated from env-knob activation to alias-config activation)"* item.

## What was stale (vs HEAD `6ce23cd`)

- **MT-ALIAS-001** — precondition claimed the base config ships `quality` as a priced Anthropic alias ("no edit required"); it actually ships **unconfigured** (no default provider, fails loud).
- **MT-ALIAS-002** — referenced a `quality-openai` peer alias that no longer exists in any `config/*.yaml`; the baseline assumed the stock config routes to Anthropic.
- **MT-OFFLINE-001** — used the removed `PERSATRIX_OFFLINE` knob and asserted the log `LLM offline mode active…` (code now emits `Offline mock provider active…`).
- **MT-OLLAMA-001** — used the removed `PERSATRIX_OLLAMA` knob and asserted a `LLM Ollama mode active…` log line the `ollama` branch **never emits**.

## Live re-run (HEAD `6ce23cd`, config-driven) — all ✅ Pass

| Leg | Cost (`/cost/summary`) | Routing / pricing |
|-----|------------------------|-------------------|
| `make demo-offline` | `1600 / 146 / $0` | `mock`/`offline`, curated reply |
| `make demo-anthropic` | `2708 / 20 / $0.008424` | `claude-sonnet-4-6` — exact rate |
| `make demo-openai` | `1887 / 17 / $0.0048875` | `gpt-4o` — exact rate (cost followed the swap) |
| `make demo-ollama` | `3479 / 8192 / $0` | `llama3.2`, real tokens, $0 cloud |

Prometheus corroborated each physical model. Real cloud spend was minimal (one short turn each on Anthropic + OpenAI).

## Also

- **F-5 marked resolved** — the base compose now plumbs **both** `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` into every agent (verified live: the OpenAI swap leg needed no throwaway override).
- The execution report preserves its dated `7e74873` record under supersede banners and adds an authoritative **Config-driven re-run (HEAD `6ce23cd`)** section.
- The 34 carried-forward rows are unaffected by #440 and remain backed by the green automated suites.

## Test plan

- [x] All four demo legs run live (incl. paid Anthropic/OpenAI turns)
- [x] Both Go alias gates + full Go internal suite green on HEAD
- [x] 128 Python alias/provider/pricing unit tests + bored-persona cost-regression-gate green
- [x] `make validate` exits 0
- [x] doc-links checker: 5610 links / 299 files valid
