### PR TITLE
chore(v034): release-prep PR 3 — version bump 0.3.3 → 0.3.4 + changelog [0.3.4]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.3.4] - 2026-05-27
+
+> **Codename:** Any Model, Any Provider
+
+### Highlights
+
+- **Any Model, Any Provider — the same agents run on Anthropic, OpenAI, a free local model (Ollama), or a `$0` offline mock, selected the one standard way** (RFC 0033, Phases 1–2). Every agent, routing default, and the summarisation path references a logical model alias (`quality` / `fast` / `summarizer`) that resolves to a `(provider, model_id, pricing)` record in [`config/optimization.yaml`](config/optimization.yaml). A vendor retirement or a provider swap is a **one-line config edit** to one alias entry — not a code change, not a config sweep. All four providers (`anthropic` / `openai` / `ollama` / `mock`) are peers dispatched through the same factory path; there is no env force-knob and no special-cased provider.
+- **No default provider — nothing privileges a vendor or can spend money by default.** The shipped config ships its role aliases **unconfigured**, so a plain `docker compose up` fails loud at agent startup with an actionable message until you pick a provider. Each provider is an equal one-command demo (`make demo-anthropic` / `demo-openai` / `demo-ollama` / `demo-offline`), each mounting a per-provider alias config via a Compose overlay. The offline `MockProvider` and the Ollama local-model provider both run the whole society at **`$0` cloud spend**, with the OTel `gen_ai.*` spans, token metrics, and the RFC 0023 wallet-lease path fully populated.
+
+### Upgrade Notes
+
+| Notable change | Detail |
+|----------------|--------|
+| **[Feature]** Provider-agnostic model aliases | Agents, routing defaults, and the summarisation path reference a logical alias (`quality` / `fast` / `summarizer`) resolved to a `(provider, model, pricing)` record in [`config/optimization.yaml`](config/optimization.yaml) `models.aliases` (RFC 0033). A vendor retirement or provider swap is a one-line edit to one alias entry. `schema_version` bumped `0.1` → `0.2`. A priced OpenAI peer alias ships. |
+| **[Behaviour change — no default provider]** Explicit, config-driven provider choice | The shipped `config/optimization.yaml` ships its `quality` / `fast` / `summarizer` role aliases **unconfigured** (`provider: unconfigured`) — there is **no default provider**. A plain `docker compose up` fails loud at agent startup (an actionable `SystemExit`) until you pick one: run a `make demo-*`, or set `provider`/`model`/pricing on the alias. Nothing privileges a vendor or can spend money by default. See [amendment 2026-05-27](docs/v0.3.4-plan-amendment-2026-05-27.md). |
+| **[Behaviour change — provider selection]** Config-driven, no env force-knob | All four providers (`anthropic` / `openai` / `ollama` / `mock`) are selected the same standard way — by the resolved alias `provider` field. The `PERSATRIX_OFFLINE` / `PERSATRIX_OLLAMA` global force-knobs are **removed** (they were never in a tagged release — added and removed within the v0.3.4 window). `make demo-anthropic` / `demo-openai` / `demo-ollama` / `demo-offline` each select their provider by mounting a per-provider alias config (`config/demo/<provider>/optimization.yaml`) via a Compose overlay. `PERSATRIX_OLLAMA_MODEL` / `PERSATRIX_OLLAMA_BASE_URL` / `PERSATRIX_OFFLINE_RESPONSES` survive as provider *configuration* (not selection). |
+| **[Behaviour change — onboarding]** Provider-neutral compose + `.env` | [`docker-compose.yaml`](docker-compose.yaml) plumbs every provider key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) into each agent optionally and drops the single-vendor `:?` startup guard, so a config-only swap to a cloud-OpenAI alias authenticates in stock Docker and first-run privileges no vendor; an agent routed to a provider whose key is unset logs a clear startup warning. [`.env.example`](.env.example) is reframed "pick one provider." |
+| **[Safety]** Missing-price guard | A resolved alias with no pricing fails closed (loud `SystemExit`) for non-local providers, rather than a silent `$0` estimate that would disable the RFC 0023 budget/lease gate. Local providers (`ollama` / `mock`, or a loopback `base_url`) are exempt — they carry an explicit `0` ($0-real). |
+| **[Cost]** Alias-derived pricing + `model_alias` span | `cost.pricing.models` (the Go cost table) is now a checked-in *projection* of the alias map (lock-step test `TestShippedCostPricingDerivedFromAliases`). The `agent.llm.call` span carries `persatrix.llm.model_alias` alongside the physical `gen_ai.request.model` (telemetry-only). |
+| Raw-ID back-compat | A raw vendor model ID still resolves (the §E fall-through) but fires a one-shot deprecation warning + increments `persatrix.llm.alias.raw_id_usage`. Phase 3 (raw-ID rejection, `_infer_provider` retirement, schema `"0.3"`) is **observed-traffic gated** — it opens when that counter reads zero across dogfood, → v0.3.5+. |
+| `$0`-local vs. the wallet cap | A genuinely-$0 local alias (offline / Ollama) never trips the simulated wallet, so the README's "agent pauses itself at the cap" behaviour shows only on a priced (cloud) alias. The offline / Ollama demos are $0 by design; use `make demo-openai` (or an Anthropic alias) to watch the cap trip. |
 
 ### 🚀 Features
 
