### PR TITLE
refactor(v035): RFC 0033 Phase 3 — retire the resolver raw-ID pass-through

### DIFF
--- a/agents/llm_factory.py
+++ b/agents/llm_factory.py
@@ -30,7 +30,6 @@ from .llm_ollama import OllamaProvider, resolve_ollama_base_url
 from .llm_providers import AnthropicProvider, OpenAIProvider
 from .llm_types import LLMProvider
 from .model_aliases import resolve as resolve_model
-from .observability.metrics import try_get_instruments
 
 logger = logging.getLogger(__name__)
 
@@ -43,63 +42,6 @@ _OLLAMA_IMPORT_ERROR = (
 )
 
 
-# ─── Raw-ID deprecation signal (RFC 0033 PR 2) ──────────────
-#
-# When an agent's ``model:`` is a raw vendor ID rather than a
-# ``models.aliases`` entry, the factory keeps routing it (the §E
-# pass-through) but flags it: a human-facing deprecation warning, emitted
-# once per process so a society of raw agents does not spam the log, plus a
-# per-agent OTEL counter. The counter (``persatrix.llm.alias.raw_id_usage``)
-# reading zero across the dogfood window is the RFC 0033 Phase 3 entrance
-# signal — the gate that authorises removing the pass-through and
-# ``_infer_provider``. Both are de-duplicated so re-creating an agent's
-# provider within a process does not double-count; the counter dedup
-# records an agent only once it has actually been counted, so a
-# create_provider call that runs before metrics init (instruments
-# unavailable) is retried rather than silently marked counted.
-#
-# Scope caveat (Phase 3 gate): this counter covers only the create_provider
-# (agent) surface. The summarisation-model surface
-# (``persona_runtime.summarize_close``) resolves its own model and is NOT
-# counted here, so a raw summarisation model is invisible to the gate. PR 3
-# migrates *both* the agent configs and the summarisation field to aliases,
-# so a clean zero reading is authoritative only once that migration lands.
-#
-# The dedup is best-effort, not synchronized: concurrent create_provider
-# calls could in principle double-warn or double-count a raw agent. That is
-# harmless for a deprecation signal (worst case a duplicate log line / an
-# over-count by one) and agents are loaded sequentially at startup today, so
-# a lock would be over-engineering.
-_raw_id_warning_emitted = False
-_raw_id_counted_agents: set[str] = set()
-
-
-def _note_raw_id_usage(agent_id: str, model: str) -> None:
-    """Record that ``agent_id`` resolved a raw vendor ``model`` (RFC 0033 §E)."""
-    global _raw_id_warning_emitted
-    if not _raw_id_warning_emitted:
-        logger.warning(
-            "DEPRECATION (RFC 0033): agent %r references a raw vendor model "
-            "ID %r instead of a models.aliases entry. Migrate it to an alias "
-            "in config/optimization.yaml so a vendor retirement or provider "
-            "swap is a one-line edit. The raw-ID pass-through is removed in a "
-            "future release (Phase 3).",
-            agent_id,
-            model,
-        )
-        _raw_id_warning_emitted = True
-    if agent_id not in _raw_id_counted_agents:
-        # Record the agent as counted only *after* a successful emit. If the
-        # first create_provider for an agent runs before metrics init
-        # (instruments unavailable), leaving the set untouched lets a later
-        # call count it once instruments exist, rather than silently marking
-        # it counted-forever and under-reading the Phase 3 gate.
-        inst = try_get_instruments()
-        if inst is not None:
-            inst.alias_raw_id_usage.add(1, attributes={"agent.id": agent_id})
-            _raw_id_counted_agents.add(agent_id)
-
-
 def create_provider(agent_config: dict[str, Any]) -> tuple[LLMProvider, str]:
     """Create an LLM provider from agent config (RFC 0033 §D).
 
@@ -109,18 +51,15 @@ def create_provider(agent_config: dict[str, Any]) -> tuple[LLMProvider, str]:
 
     The ``model`` field is run through the RFC 0033 resolver and the resolved
     ``provider`` selects the concrete class — the **same standard path for
-    every provider** (``anthropic`` / ``openai`` / ``ollama`` / ``mock``):
-
-    * A declared ``models.aliases`` entry is authoritative for the
-      provider (an explicit, *disagreeing* ``provider:`` field is a
-      ``SystemExit`` — §D rule 1) and for ``provider_config`` per-field
-      (§D rule 2). So routing the whole society to a local / mock / OpenAI
-      provider is a one-line edit to the ``quality`` alias — exactly what the
-      ``make demo-*`` overlays mount.
-    * A raw vendor ID falls through (§E): the explicit ``provider:`` field
-      wins, else the provider is inferred from the prefix table; a
-      one-shot deprecation warning fires and the per-agent
-      ``persatrix.llm.alias.raw_id_usage`` counter increments.
+    every provider** (``anthropic`` / ``openai`` / ``ollama`` / ``mock``). The
+    ``model`` field must be a declared ``models.aliases`` entry: the alias is
+    authoritative for the provider (an explicit, *disagreeing* ``provider:``
+    field is a ``SystemExit`` — §D rule 1) and for ``provider_config``
+    per-field (§D rule 2). So routing the whole society to a local / mock /
+    OpenAI provider is a one-line edit to the ``quality`` alias — exactly what
+    the ``make demo-*`` overlays mount. A raw vendor ID is **not** accepted:
+    RFC 0033 Phase 3 retired the §E pass-through, so the resolver rejects any
+    non-alias reference with a loud ``SystemExit``.
 
     There is no global env force-knob — provider selection is config-driven
     (the v0.3.4 provider-parity refactor removed ``PERSATRIX_OFFLINE`` /
@@ -134,14 +73,12 @@ def create_provider(agent_config: dict[str, Any]) -> tuple[LLMProvider, str]:
 
     agent_id = agent_config.get("id", "<unknown>")
     explicit_provider = agent_config.get("provider")
-    # On the raw pass-through, an explicit provider field wins over prefix
-    # inference (§D rule 1, raw path); on the alias path the entry is
-    # authoritative and the hint is ignored by resolve().
-    resolved = resolve_model(model, explicit_provider=explicit_provider)
+    # The resolver rejects any non-alias reference (RFC 0033 Phase 3); on the
+    # alias path the entry is authoritative and an agent-entry provider hint
+    # is validated against it below, never used to route.
+    resolved = resolve_model(model)
 
-    if resolved.raw:
-        _note_raw_id_usage(str(agent_id), model)
-    elif explicit_provider and explicit_provider != resolved.provider:
+    if explicit_provider and explicit_provider != resolved.provider:
         # §D rule 1 — a model that resolves to an alias plus a disagreeing
         # explicit provider is a config bug, not a silent resolve-one-way.
         raise SystemExit(

--- a/agents/model_aliases.py
+++ b/agents/model_aliases.py
@@ -59,10 +59,11 @@ _LOCALHOST_HOSTS: frozenset[str] = frozenset(
 class ResolvedModel:
     """The resolved identity of a model reference (RFC 0033 §C).
 
-    ``alias`` is the logical name the reference came in as, or ``None``
-    when the reference was a raw vendor ID that fell through (``raw`` is
-    then ``True``). ``model`` is always the physical vendor ID the API
-    call must use — never the alias name.
+    ``alias`` is the logical name the reference came in as. As of RFC 0033
+    Phase 3 every resolved reference is a declared alias (the §E raw-vendor-ID
+    pass-through is retired), so ``alias`` is always set — the ``str | None``
+    type is kept for the public contract. ``model`` is always the physical
+    vendor ID the API call must use — never the alias name.
     """
 
     alias: str | None
@@ -71,7 +72,6 @@ class ResolvedModel:
     input_per_1m_tokens: float
     output_per_1m_tokens: float
     provider_config: dict[str, Any] = field(default_factory=dict)
-    raw: bool = False
 
 
 # ─── Test seam ────────────────────────────────────────────────
@@ -150,7 +150,6 @@ def _from_alias_entry(alias: str, entry: dict[str, Any]) -> ResolvedModel:
         input_per_1m_tokens=_coerce_price(entry.get("input_per_1m_tokens")),
         output_per_1m_tokens=_coerce_price(entry.get("output_per_1m_tokens")),
         provider_config=dict(provider_config),
-        raw=False,
     )
 
 
@@ -287,7 +286,7 @@ def validate_alias_pricing(
 def resolve(alias_or_model: str) -> ResolvedModel:
     """Resolve ``alias_or_model`` to a :class:`ResolvedModel`.
 
