### PR TITLE
docs(v035): record scope-axes follow-up sequence + next step in v0.3.5 plan

### DIFF
--- a/docs/v0.3.5-plan.md
+++ b/docs/v0.3.5-plan.md
@@ -8,7 +8,7 @@
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
 **Codename**: *Session Isolation* (proposed — maintainer owns the final codename)
 
-**Goal**: orchestrate v0.3.5 end-to-end. One user-facing story: **every run is auto-isolated.** A rerun reusing the same channel name + `--user` no longer inherits persona memory or channel history — the **F-3** cross-run state bleed ([v0.3.0 channel test findings](v0.3.0-test-findings-pr-plan.md)), currently mitigated only by `make reset`. v0.3.5 ships the root-cause fix.
+**Goal**: orchestrate v0.3.5 end-to-end. One user-facing story: **every run is auto-isolated** — a rerun reusing the same channel name + `--user` no longer inherits persona memory or channel history (the **F-3** cross-run state bleed, [v0.3.0 channel test findings](v0.3.0-test-findings-pr-plan.md), mitigated only by `make reset` today). v0.3.5 ships the root-cause fix.
 
 The umbrella RFC is [RFC 0031](rfcs/0031-per-session-namespacing-channels.md) (Per-Session Namespacing for Channels and Persona Memory). Phase 1 (the `sessions` table + `session_id` columns + `PERSATRIX_SESSION_ID` write-path threading) shipped in v0.3.1; v0.3.5 carries **Phases 2–4**:
 