+- *(RFC 0033 — provider-agnostic model alias layer, Phases 1–2)* Landed across #431 (alias resolver + `models.aliases` block + OpenAI peer alias) → #432 (factory alias resolution + raw-ID deprecation signal) → #433 (config migration to aliases + drop the last model literal) → #434 (missing-price guard) → #435 (`model_alias` span + alias-derived pricing + cost gate) → #436 (documentation sweep) → #437 (Phases-1–2 closeout); PR plan #430. The offline (#422) and Ollama (#423) providers and the knob-free, config-driven provider selection (#440) ship alongside.
 - **Any provider, selected the same way — no force-knobs.** All four providers — `anthropic`, `openai`, `ollama`, and the offline `mock` — are now chosen by one mechanism: the resolved `provider` field on a model alias (RFC 0033). Routing the whole society to a local, mock, or OpenAI provider is a one-line edit to the `quality` alias in [`config/optimization.yaml`](config/optimization.yaml), exactly as the release headlines. `mock` and `ollama` are first-class alias providers, dispatched through the same factory path ([`agents/llm_factory.py`](agents/llm_factory.py)) as the cloud providers.
 - **Offline / demo mode — run the whole society for $0 with no API key.** The `MockProvider` ([`agents/llm_offline.py`](agents/llm_offline.py)) joins `AnthropicProvider` / `OpenAIProvider` / `OllamaProvider` behind the `LLMProvider` protocol. Point an alias at `provider: mock` and every agent returns scripted, persona-accurate replies with **zero provider calls, zero network, and zero spend**. The provider only emits plain text with `stop_reason=END_TURN`, so the runtime's `synthesize_channel_reply` seam routes it through both the chat-as-DM and channel paths unchanged; synthetic token usage keeps the OTel `gen_ai.*` spans, token metrics, and the RFC 0023 wallet-lease settle path populated at $0. Curated replies live in [`config/offline_responses.yaml`](config/offline_responses.yaml) (override via `PERSATRIX_OFFLINE_RESPONSES`); unmatched turns degrade to a deterministic in-character fallback.
 - **Ollama mode — run the whole society on a real local model, no API key, no cloud spend.** A first-class `ollama` provider ([`agents/llm_ollama.py`](agents/llm_ollama.py)) — a thin subclass of `OpenAIProvider`, since Ollama serves the OpenAI-compatible API verbatim at `/v1` — reuses the cloud provider's message/tool translation and overrides only the `gen_ai.system` name (`ollama`) and a localhost-default `base_url`. Point an alias at `provider: ollama` (with a real Ollama tag as `model:`). Unlike offline mode this is **real inference** — usage carries the model's actual token counts — but it runs on your own hardware, so cloud spend is `$0`.