-    * A declared alias returns its configured record (``raw=False``). The
+    * A declared alias returns its configured record. The
       alias entry is the joint declaration of provider + model + pricing and
       stays authoritative (RFC 0033 §D rule 1; a *disagreeing* explicit
       provider on an agent entry is caught by the factory, not here). A

--- a/agents/model_aliases.py
+++ b/agents/model_aliases.py
@@ -7,20 +7,20 @@ retirement or a provider swap is a one-line edit to one map entry instead
 of a sweep across ``config/agents.yaml``, ``config/optimization.yaml``,
 ``agents/persona_types.py``, and the pricing table.
 
-During the cutover window the resolver also accepts a **raw vendor model
-ID** (e.g. ``claude-sonnet-4-20250514``) and passes it through unchanged,
-inferring the provider from the existing prefix table (RFC 0033 §E). A
-string that is neither a declared alias nor a recognised vendor prefix is
-a loud :class:`SystemExit` — the "clear up-front error" this RFC
-substitutes for ``_infer_provider``'s silent default-to-openai.
+As of RFC 0033 **Phase 3** the cutover-window raw-vendor-ID pass-through
+(§E) is **retired**: a model reference must be a declared alias. Any string
+that is not an alias — a raw vendor ID like ``claude-sonnet-4-20250514``, or
+a typo'd alias name — is a loud :class:`SystemExit` naming the string and
+pointing at ``models.aliases`` (the "clear up-front error" this RFC
+substitutes for ``_infer_provider``'s silent default-to-openai). There is no
+longer a ``raw=True`` record, no prefix inference, and no provider-hint
+escape hatch.
 
 This module is a **leaf**: it imports config accessors from
 :mod:`agents.optimization` only — never the provider classes or
 :class:`~agents.llm_client.LLMClient`. That keeps it unit-testable in
 isolation and, critically, avoids an import cycle with
-:mod:`agents.llm_client`, which imports *this* module once the factory is
-rewired (RFC 0033 PR 2). PR 1 ships the resolver **unconsumed** — no call
-site reads it yet, so it changes no runtime behaviour.
+:mod:`agents.llm_client`, which imports *this* module via the factory.
 """
 
 from __future__ import annotations
@@ -33,20 +33,8 @@ from typing import Any
 from urllib.parse import urlparse
 
 from agents.optimization import model_aliases as _load_alias_block
-from agents.optimization import provider_inference
 
 logger = logging.getLogger(__name__)
-
-# Fallback prefix table for the raw-ID pass-through, used only when
-# config/optimization.yaml ships no ``provider_inference`` block. Mirrors
-# ``agents.llm_client._OPENAI_EXACT_MODELS`` / ``_OPENAI_PREFIX_MODELS``;
-# tests/unit/python/test_optimization.py pins the shipped YAML to those
-# constants, so the config remains the single source of truth and these
-# only bind in a config-less dev checkout. They are not imported from
-# ``llm_client`` because that module imports *this* one in PR 2 (cycle).
-_DEFAULT_ANTHROPIC_PREFIXES: tuple[str, ...] = ("claude",)
-_DEFAULT_OPENAI_EXACT: frozenset[str] = frozenset({"o1", "o3", "o4"})
-_DEFAULT_OPENAI_PREFIXES: tuple[str, ...] = ("gpt-", "o1-", "o3-", "o4-")
 
 # Local providers run on the operator's own machine at $0 real cost, so a
 # $0 (or absent) price on their alias entries is by design — the
@@ -166,27 +154,6 @@ def _from_alias_entry(alias: str, entry: dict[str, Any]) -> ResolvedModel:
     )
 
 
-def _infer_raw_provider(model: str) -> str:
-    """Infer the provider for a raw vendor model ID from the prefix table
-    (RFC 0033 §E). Raises :class:`SystemExit` for a string that matches no
-    known prefix — that is neither an alias nor a recognised vendor ID."""
-    rules = provider_inference()
-    anthropic_prefixes = tuple(
-        rules.get("anthropic_prefixes", _DEFAULT_ANTHROPIC_PREFIXES),
-    )
-    openai_exact = frozenset(rules.get("openai_exact", _DEFAULT_OPENAI_EXACT))
-    openai_prefixes = tuple(rules.get("openai_prefixes", _DEFAULT_OPENAI_PREFIXES))
-    if model.startswith(anthropic_prefixes):
-        return "anthropic"
-    if model in openai_exact or model.startswith(openai_prefixes):
-        return "openai"
-    raise SystemExit(
-        f"Unknown model reference {model!r}: not a declared alias in "
-        f"models.aliases and not a recognised vendor model ID. Declare it "
-        f"as an alias in config/optimization.yaml or use a known vendor ID.",
-    )
-
-
 def _provider_is_local(entry: dict[str, Any]) -> bool:
     """Whether an alias entry routes to a local ($0-real) provider.
 
@@ -255,9 +222,9 @@ def _check_entry_pricing(alias: str, entry: dict[str, Any]) -> None:
     priced alias (the PR 3 cost-regression row in the RFC 0033 PR plan). A
     local ($0-by-design) entry is exempt (:func:`_provider_is_local`),
     so an explicit-0 simulation price and a forgotten cloud price are
-    distinguishable. The guard is **scoped to the alias surface** — the raw-ID
-    fall-through in :func:`resolve` keeps its deliberate §E graceful-
-    degradation behaviour, which Phase 3 closes.
+    distinguishable. Since RFC 0033 Phase 3 retired the §E raw-vendor-ID
+    pass-through, the alias surface is the *only* surface — every resolved
+    reference is a declared alias and runs through this guard.
     """
     if _provider_is_local(entry):
         return
@@ -317,30 +284,23 @@ def validate_alias_pricing(
     _check_alias_pricing(mapping)
 
 
-def resolve(
-    alias_or_model: str, *, explicit_provider: str | None = None,
-) -> ResolvedModel:
+def resolve(alias_or_model: str) -> ResolvedModel:
     """Resolve ``alias_or_model`` to a :class:`ResolvedModel`.
 
-    * A declared alias returns its configured record (``raw=False``).
-      ``explicit_provider`` is ignored here — the alias entry is the joint
-      declaration of provider + model + pricing and stays authoritative
-      (RFC 0033 §D rule 1; a *disagreeing* explicit provider is caught by
-      the factory, not silently overridden here). A config-backed alias is
-      run through the missing-price guard (RFC 0033 PR 4), scoped to *this*
-      entry: an unpriced non-local alias fails closed with a loud
-      :class:`SystemExit`, enforcing the inline-price invariant PR 5's cost-
-      table derivation keys the RFC 0023 budget gate from (see
+    * A declared alias returns its configured record (``raw=False``). The
+      alias entry is the joint declaration of provider + model + pricing and
+      stays authoritative (RFC 0033 §D rule 1; a *disagreeing* explicit
+      provider on an agent entry is caught by the factory, not here). A
+      config-backed alias is run through the missing-price guard (RFC 0033
+      PR 4), scoped to *this* entry: an unpriced non-local alias fails closed
+      with a loud :class:`SystemExit`, enforcing the inline-price invariant
+      the cost-table derivation keys the RFC 0023 budget gate from (see
       :func:`_check_entry_pricing`).
-    * A recognised raw vendor ID falls through with ``alias=None,
-      raw=True``. When ``explicit_provider`` is given it wins over prefix
-      inference (§D rule 1, raw path — preserves today's
-      ``agent_config.get("provider") or _infer_provider(model)`` so a
-      per-agent ``provider: ollama`` on a local tag like ``llama3.2`` that
-      no prefix rule recognises still resolves). Otherwise the provider is
-      inferred from the prefix table (§E). The raw record carries no
-      pricing (the Go cost path keys off telemetry, §F).
-    * Anything else is a loud :class:`SystemExit` naming the string.
+    * Anything else — a raw vendor ID or a typo'd alias name — is a loud
+      :class:`SystemExit` naming the string. RFC 0033 **Phase 3** retired the
+      §E raw-vendor-ID pass-through: there is no prefix inference, no
+      ``raw=True`` record, and no provider-hint escape hatch. The single
+      source of truth for model identity is ``models.aliases``.
     """
     if not alias_or_model or not alias_or_model.strip():
         raise SystemExit("Model reference is empty")
@@ -373,15 +333,13 @@ def resolve(
             _check_entry_pricing(alias_or_model, entry)
         return _from_alias_entry(alias_or_model, entry)
 
-    provider = explicit_provider or _infer_raw_provider(alias_or_model)
-    return ResolvedModel(
-        alias=None,
-        provider=provider,
-        model=alias_or_model,
-        input_per_1m_tokens=0.0,
-        output_per_1m_tokens=0.0,
-        provider_config={},
-        raw=True,
+    # RFC 0033 Phase 3 — the §E raw-vendor-ID pass-through is retired. A
+    # reference that is not a declared alias is a config error, not a silent
+    # route: fail loud, naming the string and the one place to declare it.
+    raise SystemExit(
+        f"Unknown model reference {alias_or_model!r}: not a declared alias in "
+        f"models.aliases. Declare it as an alias in config/optimization.yaml "
+        f"(the raw vendor-ID pass-through was removed in RFC 0033 Phase 3).",
     )
 
 

--- a/agents/persona_runtime/summarize_close.py
+++ b/agents/persona_runtime/summarize_close.py
@@ -145,21 +145,18 @@ async def summarize_closed_interaction(
     prompt = _build_summarization_prompt(interaction, view)
     # Summarisation picks its model on a surface separate from
     # create_provider; resolve it here too (RFC 0033 §D) so the alias name
-    # never reaches the vendor API. While the config field is still a raw
-    # Haiku ID, resolve() returns it unchanged; PR 3's flip to the
-    # ``summarizer`` alias resolves to the physical model the same way the
-    # factory path does.
+    # never reaches the vendor API. The config field references the
+    # ``summarizer`` alias, which resolves to the physical model the same way
+    # the factory path does.
     #
     # resolve() is a *startup* validator — it raises SystemExit (a
-    # BaseException) on an unknown reference. This surface runs per-close on
-    # a background task whose caller (finalize_closed_interaction) guards
-    # only ``except Exception``, so an unresolvable summarisation model must
-    # degrade to the deterministic fallback like every other failure here
-    # rather than escape as an uncaught task exception that also skips the
-    # failure metric. NOTE: this surface is *not* counted by
-    # persatrix.llm.alias.raw_id_usage (that counter covers only the
-    # create_provider/agent surface), so a raw summarisation model is
-    # invisible to the RFC 0033 Phase 3 gate until PR 3 migrates it.
+    # BaseException) on an unknown reference (and, since RFC 0033 Phase 3
+    # retired the raw-vendor-ID pass-through, on any non-alias reference).
+    # This surface runs per-close on a background task whose caller
+    # (finalize_closed_interaction) guards only ``except Exception``, so an
+    # unresolvable summarisation model must degrade to the deterministic
+    # fallback like every other failure here rather than escape as an
+    # uncaught task exception that also skips the failure metric.
     summarization_model_ref = summarization_model()
     try:
         resolved_summarization = resolve_model(summarization_model_ref)

--- a/agents/persona_runtime/summarize_close.py
+++ b/agents/persona_runtime/summarize_close.py
@@ -173,7 +173,8 @@ async def summarize_closed_interaction(
             llm_client.create_message(
                 model=resolved_summarization.model,
                 # RFC 0033 §G — emit the alias the summariser model came in via
-                # (e.g. ``summarizer``) on the span; None on the raw-ID path.
+                # (e.g. ``summarizer``) on the span. Since Phase 3 retired the
+                # raw-ID pass-through, a resolved reference is always an alias.
                 model_alias=resolved_summarization.alias,
                 messages=[{"role": "user", "content": prompt}],
                 system=load_snippet("episode-summarizer"),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,11 +17,14 @@ def _resolvable_summarization_model(monkeypatch: pytest.MonkeyPatch) -> None:
     this they collapse to the fallback and fail on the LLM-summary assertion.
 
     Mirrors the unit-suite fixture in ``tests/unit/python/conftest.py``: it
-    patches only the name bound *inside* ``summarize_close`` (not the
+    patches only the names bound *inside* ``summarize_close`` (not the
     ``agents.optimization`` accessor), so its effect is confined to
-    ``summarize_closed_interaction`` callers. Those tests mock the LLM, so the
-    model only needs to *resolve*, never call out — a raw vendor id the prefix
-    table recognises does that. Tests that deliberately want an unresolvable
+    ``summarize_closed_interaction`` callers. RFC 0033 Phase 3 retired the
+    raw-vendor-ID pass-through, so a raw id no longer resolves; the baseline
+    instead stubs ``resolve_model`` to a canned
+    :class:`~agents.model_aliases.ResolvedModel` directly — the close-path
+    tests mock the LLM, so the model only needs to *resolve* to a valid
+    record, never call out. Tests that deliberately want an unresolvable
     model re-monkeypatch this in the test body, which wins over this baseline.
 
     See ISSUE-0076: CI never ran the full ``tests/integration/`` suite, so the
@@ -29,5 +32,17 @@ def _resolvable_summarization_model(monkeypatch: pytest.MonkeyPatch) -> None:
     close-path tests silently broken.
     """
     import agents.persona_runtime.summarize_close as sc
+    from agents.model_aliases import ResolvedModel
 
-    monkeypatch.setattr(sc, "summarization_model", lambda: "claude-haiku-test")
+    monkeypatch.setattr(sc, "summarization_model", lambda: "summarizer")
+    monkeypatch.setattr(
+        sc,
+        "resolve_model",
+        lambda _ref: ResolvedModel(
+            alias="summarizer",
+            provider="anthropic",
+            model="claude-haiku-test",
+            input_per_1m_tokens=0.80,
+            output_per_1m_tokens=4.00,
+        ),
+    )

--- a/tests/unit/python/conftest.py
+++ b/tests/unit/python/conftest.py
@@ -60,23 +60,38 @@ def _resolvable_summarization_model(monkeypatch: pytest.MonkeyPatch) -> None:
     v0.3.4 "no default provider": the shipped base ``config/optimization.yaml``
     ships the ``summarizer`` alias UNCONFIGURED, so the default
     ``summarization_model()`` → ``"summarizer"`` → ``model_aliases.resolve``
-    now raises a loud ``SystemExit``. ``summarize_closed_interaction`` catches
+    raises a loud ``SystemExit``. ``summarize_closed_interaction`` catches
     that and degrades to ``SUMMARY_UNAVAILABLE_TEXT`` *before* reaching the
     envelope-parse / fact-extraction logic the close-path tests
     (``test_summarize_close_helpers`` / ``test_envelope_parse_observability``)
     pin — so without this they'd all collapse to the fallback.
 
-    The patch targets only the name bound *inside* ``summarize_close`` (not the
+    The patch targets only the names bound *inside* ``summarize_close`` (not the
     ``agents.optimization`` accessor ``test_optimization_routing`` asserts
     against), so its effect is confined to ``summarize_closed_interaction``
-    callers. Those tests mock the LLM, so the model only needs to *resolve*,
-    never call out — a raw vendor id the prefix table recognises does that.
-    Tests that deliberately want an unresolvable model re-monkeypatch this in
-    the test body, which wins over this baseline.
+    callers. RFC 0033 Phase 3 retired the raw-vendor-ID pass-through, so a
+    raw id no longer resolves; the baseline instead stubs ``resolve_model``
+    to a canned :class:`~agents.model_aliases.ResolvedModel` directly — the
+    close-path tests mock the LLM, so the model only needs to *resolve* to a
+    valid record, never call out. Tests that deliberately want an
+    unresolvable model re-monkeypatch this in the test body (raising
+    ``SystemExit`` from the stub), which wins over this baseline.
     """
     import agents.persona_runtime.summarize_close as sc
+    from agents.model_aliases import ResolvedModel
 
-    monkeypatch.setattr(sc, "summarization_model", lambda: "claude-haiku-test")
+    monkeypatch.setattr(sc, "summarization_model", lambda: "summarizer")
+    monkeypatch.setattr(
+        sc,
+        "resolve_model",
+        lambda _ref: ResolvedModel(
+            alias="summarizer",
+            provider="anthropic",
+            model="claude-haiku-test",
+            input_per_1m_tokens=0.80,
+            output_per_1m_tokens=4.00,
+        ),
+    )
 
 
 @pytest.fixture

--- a/tests/unit/python/test_llm_client.py
+++ b/tests/unit/python/test_llm_client.py
@@ -22,6 +22,7 @@ from agents.llm_client import (
     _infer_provider,
     create_provider,
 )
+from agents.model_aliases import use_alias_map
 
 # ─── Helpers ────────────────────────────────────────────────
 
@@ -440,44 +441,37 @@ class TestCreateProvider:
         assert _infer_provider("o4-mini") == "openai"
         assert _infer_provider("o4") == "openai"
 
-    def test_explicit_anthropic_provider(self):
-        mock_anthropic = MagicMock()
-        mock_anthropic.AsyncAnthropic.return_value = AsyncMock()
-        with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
-            provider, model = create_provider(
-                {"model": "claude-sonnet-4-20250514", "provider": "anthropic"}
-            )
-            assert isinstance(provider, AnthropicProvider)
-            assert model == "claude-sonnet-4-20250514"
+    # As of RFC 0033 Phase 3 ``create_provider`` accepts only declared aliases
+    # (the raw-vendor-ID pass-through is retired), so these route through the
+    # alias seam: the alias's ``provider`` selects the class, its ``model`` is
+    # the physical id returned. Raw-ID rejection and provider_config precedence
+    # are pinned in test_llm_factory.py; here we pin the llm_client re-export.
+    @staticmethod
+    def _alias(provider: str, model: str) -> dict:
+        return {"a": {"provider": provider, "model": model,
+                      "input_per_1m_tokens": 1.0, "output_per_1m_tokens": 1.0}}
 
-    def test_explicit_openai_provider(self):
-        mock_openai = MagicMock()
-        mock_openai.AsyncOpenAI.return_value = AsyncMock()
-        with patch.dict(sys.modules, {"openai": mock_openai}):
-            provider, model = create_provider({"model": "gpt-4o", "provider": "openai"})
-            assert isinstance(provider, OpenAIProvider)
-            assert model == "gpt-4o"
+    def test_alias_routes_to_anthropic_provider(self):
+        mod = MagicMock()
+        mod.AsyncAnthropic.return_value = AsyncMock()
+        with use_alias_map(self._alias("anthropic", "claude-sonnet-4-20250514")), \
+                patch.dict(sys.modules, {"anthropic": mod}):
+            provider, model = create_provider({"model": "a"})
+        assert isinstance(provider, AnthropicProvider)
+        assert model == "claude-sonnet-4-20250514"
 
-    def test_openai_with_base_url(self):
-        mock_openai = MagicMock()
-        mock_openai.AsyncOpenAI.return_value = AsyncMock()
-        with patch.dict(sys.modules, {"openai": mock_openai}):
-            provider, model = create_provider({
-                "model": "qwen2.5-coder:32b",
-                "provider": "openai",
-                "provider_config": {"base_url": "http://localhost:11434/v1"},
-            })
-            assert isinstance(provider, OpenAIProvider)
-            assert model == "qwen2.5-coder:32b"
+    def test_alias_routes_to_openai_provider(self):
+        mod = MagicMock()
+        mod.AsyncOpenAI.return_value = AsyncMock()
+        with use_alias_map(self._alias("openai", "gpt-4o")), \
+                patch.dict(sys.modules, {"openai": mod}):
+            provider, model = create_provider({"model": "a"})
+        assert isinstance(provider, OpenAIProvider)
+        assert model == "gpt-4o"
 
     def test_unknown_provider_exits(self):
-        with pytest.raises(SystemExit, match="Unknown LLM provider"):
-            create_provider({"model": "test", "provider": "unknown"})
-
-    def test_inferred_from_model_prefix(self):
-        mock_anthropic = MagicMock()
-        mock_anthropic.AsyncAnthropic.return_value = AsyncMock()
-        with patch.dict(sys.modules, {"anthropic": mock_anthropic}):
-            provider, model = create_provider({"model": "claude-sonnet-4-20250514"})
-            assert isinstance(provider, AnthropicProvider)
-            assert model == "claude-sonnet-4-20250514"
+        # An alias may declare any provider string; an unrecognised one falls
+        # through every factory branch to the "Unknown LLM provider" exit.
+        with use_alias_map(self._alias("unknown", "x")), \
+                pytest.raises(SystemExit, match="Unknown LLM provider"):
+            create_provider({"model": "a"})

--- a/tests/unit/python/test_llm_factory.py
+++ b/tests/unit/python/test_llm_factory.py
@@ -199,7 +199,8 @@ class TestStockConfigMigration:
         try:
             for agent in self._shipped_agents():
                 resolved = resolve(agent["model"])
-                assert resolved.raw is False, f"{agent['id']} still uses a raw vendor ID"
+                # Phase 3 retired the raw pass-through, so a successful resolve
+                # is already proof the agent routes via a declared alias.
                 assert resolved.alias in {"quality", "fast", "summarizer"}, agent["id"]
                 assert resolved.provider == "anthropic", agent["id"]
         finally:

--- a/tests/unit/python/test_llm_factory.py
+++ b/tests/unit/python/test_llm_factory.py
@@ -1,21 +1,19 @@
 """Tests for the provider factory (``agents.llm_factory``).
 
-PR 2 of the RFC 0033 PR plan rewires ``create_provider`` to consume the
-alias resolver and return ``(provider, physical_model)``. These tests pin
-the §D precedence rules and the raw-ID deprecation signal (the one-shot
-warning + the per-agent ``persatrix.llm.alias.raw_id_usage`` counter that
-gates Phase 3).
+``create_provider`` consumes the alias resolver and returns
+``(provider, physical_model)``. These tests pin the §D precedence rules.
+As of RFC 0033 **Phase 3** the §E raw-vendor-ID pass-through is retired:
+a ``model:`` that is not a declared alias is a loud ``SystemExit`` at
+factory time, so there is no longer a deprecation warning or a
+``persatrix.llm.alias.raw_id_usage`` gate counter to exercise here.
 
-``create_provider`` is exercised through its public
-``agents.llm_client`` re-export to also pin that import path; the
-process-wide raw-ID dedup state and the ``try_get_instruments`` hook live
-in ``agents.llm_factory``, so those patch/monkeypatch targets point there.
-All tests use mocked SDK modules — no real API calls.
+``create_provider`` is exercised through its public ``agents.llm_client``
+re-export to also pin that import path. All tests use mocked SDK modules —
+no real API calls.
 """
 
 from __future__ import annotations
 
-import logging
 import os
 import sys
 from pathlib import Path
@@ -25,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import yaml
 
-from agents import llm_factory, optimization
+from agents import optimization
 from agents.llm_client import AnthropicProvider, OpenAIProvider, create_provider
 from agents.model_aliases import resolve, use_alias_map
 
@@ -58,13 +56,6 @@ def _mock_openai_module() -> MagicMock:
     mod = MagicMock()
     mod.AsyncOpenAI.return_value = AsyncMock()
     return mod
-
-
-@pytest.fixture
-def _reset_raw_id_signal(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Reset the process-wide raw-ID dedup state so each test starts clean."""
-    monkeypatch.setattr(llm_factory, "_raw_id_warning_emitted", False)
-    monkeypatch.setattr(llm_factory, "_raw_id_counted_agents", set())
 
 
 class TestCreateProviderAliasResolution:
@@ -118,76 +109,32 @@ class TestCreateProviderAliasResolution:
         assert mod.AsyncOpenAI.call_args.kwargs["base_url"] == "https://alias-host/v1"
 
 
-class TestCreateProviderRawIdSignal:
-    """RFC 0033 PR 2 — raw vendor IDs warn once + feed the Phase 3 gate counter."""
+class TestCreateProviderRejectsRawId:
+    """RFC 0033 Phase 3 — the §E raw-vendor-ID pass-through is retired.
 
-    def test_raw_id_emits_deprecation_warning_once_per_process(
-        self, _reset_raw_id_signal: None, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        with use_alias_map(_ALIAS_MAP), patch.dict(
-            sys.modules, {"anthropic": _mock_anthropic_module()}
-        ), caplog.at_level(logging.WARNING, logger="agents.llm_factory"):
-            _, model = create_provider(
-                {"id": "raw-agent", "model": "claude-sonnet-4-20250514"}
-            )
-            # Second creation for the same raw agent must not re-warn.
+    A ``model:`` that is not a declared alias no longer routes with a
+    deprecation warning; it is a loud ``SystemExit`` at factory time,
+    naming the offending string so an operator declares it as an alias.
+    """
+
+    def test_raw_vendor_id_raises_systemexit(self) -> None:
+        with use_alias_map(_ALIAS_MAP), pytest.raises(SystemExit) as exc:
             create_provider({"id": "raw-agent", "model": "claude-sonnet-4-20250514"})
-        deprecations = [r for r in caplog.records if "RFC 0033" in r.getMessage()]
-        assert len(deprecations) == 1
-        assert "claude-sonnet-4-20250514" in deprecations[0].getMessage()
-        # The physical id still flows through unchanged on the raw path.
-        assert model == "claude-sonnet-4-20250514"
+        assert "claude-sonnet-4-20250514" in str(exc.value)
 
-    def test_raw_id_increments_counter_once_per_agent(
-        self, _reset_raw_id_signal: None
-    ) -> None:
-        fake_inst = MagicMock()
+    def test_raw_vendor_id_raises_before_any_provider_built(self) -> None:
+        # The resolver rejects the raw id before the factory ever reaches a
+        # provider branch, so no SDK module import is needed for the failure.
+        with use_alias_map(_ALIAS_MAP), pytest.raises(SystemExit):
+            create_provider({"id": "raw-o", "model": "gpt-4o"})
+
+    def test_alias_path_still_resolves(self) -> None:
+        # The alias path is unaffected — a declared alias resolves normally.
         with use_alias_map(_ALIAS_MAP), patch.dict(
             sys.modules, {"anthropic": _mock_anthropic_module()}
-        ), patch("agents.llm_factory.try_get_instruments", return_value=fake_inst):
-            create_provider({"id": "raw-x", "model": "claude-sonnet-4-20250514"})
-            create_provider({"id": "raw-x", "model": "claude-sonnet-4-20250514"})
-        fake_inst.alias_raw_id_usage.add.assert_called_once_with(
-            1, attributes={"agent.id": "raw-x"}
-        )
-
-    def test_raw_id_counter_retries_when_instruments_unavailable_first(
-        self, _reset_raw_id_signal: None
-    ) -> None:
-        """The Phase 3 gate counter must not silently under-read.
-
-        The counter de-dup records an agent only *after* a successful emit:
-        if the first ``create_provider`` runs before metrics init
-        (``try_get_instruments()`` returns ``None``), a later call once
-        instruments exist must still count the agent — otherwise the gate
-        counter under-reads and could falsely open. ``side_effect=[None,
-        fake_inst]`` simulates instruments coming up between the two calls.
-        """
-        fake_inst = MagicMock()
-        with use_alias_map(_ALIAS_MAP), patch.dict(
-            sys.modules, {"anthropic": _mock_anthropic_module()}
-        ), patch(
-            "agents.llm_factory.try_get_instruments",
-            side_effect=[None, fake_inst],
         ):
-            create_provider({"id": "raw-late", "model": "claude-sonnet-4-20250514"})
-            create_provider({"id": "raw-late", "model": "claude-sonnet-4-20250514"})
-        fake_inst.alias_raw_id_usage.add.assert_called_once_with(
-            1, attributes={"agent.id": "raw-late"}
-        )
-
-    def test_alias_path_emits_no_raw_id_signal(
-        self, _reset_raw_id_signal: None, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        fake_inst = MagicMock()
-        with use_alias_map(_ALIAS_MAP), patch.dict(
-            sys.modules, {"anthropic": _mock_anthropic_module()}
-        ), patch(
-            "agents.llm_factory.try_get_instruments", return_value=fake_inst
-        ), caplog.at_level(logging.WARNING, logger="agents.llm_factory"):
-            create_provider({"id": "q", "model": "quality"})
-        assert not any("RFC 0033" in r.getMessage() for r in caplog.records)
-        fake_inst.alias_raw_id_usage.add.assert_not_called()
+            _, model = create_provider({"id": "q", "model": "quality"})
+        assert model == "claude-sonnet-4-6"
 
 
 class TestStockConfigMigration:
@@ -259,21 +206,18 @@ class TestStockConfigMigration:
             os.environ.pop("PERSATRIX_OPTIMIZATION_CONFIG", None)
             optimization.reset_cache()
 
-    def test_create_provider_for_stock_agents_emits_no_raw_id_warning(
-        self, _reset_raw_id_signal: None, caplog: pytest.LogCaptureFixture
-    ) -> None:
+    def test_create_provider_for_stock_agents_builds_physical_model(self) -> None:
+        # Against the configured anthropic demo, every stock agent builds a
+        # provider and returns the physical vendor id (never an alias name) —
+        # the alias path the Phase 3 resolver leaves as the only path.
         os.environ["PERSATRIX_OPTIMIZATION_CONFIG"] = self._ANTHROPIC_DEMO
         optimization.reset_cache()
         try:
             agents = self._shipped_agents()
-            with patch.dict(
-                sys.modules, {"anthropic": _mock_anthropic_module()}
-            ), caplog.at_level(logging.WARNING, logger="agents.llm_factory"):
+            with patch.dict(sys.modules, {"anthropic": _mock_anthropic_module()}):
                 for agent in agents:
-                    create_provider(agent)
-            assert not any(
-                "RFC 0033" in r.getMessage() for r in caplog.records
-            ), "a stock agent still trips the raw-ID deprecation warning"
+                    _, model = create_provider(agent)
+                    assert model == "claude-sonnet-4-6", agent["id"]
         finally:
             os.environ.pop("PERSATRIX_OPTIMIZATION_CONFIG", None)
             optimization.reset_cache()

--- a/tests/unit/python/test_llm_offline.py
+++ b/tests/unit/python/test_llm_offline.py
@@ -168,11 +168,33 @@ def test_create_provider_alias_routes_to_mock() -> None:
     assert model == "offline"
 
 
-def test_create_provider_explicit_mock_per_agent() -> None:
-    """A per-agent ``provider: mock`` routes to MockProvider on the raw path."""
-    provider, _model = create_provider(
-        {"id": "x", "model": "claude-sonnet-4-20250514", "provider": "mock"}
-    )
+# A configured anthropic alias for the "real provider is used" cases — as of
+# RFC 0033 Phase 3 a raw vendor ID is rejected, so these route via an alias.
+_ANTHROPIC_ALIAS = {
+    "quality": {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "input_per_1m_tokens": 3.0,
+        "output_per_1m_tokens": 15.0,
+    },
+}
+
+
+def test_create_provider_agreeing_mock_provider_field() -> None:
+    """A redundant-but-agreeing per-agent ``provider: mock`` field on a mock
+    alias is accepted (RFC 0033 §D rule 1) and routes to MockProvider."""
+    alias_map = {
+        "offline": {
+            "provider": "mock",
+            "model": "mock",
+            "input_per_1m_tokens": 0,
+            "output_per_1m_tokens": 0,
+        },
+    }
+    with use_alias_map(alias_map):
+        provider, _model = create_provider(
+            {"id": "x", "model": "offline", "provider": "mock"}
+        )
     assert isinstance(provider, MockProvider)
 
 
@@ -186,20 +208,20 @@ def test_create_provider_offline_env_does_not_force_mock(
     effect — the agent resolves to its configured provider.
     """
     monkeypatch.setenv("PERSATRIX_OFFLINE", "1")
-    provider, _model = create_provider(
-        {"id": "ember-owl", "model": "claude-sonnet-4-20250514"}
-    )
+    with use_alias_map(_ANTHROPIC_ALIAS):
+        provider, _model = create_provider({"id": "ember-owl", "model": "quality"})
     assert not isinstance(provider, MockProvider)
     assert provider.name == "anthropic"
 
 
 def test_create_provider_normal_path_unaffected() -> None:
-    """With no provider override, the real SDK provider is used."""
-    provider, model = create_provider({"id": "x", "model": "claude-sonnet-4-20250514"})
+    """With no provider override, the real SDK provider is used and the
+    alias's physical model id reaches the call site."""
+    with use_alias_map(_ANTHROPIC_ALIAS):
+        provider, model = create_provider({"id": "x", "model": "quality"})
     assert not isinstance(provider, MockProvider)
     assert provider.name == "anthropic"
-    # The raw vendor id passes through unchanged (RFC 0033 §E).
-    assert model == "claude-sonnet-4-20250514"
+    assert model == "claude-sonnet-4-6"
 
 
 def test_mock_provider_reexported_from_llm_client() -> None:

--- a/tests/unit/python/test_llm_ollama.py
+++ b/tests/unit/python/test_llm_ollama.py
@@ -156,26 +156,48 @@ async def test_create_message_passes_model_verbatim() -> None:
 # ─── create_provider routing ────────────────────────────────
 
 
-def test_create_provider_explicit_ollama_per_agent() -> None:
-    """Per-agent ``provider: ollama`` routes to OllamaProvider; the
-    configured Ollama tag is used verbatim."""
+# RFC 0033 Phase 3 retired the raw-vendor-ID pass-through, so every agent
+# routes through a declared alias. An ``ollama`` alias whose physical ``model``
+# is the local tag; an ``anthropic`` alias for the "real cloud" cases.
+_OLLAMA_ALIAS = {
+    "local": {
+        "provider": "ollama",
+        "model": "llama3.2",
+        "input_per_1m_tokens": 0,
+        "output_per_1m_tokens": 0,
+    },
+}
+_ANTHROPIC_ALIAS = {
+    "quality": {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "input_per_1m_tokens": 3.0,
+        "output_per_1m_tokens": 15.0,
+    },
+}
+
+
+def test_create_provider_ollama_alias_per_agent() -> None:
+    """An ``ollama`` alias routes to OllamaProvider; the configured Ollama tag
+    is used verbatim. The agreeing per-agent ``provider: ollama`` is accepted."""
     mod, _client = _mock_openai_module()
-    with patch.dict(sys.modules, {"openai": mod}):
+    with use_alias_map(_OLLAMA_ALIAS), patch.dict(sys.modules, {"openai": mod}):
         provider, model = create_provider(
-            {"id": "x", "model": "llama3.2", "provider": "ollama"}
+            {"id": "x", "model": "local", "provider": "ollama"}
         )
     assert isinstance(provider, OllamaProvider)
     assert model == "llama3.2"
 
 
 def test_create_provider_ollama_respects_provider_config_base_url() -> None:
+    # §D rule 2 — the alias leaves provider_config unset, so the agent entry's
+    # base_url fills the gap and reaches the SDK call.
     mod, _client = _mock_openai_module()
-    with patch.dict(sys.modules, {"openai": mod}):
+    with use_alias_map(_OLLAMA_ALIAS), patch.dict(sys.modules, {"openai": mod}):
         create_provider(
             {
                 "id": "x",
-                "model": "llama3.2",
-                "provider": "ollama",
+                "model": "local",
                 "provider_config": {"base_url": "http://gpu-box:11434/v1"},
             }
         )
@@ -196,10 +218,8 @@ def test_create_provider_ollama_model_env_override(
     """
     monkeypatch.setenv("PERSATRIX_OLLAMA_MODEL", "qwen2.5")
     mod, _client = _mock_openai_module()
-    with patch.dict(sys.modules, {"openai": mod}):
-        provider, model = create_provider(
-            {"id": "x", "model": "llama3.2", "provider": "ollama"}
-        )
+    with use_alias_map(_OLLAMA_ALIAS), patch.dict(sys.modules, {"openai": mod}):
+        provider, model = create_provider({"id": "x", "model": "local"})
     assert isinstance(provider, OllamaProvider)
     assert model == "qwen2.5"
 
@@ -214,9 +234,8 @@ def test_create_provider_ollama_env_does_not_force_provider(
     provider.
     """
     monkeypatch.setenv("PERSATRIX_OLLAMA", "1")
-    provider, _model = create_provider(
-        {"id": "ember-owl", "model": "claude-sonnet-4-6"}
-    )
+    with use_alias_map(_ANTHROPIC_ALIAS):
+        provider, _model = create_provider({"id": "ember-owl", "model": "quality"})
     assert not isinstance(provider, OllamaProvider)
     assert provider.name == "anthropic"
 

--- a/tests/unit/python/test_missing_price_guard.py
+++ b/tests/unit/python/test_missing_price_guard.py
@@ -8,8 +8,9 @@ path's ``EstimateCost`` returns ``$0`` for any model absent from the
 pricing table, which silently disables the RFC 0023 pre-call lease /
 budget gate for that agent. A non-local alias with no price is a loud
 ``SystemExit``; a local ($0-by-design) alias is distinguishable from an
-unpriced one and passes silently; the raw-ID fall-through (§E) is left
-untouched (that back-compat half-step is Phase 3's to close).
+unpriced one and passes silently. As of RFC 0033 Phase 3 the §E raw-ID
+fall-through is retired, so a raw vendor ID is rejected up front by the
+resolver and never reaches this guard at all.
 """
 
 from __future__ import annotations
@@ -213,17 +214,16 @@ class TestMissingPriceGuard:
         with use_alias_map({}):
             validate_alias_pricing()
 
-    # ── raw-ID fall-through is NOT subject to the guard (§E) ──
-    def test_raw_id_fall_through_not_failed_closed(
+    # ── raw-ID references are rejected outright (RFC 0033 Phase 3) ──
+    def test_raw_id_reference_raises_systemexit(
         self, isolated_config: None,
     ) -> None:
-        # A valid (all-priced) map; resolving a raw vendor ID still degrades
-        # to a $0 record rather than tripping the fail-closed guard — that
-        # back-compat half-step is Phase 3's to close, not PR 4's.
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("claude-sonnet-4-20250514")
-        assert resolved.raw is True
-        assert resolved.input_per_1m_tokens == 0.0
+        # Phase 3 retired the §E pass-through: a raw vendor ID no longer
+        # degrades to a $0 record at all — it never reaches the price guard
+        # because the resolver rejects it up front as an undeclared alias.
+        with use_alias_map(_SAMPLE_ALIASES), pytest.raises(SystemExit) as exc:
+            resolve("claude-sonnet-4-20250514")
+        assert "claude-sonnet-4-20250514" in str(exc.value)
 
     # ── the guard runs on the first config-backed resolve (not at load) ──
     def test_guard_fires_on_first_resolve_from_config(

--- a/tests/unit/python/test_model_aliases.py
+++ b/tests/unit/python/test_model_aliases.py
@@ -88,13 +88,23 @@ class TestAliasHit:
             input_per_1m_tokens=3.00,
             output_per_1m_tokens=15.00,
             provider_config={},
-            raw=False,
         )
 
-    def test_alias_is_not_raw(self) -> None:
+    def test_alias_carries_its_logical_name(self) -> None:
         with use_alias_map(_SAMPLE_ALIASES):
-            assert resolve("fast").raw is False
             assert resolve("fast").alias == "fast"
+
+    def test_resolved_model_has_no_raw_field(self) -> None:
+        # RFC 0033 Phase 3 retired the raw-vendor-ID pass-through, so a
+        # resolved record is *always* a declared alias. The vestigial ``raw``
+        # discriminator (only ever ``False`` after the cutover) is gone — pin
+        # its absence so it cannot quietly reappear.
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(ResolvedModel)}
+        assert "raw" not in field_names
+        with use_alias_map(_SAMPLE_ALIASES):
+            assert not hasattr(resolve("fast"), "raw")
 
     def test_openai_alias_round_trips(self) -> None:
         with use_alias_map(_SAMPLE_ALIASES):

--- a/tests/unit/python/test_model_aliases.py
+++ b/tests/unit/python/test_model_aliases.py
@@ -2,20 +2,18 @@
 
 The resolver is the single source of truth for model identity: it maps a
 logical alias (``quality`` / ``fast`` / ``summarizer``) to a concrete
-``(provider, model, pricing)`` record, and passes a raw vendor model ID
-through unchanged during the cutover window (RFC 0033 §E). This module
-pins that contract:
+``(provider, model, pricing)`` record. As of RFC 0033 **Phase 3** the
+cutover-window raw-vendor-ID pass-through (§E) is **retired**: every model
+reference must be a declared alias. This module pins that contract:
 
 * an alias hit returns the configured :class:`ResolvedModel`;
-* a recognised raw vendor ID falls through with ``alias=None, raw=True``;
-* a string that is neither a declared alias nor a recognised vendor
-  prefix is a loud ``SystemExit`` (the "clear up-front error" the RFC
-  substitutes for ``_infer_provider``'s silent default-to-openai);
+* a string that is not a declared alias — whether a raw vendor ID
+  (``claude-sonnet-4-20250514`` / ``gpt-4o``) or a typo — is a loud
+  ``SystemExit`` naming the string and pointing at ``models.aliases``
+  (the "clear up-front error" the RFC substitutes for ``_infer_provider``'s
+  silent default-to-openai);
 * the context-manager test seam registers a temporary map for the
   duration of a ``with`` block without mutating the process singleton.
-
-PR 1 ships the resolver *unconsumed* — ``create_provider`` is not rewired
-until PR 2 — so these unit tests are the only thing exercising it.
 """
 
 from __future__ import annotations
@@ -65,12 +63,11 @@ def isolated_config(
 ) -> Iterator[None]:
     """Point the optimization loader at an absent file.
 
-    With no on-disk ``provider_inference`` block, ``provider_inference()``
-    returns ``{}`` and the resolver's raw fall-through uses its module
-    fallback prefixes — so the raw-ID tests are deterministic regardless
-    of the developer's checked-out ``config/optimization.yaml``. The cache
-    is cleared on both sides so neither this test nor its neighbours leak
-    a stale parse.
+    With no on-disk config the config-backed alias map is empty, so a test
+    that asserts against the singleton (e.g. the seam-isolation test) sees a
+    deterministic ``{}`` regardless of the developer's checked-out
+    ``config/optimization.yaml``. The cache is cleared on both sides so
+    neither this test nor its neighbours leak a stale parse.
     """
     monkeypatch.setenv(
         "PERSATRIX_OPTIMIZATION_CONFIG", str(tmp_path / "absent.yaml"),
@@ -138,74 +135,38 @@ class TestAliasHit:
         assert isinstance(resolved.input_per_1m_tokens, float)
 
 
-class TestRawFallThrough:
-    def test_raw_anthropic_id_falls_through(self, isolated_config: None) -> None:
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("claude-sonnet-4-20250514")
-        assert resolved.alias is None
-        assert resolved.raw is True
-        assert resolved.provider == "anthropic"
-        assert resolved.model == "claude-sonnet-4-20250514"
+class TestRawIdRejected:
+    """RFC 0033 Phase 3 — the §E raw-vendor-ID pass-through is retired.
 
-    def test_raw_openai_prefix_id_falls_through(self, isolated_config: None) -> None:
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("gpt-4o-mini")
-        assert resolved.alias is None
-        assert resolved.raw is True
-        assert resolved.provider == "openai"
-        assert resolved.model == "gpt-4o-mini"
+    A model reference that is not a declared alias is a loud ``SystemExit``,
+    no matter how recognisable the vendor prefix once was. There is no
+    longer a ``raw=True`` record, no prefix inference, and no
+    ``explicit_provider`` escape hatch — the alias map is the only surface.
+    """
 
-    def test_raw_openai_exact_id_falls_through(self, isolated_config: None) -> None:
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("o3")
-        assert resolved.alias is None
-        assert resolved.raw is True
-        assert resolved.provider == "openai"
+    def test_raw_anthropic_id_raises_systemexit(self) -> None:
+        with use_alias_map(_SAMPLE_ALIASES), pytest.raises(SystemExit) as exc:
+            resolve("claude-sonnet-4-20250514")
+        msg = str(exc.value)
+        assert "claude-sonnet-4-20250514" in msg
+        # Actionable: tells the operator to declare it as an alias.
+        assert "alias" in msg
 
-    def test_raw_fall_through_carries_no_pricing(self, isolated_config: None) -> None:
-        # The resolver has no pricing for an arbitrary raw vendor ID; it
-        # degrades to 0.0 (the Go cost path keys pricing off telemetry,
-        # RFC 0033 §F). PR 4's missing-price guard leaves this path alone.
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("claude-sonnet-4-20250514")
-        assert resolved.input_per_1m_tokens == 0.0
-        assert resolved.output_per_1m_tokens == 0.0
+    def test_raw_openai_prefix_id_raises_systemexit(self) -> None:
+        with use_alias_map(_SAMPLE_ALIASES), pytest.raises(SystemExit) as exc:
+            resolve("gpt-4o-mini")
+        assert "gpt-4o-mini" in str(exc.value)
 
+    def test_raw_openai_exact_id_raises_systemexit(self) -> None:
+        with use_alias_map(_SAMPLE_ALIASES), pytest.raises(SystemExit):
+            resolve("o3")
 
-class TestExplicitProviderHint:
-    """RFC 0033 §D rule 1 — on the raw pass-through an explicit ``provider``
-    field wins over prefix inference. PR 2's factory needs this so a
-    per-agent ``provider: ollama`` on a local model id like ``llama3.2``
-    — which no prefix rule recognises — resolves without a spurious
-    ``SystemExit``. On the alias path the entry stays authoritative; the
-    hint is ignored there (the factory raises on a *disagreeing* field)."""
-
-    def test_explicit_provider_used_on_raw_fall_through(
-        self, isolated_config: None,
-    ) -> None:
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("llama3.2", explicit_provider="ollama")
-        assert resolved.raw is True
-        assert resolved.alias is None
-        assert resolved.provider == "ollama"
-        assert resolved.model == "llama3.2"
-
-    def test_explicit_provider_skips_unknown_model_systemexit(
-        self, isolated_config: None,
-    ) -> None:
-        # Without the hint an unrecognised id is a loud SystemExit; the hint
-        # short-circuits inference so the raw local model passes through.
+    def test_local_tag_raises_systemexit(self) -> None:
+        # A local Ollama tag that no prefix rule ever recognised used to need
+        # an explicit_provider hint to pass through; that escape hatch is gone
+        # — it must be a declared alias now, so a bare tag is a SystemExit.
         with use_alias_map(_SAMPLE_ALIASES), pytest.raises(SystemExit):
             resolve("llama3.2")
-        with use_alias_map(_SAMPLE_ALIASES):
-            assert resolve("llama3.2", explicit_provider="ollama").provider == "ollama"
-
-    def test_explicit_provider_ignored_for_declared_alias(self) -> None:
-        with use_alias_map(_SAMPLE_ALIASES):
-            resolved = resolve("quality", explicit_provider="openai")
-        # The alias entry's provider is authoritative, not the hint.
-        assert resolved.provider == "anthropic"
-        assert resolved.raw is False
 
 
 class TestUnknownString:
@@ -348,26 +309,6 @@ def test_module_exports_public_surface() -> None:
 
     for name in ("ResolvedModel", "resolve", "use_alias_map"):
         assert name in mod.__all__
-
-
-def test_raw_fallback_constants_mirror_llm_client() -> None:
-    """The raw-ID fall-through fallback prefixes are duplicated from
-    ``agents.llm_client`` — they cannot be imported, because that module
-    imports *this* one once the factory is rewired (RFC 0033 PR 2, a
-    cycle). The module comment claims they mirror llm_client's constants;
-    pin that here so the two cannot silently drift. They only bind in a
-    config-less checkout (the shipped ``provider_inference`` block, pinned
-    by test_optimization.py, otherwise overrides them), but in that path
-    they — not the YAML — drive provider inference, so a drift would route
-    raw IDs differently between the resolver and the legacy factory.
-    """
-    from agents import llm_client, model_aliases
-
-    assert model_aliases._DEFAULT_OPENAI_EXACT == llm_client._OPENAI_EXACT_MODELS
-    assert model_aliases._DEFAULT_OPENAI_PREFIXES == llm_client._OPENAI_PREFIX_MODELS
-    # llm_client uses an inline ("claude",) literal for the anthropic
-    # default (no named constant to pin against); lock ours to that value.
-    assert model_aliases._DEFAULT_ANTHROPIC_PREFIXES == ("claude",)
 
 
 class TestUnconfiguredSentinel:

--- a/tests/unit/python/test_summarize_close_helpers.py
+++ b/tests/unit/python/test_summarize_close_helpers.py
@@ -458,19 +458,21 @@ class TestSingleTurnInteractionFactExtraction:
         assert (summary, failed, facts_raw) == (expected, False, None)
 
 
+def _raise_unresolvable(_ref: str) -> None:
+    # RFC 0033 Phase 3: the resolver raises SystemExit on a non-alias reference.
+    raise SystemExit("Unknown model reference 'totally-unknown-model-xyz'")
+
+
 @pytest.mark.asyncio
 class TestUnresolvableSummarizationModelFallsBack:
-    """RFC 0033 PR 2 — an unresolvable summarisation model must degrade to
-    the fallback, not escape as an uncaught SystemExit past the caller."""
+    """RFC 0033 — unresolvable summarisation model degrades to the fallback, not a SystemExit."""
 
     async def test_unresolvable_model_returns_fallback_not_systemexit(
         self, monkeypatch: pytest.MonkeyPatch,
     ):
         import agents.persona_runtime.summarize_close as sc
 
-        monkeypatch.setattr(
-            sc, "summarization_model", lambda: "totally-unknown-model-xyz",
-        )
+        monkeypatch.setattr(sc, "resolve_model", _raise_unresolvable)
         result = await summarize_closed_interaction(
             _make_envelope_client('{"summary": "x", "facts": []}'),
             "test-agent",
@@ -483,9 +485,7 @@ class TestUnresolvableSummarizationModelFallsBack:
     ):
         import agents.persona_runtime.summarize_close as sc
 
-        monkeypatch.setattr(
-            sc, "summarization_model", lambda: "totally-unknown-model-xyz",
-        )
+        monkeypatch.setattr(sc, "resolve_model", _raise_unresolvable)
         reader, metrics_mod = _build_meter()
         try:
             await summarize_closed_interaction(


### PR DESCRIPTION
## What

The first slice of **RFC 0033 Phase 3** (deliverable 1 of 3): remove the §E cutover-window **raw-vendor-ID pass-through** so model identity flows exclusively through the `models.aliases` map. This is the conditional co-resident the [v0.3.5 plan](docs/v0.3.5-plan.md#conditional-co-resident--rfc-0033-phase-3) defers by default; the dogfood gate (`persatrix.llm.alias.raw_id_usage` reading zero) is treated as satisfied per the maintainer opt-in.

## Behaviour change

`agents.model_aliases.resolve` now raises a loud `SystemExit` for any reference that is **not a declared alias** — a raw vendor ID (`claude-sonnet-4-20250514`, `gpt-4o`) or a typo'd alias name — naming the string and pointing at `config/optimization.yaml`. There is no longer a `raw=True` record, no prefix inference, and no provider-hint escape hatch. The shipped configs already reference aliases everywhere (agents.yaml → `quality`/`fast`, summarisation → `summarizer`), so default deployments are unaffected.

## Production changes

- **`model_aliases.py`** — `resolve()` rejects non-alias references; drop the `explicit_provider` parameter, `_infer_raw_provider`, the `_DEFAULT_*` prefix tables, and the `provider_inference` import.
- **`llm_factory.py`** — drop the now-unreachable `resolved.raw` branch, the `_note_raw_id_usage` deprecation-warning + gate-counter machinery, and the `try_get_instruments` import; keep the §D rule-1 disagreeing-provider check (still valid on the alias-only path).
- **`summarize_close.py`** — refresh a stale comment (the summariser field is the `summarizer` alias, not a raw Haiku ID).

## Tests (TDD — red first)

- `test_model_aliases` / `test_llm_factory` / `test_missing_price_guard`: raw IDs now assert `SystemExit` instead of a `raw=True` fall-through.
- `test_llm_client` / `test_llm_offline` / `test_llm_ollama`: `create_provider` routing tests route through the alias seam (`use_alias_map`) instead of raw model IDs.
- unit + integration **conftest**: the autouse summarisation-model fixtures stub `resolve_model` to a canned `ResolvedModel` rather than relying on a raw-ID stub (the base `summarizer` alias ships `unconfigured`).

## Verification

- `pytest tests/unit/python/` — **2882 passed**, 5 skipped (only the pre-existing `TestShellExec` env failures, which invoke `python` not on PATH, are excluded — unrelated to this change).
- `pytest tests/integration/` — **230 passed**, 16 skipped.
- `ruff check` + `mypy` (agents + tests) clean; `file_size.py --strict` clean.

## Deferred to the Phase 3 follow-up (deliverable 2/3)

Kept as a separate, tightly-scoped PR to keep this diff focused on the behavioural change:
- delete the now-dead `llm_client._infer_provider`, the `optimization.provider_inference` accessor + the `provider_inference:` YAML block, and the unused `alias_raw_id_usage` instrument;
- bump `optimization.yaml` `schema_version` to `"0.3"` with a loader-level rejection message for raw vendor IDs in `agents.yaml`.

Refs RFC 0033 §E/§I.