@@ -18,10 +18,10 @@ The umbrella RFC is [RFC 0031](rfcs/0031-per-session-namespacing-channels.md) (P
 
 **Out of scope** — not absorbed into the Session Isolation story:
 
-- [RFC 0033](rfcs/0033-model-alias-layer.md) **Phase 3** (raw-ID pass-through removal, `_infer_provider` retirement, schema bump to `"0.3"`). Gated on observed dogfood traffic showing the `persatrix.llm.alias.raw_id_usage` counter at zero — an observed-state gate, not a date ([RFC 0033 §Phased Implementation Plan](rfcs/0033-model-alias-layer.md#phased-implementation-plan)). It is a *different* story ("every model is an alias"), so it does not bundle into Session Isolation by default — see [§Conditional co-resident](#conditional-co-resident--rfc-0033-phase-3) for the ride-along condition and its cleanup issues.
+- [RFC 0033](rfcs/0033-model-alias-layer.md) **Phase 3** (raw-ID pass-through removal, `_infer_provider` retirement, schema bump to `"0.3"`). Gated on the `persatrix.llm.alias.raw_id_usage` counter reading zero in dogfood — observed state, not a date. A *different* story ("every model is an alias"), so it does not bundle in by default; see [§Conditional co-resident](#conditional-co-resident--rfc-0033-phase-3) for the ride-along condition and cleanup issues.
 - [RFC 0030](rfcs/0030-multi-agent-conversation-governance.md) Phase 1, [RFC 0034](rfcs/0034-persona-conversational-working-memory.md) Phases 2–3, [RFC 0039](rfcs/0039-user-accounts-authentication.md) — `v0.3.x` candidates not on this contract.
 
-**Companion documents**: [v0.3.4 plan](v0.3.4-plan.md) (structural template) · [v0.3.x-sequencing.md §Amendment 2026-05-23](v0.3.x-sequencing.md#amendment-2026-05-23--v034-carries-rfc-0033-ahead-of-rfc-0031-phases-24) (canonical decision committing v0.3.5 = RFC 0031 Phases 2–4) · [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md) (Phase 2 implementation workstream) · [`0031-pr-plan.md`](rfcs/0031-pr-plan.md) (Phase 1 template, shipped in v0.3.1).
+**Companion documents**: [v0.3.4 plan](v0.3.4-plan.md) (template) · [v0.3.x-sequencing.md §Amendment 2026-05-23](v0.3.x-sequencing.md#amendment-2026-05-23--v034-carries-rfc-0033-ahead-of-rfc-0031-phases-24) (canonical v0.3.5 = Phases 2–4 decision) · [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md) (Phase 2 workstream) · [`0031-pr-plan.md`](rfcs/0031-pr-plan.md) (Phase 1, v0.3.1).
 
 ---
 
@@ -50,7 +50,13 @@ The umbrella RFC is [RFC 0031](rfcs/0031-per-session-namespacing-channels.md) (P
 
 ## Amendment — scope-axes reframing
 
-A post-Phase-2 review reframes session as room-continuity and moves run/test isolation to a new **epoch** axis (detail: [Memory Scope Axes](memory-scope-axes.md)); **what shipped stands** (Phase 2 closed F-3). Follow-ups, not in this release: [ISSUE-0083](issues/ISSUE-0083-session-binding-sender-axis-fragments-multiparty-rooms.md), [ISSUE-0084](issues/ISSUE-0084-fact-scope-by-subject-not-uniform-session.md), [ISSUE-0085](issues/ISSUE-0085-epoch-axis-run-isolation.md).
+A post-Phase-2 review reframes session as room-continuity and moves run/test isolation to a new **epoch** axis (detail: [Memory Scope Axes](memory-scope-axes.md)); **what shipped stands** (Phase 2 closed F-3). Three follow-ups are deferred beyond v0.3.5, dependency-ordered (no calendar):
+
+1. **[ISSUE-0083](issues/ISSUE-0083-session-binding-sender-axis-fragments-multiparty-rooms.md)** — drop the sender axis (`(agent, channel, user)` → `(agent, channel)`); **load-bearing prerequisite, do first.**
+2. **[ISSUE-0085](issues/ISSUE-0085-epoch-axis-run-isolation.md)** — add the `epoch` run/test-isolation axis; **after 0083.**
+3. **[ISSUE-0084](issues/ISSUE-0084-fact-scope-by-subject-not-uniform-session.md)** — fact scope by subject; **independent.**
+
+Two decisions are open and due **before Phase 3 PR 4**: ISSUE-0083's order vs. PR 4, and whether epoch gets an operator surface in Phase 3 — both in the [Phase 3 plan amendment](rfcs/0031-phase3-pr-plan.md#amendment--scope-axes-reframing).
 
 ---
 
@@ -58,23 +64,23 @@ A post-Phase-2 review reframes session as room-continuity and moves run/test iso
 
 Three reasons RFC 0031 Phases 2–4 deserve an umbrella plan rather than a bare PR-plan execution:
 
-1. **F-3 is still open after Phase 1.** Phase 1 (v0.3.1) tags every write with a `session_id`, but every read still surfaces every session's rows by design ([RFC §Phase 1](rfcs/0031-per-session-namespacing-channels.md#phase-1-sessions-table-column-additions-default-session-plumbing): *"F-3 closes when Phase 2's recall filtering lands"*). The plan makes "F-3 reproduction shows no carryover" a release-level gate so the half-finished state isn't mistaken for the fix.
+1. **F-3 is still open after Phase 1.** Phase 1 (v0.3.1) tags every write with a `session_id`, but every read still surfaces every session's rows by design ([RFC §Phase 1](rfcs/0031-per-session-namespacing-channels.md#phase-1-sessions-table-column-additions-default-session-plumbing)). The plan makes "F-3 reproduction shows no carryover" a release-level gate so the half-finished state isn't mistaken for the fix.
 
-2. **The fix must not break the dementia test.** Session-scoped default recall and long-arc continuity are in tension; [OQ #1 resolution 1a](rfcs/0031-per-session-namespacing-channels.md#open-questions) (the arc shares one session id) reconciles them, but only if Phase 2's dementia-test bridge proves it — so the plan makes that proof a gate.
+2. **The fix must not break the dementia test.** Session-scoped recall and long-arc continuity are in tension; [OQ #1 resolution 1a](rfcs/0031-per-session-namespacing-channels.md#open-questions) (the arc shares one session id) reconciles them only if Phase 2's dementia-test bridge proves it — so the plan gates on that proof.
 
-3. **Phase 3 has no PR plan yet, and Phase 4 closes a tracked issue.** Phase 2 is drafted in [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md); Phase 3 (operator CLI) needs its PR plan authored, and Phase 4 carries the [ISSUE-0051](issues/ISSUE-0051-per-session-memory-namespacing-channels.md) close-out. Sequencing the three phases (single RFC, so intra-RFC ordering only) is what an umbrella owns.
+3. **Phase 3 needs a PR plan; Phase 4 closes a tracked issue.** Phase 2 is drafted in [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md); Phase 3 (operator CLI) needs its PR plan authored; Phase 4 carries the [ISSUE-0051](issues/ISSUE-0051-per-session-memory-namespacing-channels.md) close-out. Sequencing the three phases (intra-RFC ordering) is what an umbrella owns.
 
 ---
 
 ## Acceptance for v0.3.5
 
-The promise — *"every run is auto-isolated; persona memory no longer bleeds across runs that reuse a channel name + user identity"* — is met when:
+The promise — *every run is auto-isolated; persona memory no longer bleeds across runs reusing a channel name + user* — is met when:
 
-- **Default recall is session-scoped** across all four persona-memory tiers — `episodes`, `relationships`, `facts`, `notes` — defaulting to the active session plus the always-visible `legacy` carve-out; cross-session recall is the explicit `sessions=[…]` / `sessions="*"` opt-in per [RFC §D](rfcs/0031-per-session-namespacing-channels.md#d-recall-semantics). (Notes had no `session_id` column after Phase 1; [Phase 2 PR 1](rfcs/0031-phase2-pr-plan.md#pr-1-featurev035-rfc0031p2-notes-coverage--notes-tier-session-coverage) closes that gap.)
+- **Default recall is session-scoped** across all four tiers (`episodes`, `relationships`, `facts`, `notes`) — active session plus the always-visible `legacy` carve-out; cross-session recall is the explicit `sessions=[…]` / `sessions="*"` opt-in per [RFC §D](rfcs/0031-per-session-namespacing-channels.md#d-recall-semantics). (Notes gained their `session_id` column in [Phase 2 PR 1](rfcs/0031-phase2-pr-plan.md#pr-1-featurev035-rfc0031p2-notes-coverage--notes-tier-session-coverage).)
 - **F-3 reproduction shows no carryover** — re-running the [v0.3.0 F-3 repro](v0.3.0-test-findings-pr-plan.md) with the same channel name + `--user` under a new `PERSATRIX_SESSION_ID` surfaces none of the prior run's participants, topics, or facts.
-- **The dementia test still passes** — [MT-MEMORY-005](manual-tests/MT-MEMORY-005-dementia-test.md) under one session id preserves continuity; a second session does not bleed; `tests/integration/test_session_continuity.py` is the executable regression pin.
+- **The dementia test still passes** — [MT-MEMORY-005](manual-tests/MT-MEMORY-005-dementia-test.md) under one session id preserves continuity, a second does not bleed; `tests/integration/test_session_continuity.py` is the regression pin.
 - **The operator surface exists** — `persatrix session new / use / list / archive / current`; the active-session pointer resolves per [RFC §E](rfcs/0031-per-session-namespacing-channels.md#e-operator-surface); `--session` overrides it on `persatrix chat` / `persatrix channel …`.
-- **`make reset` is kept but documented as deprecated** in favour of `persatrix session new --activate`; **`docs/guides/sessions.md` ships** and [ISSUE-0051](issues/ISSUE-0051-per-session-memory-namespacing-channels.md) is closed at the Phase 4 close-out.
+- **`make reset` kept, documented as deprecated** in favour of `persatrix session new --activate`; **`docs/guides/sessions.md` ships**; [ISSUE-0051](issues/ISSUE-0051-per-session-memory-namespacing-channels.md) closed at the Phase 4 close-out.
 
 Out of acceptance: RFC 0033 Phase 3 (observed-traffic gated — see [§Conditional co-resident](#conditional-co-resident--rfc-0033-phase-3)); RFC 0030 Phase 1; RFC 0034 Phases 2–3; RFC 0039.
 
@@ -227,21 +233,21 @@ Phases are sequential (2 → 3 → 4): the CLI (Phase 3) sets the active session
 
 ## Candidate fold-ins (maintainer decision)
 
-Surfaced during the pre-planning issue triage. None is required for the Session Isolation story; the maintainer owns whether to commit them.
+Surfaced during pre-planning triage. None is required for Session Isolation; the maintainer owns whether to commit them.
 
 | Issue | Sev | Recommendation |
 |-------|-----|----------------|
 | [ISSUE-0053](issues/ISSUE-0053-persona-runtime-init-size-headroom.md) | low | **Fold in.** `agents/persona_runtime/__init__.py` is at the 500-line cap, so the first Phase 2 edit to it trips the file-size check — pre-empt at that PR (likely PR 4's call-site threading). Unblocks rather than expands scope. |
-| [ISSUE-0068](issues/ISSUE-0068-chat-peer-recorded-as-agent-participant-type.md) | medium | **Opportunistic.** Active defect — REST chat records the human peer as `other_participant_type='agent'`. The fix touches the relationship tier + the `ChannelMessageEvent` proto, the same surfaces Phase 2 works in; fold in if that proto work is open anyway (needs RFC review). Otherwise defer — separate story. |
+| [ISSUE-0068](issues/ISSUE-0068-chat-peer-recorded-as-agent-participant-type.md) | medium | **Opportunistic.** Active defect — REST chat records the human peer as `other_participant_type='agent'`. Fix touches the relationship tier + `ChannelMessageEvent` proto, the surfaces Phase 2 works in; fold in if that proto work is open (needs RFC review), else defer. |
 | [ISSUE-0072](issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md) | low | **Route to the RFC 0033 Phase 3 thread**, not this one — last hardcoded vendor literals in production Python; alias-layer hygiene, unrelated to session isolation. See [§Conditional co-resident](#conditional-co-resident--rfc-0033-phase-3). |
 
 ---
 
 ## Conditional co-resident — RFC 0033 Phase 3
 
-[RFC 0033 Phase 3](rfcs/0033-model-alias-layer.md#phased-implementation-plan) (remove the raw-ID pass-through, retire `_infer_provider`, bump `schema_version` to `"0.3"`) is targeted at **v0.3.5+**, gated on the `persatrix.llm.alias.raw_id_usage` counter reading zero across dogfood — an observed-state gate, not a date. It is a *different* story ("every model is an alias"), so it does **not** bundle into Session Isolation by default.
+[RFC 0033 Phase 3](rfcs/0033-model-alias-layer.md#phased-implementation-plan) (remove the raw-ID pass-through, retire `_infer_provider`, bump `schema_version` to `"0.3"`) is targeted at **v0.3.5+**, gated on the `persatrix.llm.alias.raw_id_usage` counter reading zero across dogfood — observed state, not a date. A *different* story, so it does **not** bundle into Session Isolation by default.
 
-If the dogfood signal is clean by the time release-prep opens **and** the maintainer judges the two shippable together, Phase 3 can ride along with its cleanup issues ([ISSUE-0072](issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md), [ISSUE-0069](issues/ISSUE-0069-task-agent-evaluator-routing-defaults-unconsumed.md), [ISSUE-0071](issues/ISSUE-0071-alias-pricing-guard-no-eager-startup-validation.md), [ISSUE-0074](issues/ISSUE-0074-mock-provider-raw-id-deprecation-gate.md)). **Default: deferred** — the one-story contract holds unless the maintainer opts in.
+If the dogfood signal is clean when release-prep opens **and** the maintainer judges the two shippable together, Phase 3 can ride along with its cleanup issues ([ISSUE-0072](issues/ISSUE-0072-memory-compression-hardcoded-model-literals.md), [ISSUE-0069](issues/ISSUE-0069-task-agent-evaluator-routing-defaults-unconsumed.md), [ISSUE-0071](issues/ISSUE-0071-alias-pricing-guard-no-eager-startup-validation.md), [ISSUE-0074](issues/ISSUE-0074-mock-provider-raw-id-deprecation-gate.md)). **Default: deferred** unless the maintainer opts in.
 
 ---
 
@@ -250,14 +256,14 @@ If the dogfood signal is clean by the time release-prep opens **and** the mainta
 Per [.github/copilot-instructions.md §Status Hygiene](../.github/copilot-instructions.md):
 
 - **This PR (Phase 0)** → Version Map v0.3.5 → `🚧 Planning`; RFC Master Index RFC 0031 row unchanged (already `v0.3.1 (P1) + v0.3.5 (P2–4)`).
-- **Phase 1 PR 1 opens** → RFC 0031 → `🚧 Implementing` (resuming from the Phase 1 `⚠️ Partially Implemented` pause — not a regression).
+- **Phase 1 PR 1 opens** → RFC 0031 → `🚧 Implementing` (resuming from the Phase 1 `⚠️ Partially Implemented` pause).
 - **Phase 6 (tag)** → Version Map v0.3.5 → `✅ Released`; RFC 0031 → `✅ Implemented`; `Last updated` refresh.
 
 ---
 
 ## Risk and mitigations
 
-The per-PR implementation risks — the facade-bypass recall path, the notes-tier column gap, and the OQ #4 frozen-signature amendment — live in the [Phase 2 PR plan §Risk table](rfcs/0031-phase2-pr-plan.md#risk-and-mitigations). The release-level risks:
+The per-PR implementation risks live in the [Phase 2 PR plan §Risk table](rfcs/0031-phase2-pr-plan.md#risk-and-mitigations). The release-level risks:
 
 | Risk | Mitigation |
 |------|------------|
@@ -273,6 +279,7 @@ The per-PR implementation risks — the facade-bypass recall path, the notes-tie
 2. Open RFC 0031 Phase 2 PR 1 (`feature/v035-rfc0031p2-notes-coverage`) from the swept [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md); flip RFC 0031 → `🚧 Implementing` on that PR.
 3. Decide the [candidate fold-ins](#candidate-fold-ins-maintainer-decision) (ISSUE-0053 / 0068) and the [RFC 0033 Phase 3 co-resident](#conditional-co-resident--rfc-0033-phase-3) question — before release-prep (Phase 4) opens, so the CHANGELOG story stays singular.
 4. ✅ Author [`docs/rfcs/0031-phase3-pr-plan.md`](rfcs/0031-phase3-pr-plan.md) (Phase 2 of this plan); its five implementation PRs execute it next.
+5. **Next: open Phase 3 PR 1** (`feature/v035-rfc0031p3-rest`); flip RFC 0031 → `🚧 Implementing` on that PR. Resolve the two [scope-axes open decisions](#amendment--scope-axes-reframing) before Phase 3 PR 4 opens.
 
 Fall-back: Phases 2–4 are independently shippable, so a thinner v0.3.5 could ship Phase 2 alone (the F-3 closer) and re-home Phases 3–4 to v0.3.6 — leaving the operator surface as the env var only. The recall fix is the load-bearing half; the CLI is ergonomics.
 

--- a/docs/v0.3.5-plan.md
+++ b/docs/v0.3.5-plan.md
@@ -56,7 +56,7 @@ A post-Phase-2 review reframes session as room-continuity and moves run/test iso
 2. **[ISSUE-0085](issues/ISSUE-0085-epoch-axis-run-isolation.md)** — add the `epoch` run/test-isolation axis; **after 0083.**
 3. **[ISSUE-0084](issues/ISSUE-0084-fact-scope-by-subject-not-uniform-session.md)** — fact scope by subject; **independent.**
 
-Two decisions are open and due **before Phase 3 PR 4**: ISSUE-0083's order vs. PR 4, and whether epoch gets an operator surface in Phase 3 — both in the [Phase 3 plan amendment](rfcs/0031-phase3-pr-plan.md#amendment--scope-axes-reframing).
+Two decisions are open: ISSUE-0083's order vs. PR 4 (due **before Phase 3 PR 4**), and whether epoch gets an operator surface in Phase 3 or a sibling phase — both in the [Phase 3 plan amendment](rfcs/0031-phase3-pr-plan.md#amendment--scope-axes-reframing).
 
 ---
 
@@ -279,7 +279,7 @@ The per-PR implementation risks live in the [Phase 2 PR plan §Risk table](rfcs/
 2. Open RFC 0031 Phase 2 PR 1 (`feature/v035-rfc0031p2-notes-coverage`) from the swept [`0031-phase2-pr-plan.md`](rfcs/0031-phase2-pr-plan.md); flip RFC 0031 → `🚧 Implementing` on that PR.
 3. Decide the [candidate fold-ins](#candidate-fold-ins-maintainer-decision) (ISSUE-0053 / 0068) and the [RFC 0033 Phase 3 co-resident](#conditional-co-resident--rfc-0033-phase-3) question — before release-prep (Phase 4) opens, so the CHANGELOG story stays singular.
 4. ✅ Author [`docs/rfcs/0031-phase3-pr-plan.md`](rfcs/0031-phase3-pr-plan.md) (Phase 2 of this plan); its five implementation PRs execute it next.
-5. **Next: open Phase 3 PR 1** (`feature/v035-rfc0031p3-rest`); flip RFC 0031 → `🚧 Implementing` on that PR. Resolve the two [scope-axes open decisions](#amendment--scope-axes-reframing) before Phase 3 PR 4 opens.
+5. **Next: open Phase 3 PR 1** (`feature/v035-rfc0031p3-rest`); flip RFC 0031 → `🚧 Implementing` on that PR. Resolve the [scope-axes open decisions](#amendment--scope-axes-reframing) — 0083's order before Phase 3 PR 4 opens.
 
 Fall-back: Phases 2–4 are independently shippable, so a thinner v0.3.5 could ship Phase 2 alone (the F-3 closer) and re-home Phases 3–4 to v0.3.6 — leaving the operator surface as the env var only. The recall fix is the load-bearing half; the CLI is ergonomics.
 


### PR DESCRIPTION
## What

Makes the **scope-axes follow-up sequence** and the **next action** discoverable from the v0.3.5 master plan. After [#462](https://github.com/mkhomutov/Persatrix/pull/462) the three follow-up issues (0083/0084/0085) were listed flatly in the plan's amendment, with no execution order and no "what next" — the dependency order and the open decisions lived only scattered across the issues, the scope-axes note, and the Phase 3 plan amendment.

Doc-only. No production code, no status flips.

## Changes (`docs/v0.3.5-plan.md`)

- **Amendment section** — replace the flat issue list with the dependency-ordered sequence:
  1. **ISSUE-0083** (drop sender axis) — load-bearing prerequisite, do first
  2. **ISSUE-0085** (epoch axis) — after 0083
  3. **ISSUE-0084** (fact scope by subject) — independent

  …and surface the two open decisions due **before Phase 3 PR 4**: 0083's order vs. PR 4, and whether epoch gets an operator surface in Phase 3 (both detailed in the Phase 3 plan amendment). No calendar — dependency-ordered only.
- **Decision/next-steps** — add item 5: open Phase 3 PR 1 (`feature/v035-rfc0031p3-rest`) next; resolve the two scope-axes open decisions before PR 4.

## Note on the word cap

`docs/v0.3.5-plan.md` was already at the **3000-word doc cap** (the file-size hook blocks over it), so the additions are offset by **information-preserving condensation** of several existing passages — RFC 0033 out-of-scope/co-resident wording, the "why this plan exists" reasons, acceptance bullets, and the companion-docs / risk-table intros. No facts or links removed.

## Checks

- file-size ✓ (3000/3000), doc_links ✓ (6011 links), doc-status ✓
- pre-commit 7/7