@@ -21,6 +42,30 @@ All notable changes to this project will be documented in this file.
 
 - [`schemas/agent.schema.json`](schemas/agent.schema.json) documents the `provider` field (`anthropic` / `openai` / `ollama` / `mock`) and `provider_config.base_url`, so an explicit `provider: mock` / `provider: ollama` (and the OpenAI-compatible `base_url` for local models) validate instead of being rejected by `additionalProperties: false`. The `ollama` provider defaults `base_url` to `http://localhost:11434/v1`; the `PERSATRIX_OFFLINE_RESPONSES` / `PERSATRIX_OLLAMA_MODEL` / `PERSATRIX_OLLAMA_BASE_URL` provider-configuration env vars are documented in [`.env.example`](.env.example).
 - New per-provider demo alias configs under [`config/demo/`](config/demo/) (`anthropic` / `offline` / `ollama` / `openai`, each a `<provider>/optimization.yaml`) — each points the `quality` / `fast` / `summarizer` aliases at one provider with a matching derived `cost.pricing.models`. The shipped base `cost.pricing.models` projects the `unconfigured` placeholder; the alias cost-attribution gate (`internal/server/cost_alias_gate_test.go`, `internal/cost/cost_alias_pricing_test.go`) now pins the configured `config/demo/anthropic` artifact.
+
+### 📚 Documentation
+
+- *(release)* Post-release follow-up for v0.3.3 (#421)
+- *(v034)* Open v0.3.4 master plan — Any Model, Any Provider (#424)
+- *(v034)* Harden the v0.3.4 plan for provider parity (#425)
+- Require plain-English docs and comments (#426)
+- *(v034)* RFC 0033 PR plan — Phases 1–2 (#430)
+- *(v034)* RFC 0033 PR 6 — documentation sweep (literal vendor IDs → aliases) (#436)
+- *(v034)* RFC 0033 PR 7 — Phases-1–2 closeout (#437)
+- *(v034)* Release-prep plan — master-plan Phase 3 (#438)
+- *(v034)* Release-prep PR 1 — manual-test execution report (alias routing + provider swap + offline + Ollama) (#439)
+- *(v034)* New [model-providers guide](docs/guides/model-providers.md) + provider-neutral onboarding, shipped with the knob-free provider-selection refactor (#440)
+- *(v034)* Refresh the four MT recipes to config-driven form + live re-run on HEAD (#441)
+- *(RFC drafts — tracking only, all `🔨 Draft`)* RFC 0045 — open-core library-extraction policy (#427); RFC 0046 — budget-lease library extraction `persatrix-budget` (#428); RFC 0047 — low-coupling batch library extraction, prompt kit / mock LLM / schemas (#429)
+
+### 🧪 Testing
+
+- Four new manual tests — [`MT-ALIAS-001`](docs/manual-tests/MT-ALIAS-001.md) *alias routing, live* (the **primary v0.3.4 release gate**: an alias-routed agent reports correctly-keyed **non-zero** `/api/v1/cost/summary` priced at the physical model, with `persatrix.llm.model_alias` on the `agent.llm.call` span while `gen_ai.request.model` stays the physical ID); [`MT-ALIAS-002`](docs/manual-tests/MT-ALIAS-002.md) *one-line provider swap* (the headline claim — a single alias edit re-routes the same agent); [`MT-OFFLINE-001`](docs/manual-tests/MT-OFFLINE-001.md) *offline, $0, zero network*; [`MT-OLLAMA-001`](docs/manual-tests/MT-OLLAMA-001.md) *Ollama local model, real tokens, $0 cloud*.
+- New **alias cost-attribution gate** — [`internal/server/cost_alias_gate_test.go`](internal/server/cost_alias_gate_test.go) + [`internal/cost/cost_alias_pricing_test.go`](internal/cost/cost_alias_pricing_test.go) — the automated release-blocker counterpart to `MT-ALIAS-001`; with no default provider it pins the configured `config/demo/anthropic` artifact (plus `config/demo/openai` for the priced peer). The carried-forward bored-persona [`cost-regression-gate`](tests/integration/test_bored_persona_cost.py) stays a release-blocker.
+- The offline / Ollama factory-interplay regression ([`test_llm_offline.py`](tests/unit/python/test_llm_offline.py) / [`test_llm_ollama.py`](tests/unit/python/test_llm_ollama.py)) and the `unconfigured`-sentinel fail-loud ([`test_model_aliases.py`](tests/unit/python/test_model_aliases.py) / [`test_llm_factory.py`](tests/unit/python/test_llm_factory.py)) keep provider selection config-driven after the force-knob removal.
+- Full **38-row** manual-test surface (4 new + 34 carried-forward) executed against the `7e74873` RC tip and re-run in config-driven form on HEAD `6ce23cd`; the release gate is met (#439, #441).
+
+[0.3.4]: https://github.com/mkhomutov/Persatrix/compare/v0.3.3...v0.3.4
 
 ## [0.3.3] - 2026-05-22
 

--- a/agents/observability/metrics.py
+++ b/agents/observability/metrics.py
@@ -52,7 +52,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.3"
+_DEFAULT_SERVICE_VERSION = "0.3.4"
 _DEFAULT_EXPORT_INTERVAL_MS = 60_000
 _DEFAULT_EXPORT_TIMEOUT_MS = 10_000
 

--- a/agents/observability/tracing.py
+++ b/agents/observability/tracing.py
@@ -16,7 +16,7 @@ Environment variables (all optional; defaults match the Go side):
     PERSATRIX_AGENT_ID             sets ``service.instance.id``
     PERSATRIX_SERVICE_ROLE         sets ``service.role`` (optional free-text)
     PERSATRIX_SERVICE_VERSION      sets ``service.version``
-                                    (default: "0.3.3")
+                                    (default: "0.3.4")
 
 Baggage key naming convention
 -----------------------------
@@ -69,7 +69,7 @@ _SCHEMA_URL = "https://persatrix.dev/schemas/observability/1.0.0"
 
 _DEFAULT_SERVICE_NAME = "persatrix-agent"
 _DEFAULT_OTLP_ENDPOINT = "http://localhost:4318"
-_DEFAULT_SERVICE_VERSION = "0.3.3"
+_DEFAULT_SERVICE_VERSION = "0.3.4"
 
 # BatchSpanProcessor tuning — deterministic across environments.
 _BSP_MAX_QUEUE_SIZE = 2048

--- a/agents/pyproject.toml
+++ b/agents/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Persatrix-agents"
-version = "0.3.3"
+version = "0.3.4"
 description = "Persatrix AI Agent Runtime"
 requires-python = ">=3.11"
 license = {text = "BUSL-1.1"}

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -893,7 +893,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "persatrix"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "colored",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "persatrix"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 description = "Persatrix CLI — manage agents, workflows, and the mesh"
 license = "BUSL-1.1"

--- a/docs/v0.3.4-release-checklist.md
+++ b/docs/v0.3.4-release-checklist.md
@@ -60,10 +60,10 @@ Before tagging, all shipped components must declare `0.3.4` consistently. All co
 
 Checklist (filled in by release-prep plan PR 3; PR 4 confirms on the post-bump tip):
 
-- [ ] `agents/pyproject.toml` → `0.3.4`
-- [ ] `agents/observability/{metrics,tracing}.py` → `_DEFAULT_SERVICE_VERSION = "0.3.4"` (both)
-- [ ] `cli/Cargo.toml` → `0.3.4`; `cli/Cargo.lock` regenerated (CLI builds as `persatrix v0.3.4`)
-- [ ] `make all` builds at the new version — orchestrator (`go build`) + CLI (`cargo build --release`) both at `0.3.4`
+- [x] `agents/pyproject.toml` → `0.3.4`
+- [x] `agents/observability/{metrics,tracing}.py` → `_DEFAULT_SERVICE_VERSION = "0.3.4"` (both)
+- [x] `cli/Cargo.toml` → `0.3.4`; `cli/Cargo.lock` regenerated (CLI builds as `persatrix v0.3.4`)
+- [x] `make all` builds at the new version — orchestrator (`go build`) + CLI (`cargo build --release`) both at `0.3.4`
 - [ ] No docs describe v0.3.4 as unreleased WIP — README Roadmap row + this checklist's status + the ROADMAP Version Map row flip to released by PR 4 / Phase 5; only post-tag artifacts (tag link, Release URL, "Released" stamps) remain for the Phase 5 follow-up.
 
 ---
@@ -74,16 +74,16 @@ The release changelog must preserve every existing curated section in [`CHANGELO
 
 Checklist:
 
-- [ ] `CHANGELOG.md` contains a `[0.3.4]` section (PR 3)
-- [ ] The existing curated `[0.3.3]` … `[0.1.0]` sections are preserved verbatim — not overwritten
-- [ ] The `[0.3.4]` section includes:
+- [x] `CHANGELOG.md` contains a `[0.3.4]` section (PR 3); `[Unreleased]` content folded in, not duplicated
+- [x] The existing curated `[0.3.3]` … `[0.1.0]` sections are preserved verbatim — not overwritten
+- [x] The `[0.3.4]` section includes:
   - **Highlights**: the same agents run on any provider — Anthropic / OpenAI / Ollama / offline mock — selected the one standard way (a logical model alias's `provider` field); a vendor swap is a one-line config edit. Provider selection is purely config/alias-driven (no env force-knob).
   - **Features**: RFC 0033 PRs 1–7 (alias resolver + `models.aliases` block + OpenAI peer alias → factory alias resolution + raw-ID deprecation signal → config migration → missing-price guard → `model_alias` span + derived pricing + cost gate → doc sweep → closeout); the offline mock + Ollama providers; the knob-free, config-driven provider selection + per-provider demo configs + `make demo-openai`; PR ranges per [release-prep plan §RFC PR roll-up](v0.3.4-release-prep-plan.md#rfc-pr-roll-up)
   - **(No Bug Fixes section)** — no tracked-issue bug-fix PRs shipped in `v0.3.3..HEAD`
   - **Documentation**: MT execution report (release-prep PR 1, [#439](https://github.com/mkhomutov/Persatrix/pull/439)), the model-providers guide + provider-neutral onboarding (release-prep PR 2), release-prep + master plans + the two amendments, the RFC 0045–0047 drafts on an RFC-tracking line
   - **Testing**: 4 new MTs (`MT-ALIAS-001` / `MT-ALIAS-002` / `MT-OFFLINE-001` / `MT-OLLAMA-001`), the alias cost-attribution gate, the carried-forward `cost-regression-gate`, and the offline/Ollama factory-interplay suites
   - **Upgrade Notes** subsection (see §3.1 below)
-- [ ] RFC 0045–0047 drafts ([#427](https://github.com/mkhomutov/Persatrix/pull/427)–[#429](https://github.com/mkhomutov/Persatrix/pull/429), all `🔨 Draft`) stay under an RFC-tracking line in **Documentation**, not Features
+- [x] RFC 0045–0047 drafts ([#427](https://github.com/mkhomutov/Persatrix/pull/427)–[#429](https://github.com/mkhomutov/Persatrix/pull/429), all `🔨 Draft`) stay under an RFC-tracking line in **Documentation**, not Features
 
 Suggested generation command:
 
@@ -206,13 +206,13 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [ ] make check-licenses passes
 [ ] THIRD_PARTY_NOTICES.md regenerated via make notices — up to date, no delta (no new prod dep)
 [ ] make generate-sanitizer-patterns-check passes
-[ ] agents/pyproject.toml updated to 0.3.4
-[ ] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.4
-[ ] cli/Cargo.toml updated to 0.3.4
-[ ] cli/Cargo.lock regenerated and committed
-[ ] make all builds successfully (orchestrator + CLI both at 0.3.4)
-[ ] CHANGELOG.md contains a curated [0.3.4] section with upgrade notes (no Bug Fixes section); [Unreleased] content folded in, not duplicated
-[ ] Existing [0.3.3] … [0.1.0] sections preserved verbatim
+[x] agents/pyproject.toml updated to 0.3.4
+[x] agents/observability/{metrics,tracing}.py service.version defaults updated to 0.3.4
+[x] cli/Cargo.toml updated to 0.3.4
+[x] cli/Cargo.lock regenerated and committed
+[x] make all builds successfully (orchestrator + CLI both at 0.3.4)
+[x] CHANGELOG.md contains a curated [0.3.4] section with upgrade notes (no Bug Fixes section); [Unreleased] content folded in, not duplicated
+[x] Existing [0.3.3] … [0.1.0] sections preserved verbatim
 [x] All 38 manual-test rows recorded in docs/manual-tests/v0.3.4-execution-report.md
 [x] No unresolved Fail in manual tests; zero Not run
 [x] MT-ALIAS-001 recorded Pass (primary release gate); alias cost-attribution gate green on the RC tip

--- a/docs/v0.3.4-release-prep-plan.md
+++ b/docs/v0.3.4-release-prep-plan.md
@@ -41,11 +41,13 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 |----|-------|-------|--------|--------|-----------|--------|
 | 0 | — | v0.3.4 release-prep plan (this document) | `feature/v034-release-prep-plan` | ✅ Merged | [#438](https://github.com/mkhomutov/Persatrix/pull/438) | 2026-05-27 |
 | 1 | A | MT execution report (alias routing + provider-swap + offline + Ollama) | `feature/v034-release-prep-mt-exec` | ✅ Merged | [#439](https://github.com/mkhomutov/Persatrix/pull/439) | 2026-05-27 |
-| 2 | A | README + ROADMAP + model-alias/provider guide + provider-neutral onboarding (`.env` / compose / `demo-openai`) + release checklist **+ knob-free provider-selection refactor** ([amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) | `feature/v034-release-prep-docs` | 🔀 PR open | [#440](https://github.com/mkhomutov/Persatrix/pull/440) | — |
-| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog `[0.3.4]` | `feature/v034-release-prep-version-bump` | ⬜ Not started | — | — |
+| 2 | A | README + ROADMAP + model-alias/provider guide + provider-neutral onboarding (`.env` / compose / `demo-openai`) + release checklist **+ knob-free provider-selection refactor** ([amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) | `feature/v034-release-prep-docs` | ✅ Merged | [#440](https://github.com/mkhomutov/Persatrix/pull/440) | 2026-05-27 |
+| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog `[0.3.4]` | `feature/v034-release-prep-version-bump` | 🔀 PR open | — | — |
 | 4 | B | Final pre-tag verification & release notes | `feature/v034-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
+
+**Follow-on (not a sequenced row)**: [#441](https://github.com/mkhomutov/Persatrix/pull/441) — ✅ Merged 2026-05-27 — refreshed the four v0.3.4 MT recipes (`MT-ALIAS-001/002`, `MT-OFFLINE-001`, `MT-OLLAMA-001`) from the removed env force-knobs to the config-driven alias-config activation introduced by PR 2, with a live re-run on HEAD; a documentation follow-on to PR 1 / PR 2, not part of the original five-PR sequence.
 
 ---
 

--- a/docs/v0.3.4-release-prep-plan.md
+++ b/docs/v0.3.4-release-prep-plan.md
@@ -42,7 +42,7 @@ Update this table as each PR merges. Flip **Status** and add GitHub PR number + 
 | 0 | — | v0.3.4 release-prep plan (this document) | `feature/v034-release-prep-plan` | ✅ Merged | [#438](https://github.com/mkhomutov/Persatrix/pull/438) | 2026-05-27 |
 | 1 | A | MT execution report (alias routing + provider-swap + offline + Ollama) | `feature/v034-release-prep-mt-exec` | ✅ Merged | [#439](https://github.com/mkhomutov/Persatrix/pull/439) | 2026-05-27 |
 | 2 | A | README + ROADMAP + model-alias/provider guide + provider-neutral onboarding (`.env` / compose / `demo-openai`) + release checklist **+ knob-free provider-selection refactor** ([amendment 2026-05-27](v0.3.4-plan-amendment-2026-05-27.md)) | `feature/v034-release-prep-docs` | ✅ Merged | [#440](https://github.com/mkhomutov/Persatrix/pull/440) | 2026-05-27 |
-| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog `[0.3.4]` | `feature/v034-release-prep-version-bump` | 🔀 PR open | — | — |
+| 3 | B | Version bump (`agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py`, `cli/Cargo.toml`, `cli/Cargo.lock`) + changelog `[0.3.4]` | `feature/v034-release-prep-version-bump` | 🔀 PR open | [#442](https://github.com/mkhomutov/Persatrix/pull/442) | — |
 | 4 | B | Final pre-tag verification & release notes | `feature/v034-release-prep-final` | ⬜ Not started | — | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged


### PR DESCRIPTION
## Summary

Track B of the [v0.3.4 release-prep plan](docs/v0.3.4-release-prep-plan.md) — **PR 3 of 5**. Bumps every shipped component `0.3.3 → 0.3.4` and curates the `CHANGELOG` `[0.3.4]` section ("Any Model, Any Provider"). The final pre-tag gate sweep + Docker smoke + tag are PR 4 / Phase 5.

Depends on PR 2 ([#440](https://github.com/mkhomutov/Persatrix/pull/440), merged) and the follow-on MT-recipe refresh ([#441](https://github.com/mkhomutov/Persatrix/pull/441), merged).

## Version bump (`scripts/bump_version.py 0.3.4`)

- `agents/pyproject.toml`, `agents/observability/{metrics,tracing}.py` (`_DEFAULT_SERVICE_VERSION`, both spots), `cli/Cargo.toml` → `0.3.4`
- `cli/Cargo.lock` regenerated via `cargo update --workspace` — workspace package only, **no external dependency churn** (single-line diff)
- `make build` green; CLI binary reports `persatrix 0.3.4`

## Changelog `[0.3.4]` — "Any Model, Any Provider"

- The curated `[Unreleased]` offline / Ollama / knob-free provider-selection content is **folded into `[0.3.4]`, not re-authored**; the `[Unreleased]` header is removed
- Added **Highlights**, **Upgrade Notes** (canonical text from release-checklist §3.1, links re-rooted to repo root), an **RFC 0033 PR roll-up** (#430–#437 plus offline #422 / Ollama #423 / knob-free #440), **Documentation**, and **Testing**
- **No Bug Fixes** section — no tracked-issue bug-fix PRs in `v0.3.3..HEAD`
- `[0.3.3]` and all prior sections preserved **verbatim** — diff confined to the new top section

## Docs

- Filled the release-checklist §2 Version Alignment / §3 Changelog / §7 summary boxes that PR 3 owns
- Corrected the prep-plan Progress Overview (PR 2 → ✅ Merged #440; PR 3 → 🔀 PR open) and footnoted the out-of-sequence follow-on #441

## Verification

- `make build` green — orchestrator (`go build`) + CLI (`cargo build --release`), CLI reports `persatrix 0.3.4`
- `scripts/checks/doc_links.py`: 5628 links across 299 files OK
- Pre-commit: 7/7 (filemap, go fmt, ruff, cargo fmt, doc links, doc status, file size)

## Out of scope → PR 4 / Phase 5

- Full gate sweep: `make test` / `make lint` / `make validate` / `make proto && git diff --exit-code` / `make check-licenses` / `make notices` / `make generate-sanitizer-patterns-check`
- Docker smoke (bare-`up` fail-loud + alias-routed cost + one-line swap + offline + Ollama + OpenAI)
- ROADMAP Version Map → ✅ Released, checklist Status → ✅ Released, the `v0.3.4` tag + GitHub Release
