### PR TITLE
feat(v036): RFC 0048 Phase 1 PR 2 — UI config/context endpoints + config/ui.yaml + schema

### DIFF
--- a/agents/tests/test_validate_ui_schema.py
+++ b/agents/tests/test_validate_ui_schema.py
@@ -1,0 +1,61 @@
+"""RFC 0048 Phase 1 PR 2 — config/ui.yaml schema validation.
+
+Pins the feature-toggle contract enforced by ``schemas/ui.schema.json``:
+
+* The committed ``config/ui.yaml`` passes ``make validate``.
+* The schema is wired into ``validate.py``'s ``_SCHEMA_MAP`` so the file is
+  actually checked (a missing entry would silently skip it).
+* The runtime-derived ``available`` flag MUST NOT be authored — a ``ui.yaml``
+  carrying an ``available:`` key fails validation (per-panel
+  ``additionalProperties:false``). This is the single enforcement of the
+  "ships dark → flip on when the subsystem is wired" contract (RFC 0048 §C).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents.validate import _SCHEMA_MAP, validate_config_dir
+
+# Repo root is three levels up from agents/tests/.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCHEMAS_DIR = str(_REPO_ROOT / "schemas")
+
+
+def test_ui_yaml_is_wired_into_schema_map() -> None:
+    """validate.py must know to check ui.yaml, or the schema is dead weight."""
+    assert _SCHEMA_MAP.get("ui.yaml") == "ui.schema.json"
+
+
+def test_committed_ui_yaml_validates() -> None:
+    """The shipped config/ui.yaml passes its schema."""
+    config_dir = str(_REPO_ROOT / "config")
+    success, errors, files_checked = validate_config_dir(config_dir, _SCHEMAS_DIR)
+    ui_errors = [e for e in errors if e.file.endswith("ui.yaml")]
+    assert ui_errors == [], f"config/ui.yaml must validate cleanly: {[str(e) for e in ui_errors]}"
+    assert files_checked >= 1
+    assert success or not ui_errors
+
+
+def test_authored_available_key_is_rejected(tmp_path: Path) -> None:
+    """An `available:` key in ui.yaml is runtime-derived, so the schema rejects it."""
+    (tmp_path / "ui.yaml").write_text(
+        "panels:\n  chat:\n    enabled: true\n    available: true\n",
+        encoding="utf-8",
+    )
+
+    success, errors, _ = validate_config_dir(str(tmp_path), _SCHEMAS_DIR)
+    assert not success, "an authored `available:` key must fail validation"
+    assert any(e.file.endswith("ui.yaml") for e in errors)
+
+
+def test_unknown_per_panel_key_is_rejected(tmp_path: Path) -> None:
+    """A typo'd per-panel key surfaces at validate time, not silently as a no-op."""
+    (tmp_path / "ui.yaml").write_text(
+        "panels:\n  chat:\n    enbaled: true\n",  # typo: enbaled
+        encoding="utf-8",
+    )
+
+    success, errors, _ = validate_config_dir(str(tmp_path), _SCHEMAS_DIR)
+    assert not success
+    assert any(e.file.endswith("ui.yaml") for e in errors)

--- a/agents/validate.py
+++ b/agents/validate.py
@@ -27,6 +27,7 @@ _SCHEMA_MAP: dict[str, str] = {
     "agents.yaml": "agent.schema.json",
     "channels.yaml": "channel.schema.json",
     "optimization.yaml": "optimization.schema.json",
+    "ui.yaml": "ui.schema.json",
 }
 
 # Workflow files live in a separate directory and share one schema.

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -357,7 +357,7 @@ func main() {
 		logger.Fatal("channels: config-vs-store reconcile failed", zap.Error(chanErr))
 	}
 	defer chanCleanup()
-	srvOpts = append(append(srvOpts, chanOpts...), initUI(*enableUI, logger)...) // RFC 0048: +off-by-default web console
+	srvOpts = append(append(srvOpts, chanOpts...), initUI(*enableUI, *configDir, logger)...) // RFC 0048: +off-by-default web console
 
 	// 8c. Initialize scheduler (workflow run polling + execution)
 	sched := scheduler.NewWorkflowScheduler(store, reg, plan, exec, logger, absWorkflowsDir, schedOpts...)

--- a/cmd/orchestrator/ui.go
+++ b/cmd/orchestrator/ui.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"path/filepath"
 
 	"go.uber.org/zap"
 
@@ -20,7 +21,7 @@ import (
 var enableUI = flag.Bool("enable-ui", false,
 	"Serve the embedded web console at /ui (RFC 0048; localhost-only until RFC 0039 auth)")
 
-// initUI returns the server option that serves the embedded web console, or
+// initUI returns the server options that serve the embedded web console, or
 // nil when the console is disabled.
 //
 // When enableUI is false (the default), it returns no option, so the /ui/
@@ -28,15 +29,22 @@ var enableUI = flag.Bool("enable-ui", false,
 // runtime behaviour changes. When true, it wires the committed embedded asset
 // tree — a placeholder until `make ui` (RFC 0048 Phase 1 PR 3) overwrites it
 // with the real Svelte bundle, so a flag-on binary built without the JS
-// toolchain serves a clear "run make ui" message instead of failing.
+// toolchain serves a clear "run make ui" message instead of failing — plus the
+// parsed config/ui.yaml feature toggles that /api/v1/ui/config reports (RFC
+// 0048 Phase 1 PR 2).
 //
-// Returns a slice (zero or one option) so the caller can append unconditionally,
-// matching initChannels' shape.
+// config/ui.yaml is loaded from cfgDir with the channels.yaml-consistent
+// posture: an absent file is the expected zero-config case (defaults apply); a
+// malformed file is logged at WARN and soft-degrades to defaults so a config
+// typo never blocks the console from booting.
+//
+// Returns a slice (zero or two options) so the caller can append
+// unconditionally, matching initChannels' shape.
 //
 // On the enabled path it emits a startup WARN — co-located with the wiring like
 // channels.go's unauthenticated-surface warning — so the security posture is
 // impossible to miss in an operator's first log scrape.
-func initUI(enableUI bool, logger *zap.Logger) []server.ServerOption {
+func initUI(enableUI bool, cfgDir string, logger *zap.Logger) []server.ServerOption {
 	if !enableUI {
 		return nil
 	}
@@ -46,5 +54,18 @@ func initUI(enableUI bool, logger *zap.Logger) []server.ServerOption {
 			zap.String("auth_eta", "RFC 0039"),
 		)
 	}
-	return []server.ServerOption{server.WithUI(ui.Assets())}
+
+	uiCfgPath := filepath.Join(cfgDir, "ui.yaml")
+	uiCfg, err := server.LoadUIConfig(uiCfgPath)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("ui: config/ui.yaml load failed; falling back to Slice-1 panel defaults",
+				zap.String("path", uiCfgPath),
+				zap.Error(err),
+			)
+		}
+		uiCfg = server.DefaultUIConfig()
+	}
+
+	return []server.ServerOption{server.WithUI(ui.Assets()), server.WithUIConfig(uiCfg)}
 }

--- a/cmd/orchestrator/ui_test.go
+++ b/cmd/orchestrator/ui_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +23,7 @@ import (
 // posture (RFC 0048 §Security): --enable-ui=false yields no server option, so
 // the /ui/ route is never registered.
 func TestInitUI_DisabledByDefault(t *testing.T) {
-	opts := initUI(false, zap.NewNop())
+	opts := initUI(false, t.TempDir(), zap.NewNop())
 	assert.Empty(t, opts,
 		"--enable-ui=false (default) must wire no UI option so /ui/ is never registered")
 }
@@ -32,7 +34,7 @@ func TestInitUI_DisabledByDefault(t *testing.T) {
 func TestInitUI_DisabledEmitsNoWarn(t *testing.T) {
 	core, recorded := observer.New(zapcore.WarnLevel)
 
-	_ = initUI(false, zap.New(core))
+	_ = initUI(false, t.TempDir(), zap.New(core))
 
 	assert.Empty(t, recorded.FilterMessageSnippet("web console ENABLED").All(),
 		"the disabled path must not emit the console-enabled security WARN")
@@ -44,10 +46,10 @@ func TestInitUI_DisabledEmitsNoWarn(t *testing.T) {
 func TestInitUI_EnabledWiresOption(t *testing.T) {
 	core, recorded := observer.New(zapcore.WarnLevel)
 
-	opts := initUI(true, zap.New(core))
+	opts := initUI(true, t.TempDir(), zap.New(core))
 
-	require.Len(t, opts, 1,
-		"--enable-ui=true must wire exactly one server option (WithUI(ui.Assets()))")
+	require.Len(t, opts, 2,
+		"--enable-ui=true must wire WithUI(ui.Assets()) + WithUIConfig(...)")
 	warns := recorded.FilterMessageSnippet("web console ENABLED").All()
 	require.Len(t, warns, 1,
 		"the enabled path must emit exactly one console-enabled security WARN")
@@ -60,7 +62,7 @@ func TestInitUI_EnabledWiresOption(t *testing.T) {
 // from the internal/ui embed package — the "go build with no JS toolchain"
 // guarantee surfaced through a flag-on binary.
 func TestInitUI_EnabledServesPlaceholder(t *testing.T) {
-	srv := buildUITestServer(t, initUI(true, zap.NewNop())...)
+	srv := buildUITestServer(t, initUI(true, t.TempDir(), zap.NewNop())...)
 	hs := httptest.NewServer(srv.Handler())
 	t.Cleanup(hs.Close)
 
@@ -70,6 +72,38 @@ func TestInitUI_EnabledServesPlaceholder(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode,
 		"a flag-on binary must serve the embedded placeholder shell at /ui/")
+}
+
+// TestInitUI_EnabledServesConfig is the end-to-end proof that the enabled path
+// wires the config endpoint (RFC 0048 PR 2): a flag-on binary serves
+// /api/v1/ui/config off the loaded (here: absent → default) ui.yaml.
+func TestInitUI_EnabledServesConfig(t *testing.T) {
+	srv := buildUITestServer(t, initUI(true, t.TempDir(), zap.NewNop())...)
+	hs := httptest.NewServer(srv.Handler())
+	t.Cleanup(hs.Close)
+
+	resp, err := http.Get(hs.URL + "/api/v1/ui/config")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"a flag-on binary must serve /api/v1/ui/config")
+}
+
+// TestInitUI_MalformedConfigSoftDegrades pins the channels.yaml-consistent
+// posture: a malformed config/ui.yaml does not abort console wiring — initUI
+// logs a WARN and falls back to defaults so the console still boots.
+func TestInitUI_MalformedConfigSoftDegrades(t *testing.T) {
+	cfgDir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(cfgDir, "ui.yaml"), []byte("panels: [broken\n"), 0o600))
+
+	core, recorded := observer.New(zapcore.WarnLevel)
+	opts := initUI(true, cfgDir, zap.New(core))
+
+	require.Len(t, opts, 2, "a malformed ui.yaml must still wire the console (defaults)")
+	assert.NotEmpty(t, recorded.FilterMessageSnippet("ui.yaml").All(),
+		"a malformed ui.yaml must surface a WARN")
 }
 
 // buildUITestServer constructs a minimal Server with the given options for the

--- a/config/ui.yaml
+++ b/config/ui.yaml
@@ -1,0 +1,27 @@
+# Web Console Configuration (RFC 0048 — operator/tester web console, v0.3.6+).
+#
+# Schema: schemas/ui.schema.json — `make validate` against this file.
+#
+# This file is the feature-toggle surface for the embedded web console served
+# at /ui (orchestrator --enable-ui, default off). Each panel has a single
+# operator-authored knob, `enabled`, deciding whether the console *offers* it.
+#
+# IMPORTANT — `available` is runtime-derived, never authored here. The server
+# computes, per request, whether each panel's backing subsystem is actually
+# wired (e.g. channel_timeline.available = channels are configured) and reports
+# it alongside `enabled` in GET /api/v1/ui/config. The console renders a panel
+# only when it is BOTH enabled here AND available at runtime. Writing an
+# `available:` key in this file is a validation error (schema
+# additionalProperties:false) — it would have no effect and misleads the reader.
+#
+# Slice 1 (v0.3.6) ships the two hero panels on; memory_strip (Slice 2) and
+# cost (Slice 4) ship off so they land additively with no Slice-1 rework.
+panels:
+  chat:
+    enabled: true
+  channel_timeline:
+    enabled: true
+  memory_strip:
+    enabled: false
+  cost:
+    enabled: false

--- a/docs/guides/version-bump.md
+++ b/docs/guides/version-bump.md
@@ -20,8 +20,16 @@ This updates:
 |------|-------|
 | `cli/Cargo.toml` | `version = "X.Y.Z"` |
 | `agents/pyproject.toml` | `version = "X.Y.Z"` |
+| `agents/observability/metrics.py` | `_DEFAULT_SERVICE_VERSION = "X.Y.Z"` |
+| `agents/observability/tracing.py` | `_DEFAULT_SERVICE_VERSION = "X.Y.Z"` (+ docstring default) |
+| `internal/server/ui_handlers.go` | `const defaultServiceVersion = "X.Y.Z"` |
 
-The Go orchestrator version is set by the **git tag** — no file edit needed.
+A proper release build stamps the Go orchestrator's binary version from the
+**git tag** (`go install`/`ldflags`). The `ui_handlers.go` constant above is only
+the **fallback** the web console reports when that stamp and the
+`PERSATRIX_SERVICE_VERSION` env var are both absent (a plain `go build`/Docker
+image), so it must be bumped in lockstep — same posture as the Python
+`_DEFAULT_SERVICE_VERSION` defaults.
 
 ## Manual Steps
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -346,8 +346,8 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/sessions/{id}", s.handleGetSession)
 	s.mux.HandleFunc("POST /api/v1/sessions/{id}/archive", s.handleArchiveSession)
 
-	// Embedded web console static serving (RFC 0048 — optional, nil-safe; see ui.go).
-	s.registerUIRoutes()
+	// Embedded web console (RFC 0048) registers in Handler() on the
+	// security-bypass root mux, not here — see registerUIRoutes.
 
 	// Minimal health endpoint (C-02: satisfies existing docker-compose.yaml healthcheck)
 	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
@@ -379,6 +379,11 @@ func (s *Server) registerRoutes() {
 // future top-level endpoints — must be added under `/api/v1/` or they
 // will silently bypass the security middleware.
 //
+// The embedded web console (RFC 0048, WithUI) is the one deliberate exception:
+// it registers on this root mux too, so its anonymous operator traffic also
+// bypasses the limiter+breaker — leaving it under the H-01 deny would 403 the
+// console whenever an agent is quarantined. See registerUIRoutes.
+//
 // The 429/403 short-circuit responses still flow back through
 // loggingMiddleware and appear in the access log with their
 // X-Request-ID header set, because both wrappers sit inside the logging
@@ -386,22 +391,17 @@ func (s *Server) registerRoutes() {
 func (s *Server) Handler() http.Handler {
 	// TODO(v0.2): per-request timeout middleware — see RFC 0002 H3
 	//
-	// Path-scoped middleware mount. We need /healthz to bypass the
-	// limiter+breaker (see godoc above), but s.mux already has every
-	// route registered on it (including /healthz). The cheapest
-	// "bypass" is to construct a tiny outer mux that splits traffic:
-	//   - /healthz                     → handle directly, no security layer
-	//   - everything else (/api/v1/…)  → wrapped mux
-	// The inner /healthz registration on s.mux becomes unreachable
-	// through Handler() but is preserved so any test/integration code
-	// hitting s.mux directly (without the middleware stack) keeps
-	// working.
+	// Path-scoped middleware mount: an outer mux splits /healthz (and the
+	// RFC 0048 console) off to bypass the limiter+breaker while everything
+	// else flows through the wrapped s.mux. The /healthz copy on s.mux is
+	// shadowed here but kept so direct-s.mux test/integration code still works.
 	var apiH http.Handler = s.mux
 	if s.rateLimiter != nil || s.circuitBreaker != nil {
 		apiH = security.RESTRateLimitMiddleware(s.rateLimiter, s.circuitBreaker)(apiH)
 	}
 	root := http.NewServeMux()
 	root.HandleFunc("GET /healthz", s.handleHealthz)
+	s.registerUIRoutes(root) // RFC 0048 console: bypass limiter+breaker like /healthz (no-op when WithUI unwired)
 	root.Handle("/", apiH)
 
 	var h http.Handler = root

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,11 +104,9 @@ type Server struct {
 	// --enable-ui is off — the /ui/ route is never registered, so /ui/ is a
 	// clean 404 and the rest of the surface is untouched. Wired via WithUI.
 	uiFS fs.FS
-
-	// uiConfig holds the parsed config/ui.yaml feature toggles (RFC 0048 Phase 1
-	// PR 2) that /api/v1/ui/config reports. Nil → handleUIConfig falls back to
-	// the Slice-1 defaults. Wired via WithUIConfig. The companion `available`
-	// flag is runtime-derived (see Server.panelAvailable), never stored here.
+	// uiConfig holds the parsed config/ui.yaml feature toggles (RFC 0048 PR 2)
+	// reported by /api/v1/ui/config; nil → the Slice-1 defaults. The companion
+	// `available` flag is runtime-derived (Server.panelAvailable), not stored.
 	uiConfig *UIConfig
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,6 +104,12 @@ type Server struct {
 	// --enable-ui is off — the /ui/ route is never registered, so /ui/ is a
 	// clean 404 and the rest of the surface is untouched. Wired via WithUI.
 	uiFS fs.FS
+
+	// uiConfig holds the parsed config/ui.yaml feature toggles (RFC 0048 Phase 1
+	// PR 2) that /api/v1/ui/config reports. Nil → handleUIConfig falls back to
+	// the Slice-1 defaults. Wired via WithUIConfig. The companion `available`
+	// flag is runtime-derived (see Server.panelAvailable), never stored here.
+	uiConfig *UIConfig
 }
 
 // ServerOption configures optional Server dependencies.

--- a/internal/server/ui.go
+++ b/internal/server/ui.go
@@ -25,6 +25,18 @@ func WithUI(uiFS fs.FS) ServerOption {
 	}
 }
 
+// WithUIConfig injects the parsed config/ui.yaml feature toggles (RFC 0048 §C)
+// that /api/v1/ui/config reports to the SPA. Separate from WithUI so the asset
+// tree and the toggle config stay independently injectable (a test can supply
+// toggles without an FS, or an FS without toggles). When absent — including
+// whenever --enable-ui is off — handleUIConfig falls back to the Slice-1
+// defaults (see [DefaultUIConfig]).
+func WithUIConfig(cfg *UIConfig) ServerOption {
+	return func(s *Server) {
+		s.uiConfig = cfg
+	}
+}
+
 // registerUIRoutes serves the embedded web console under /ui/ when WithUI wired
 // the asset tree (orchestrator --enable-ui, default off). Absent it, the route
 // is never registered, so /ui/ is a clean 404 and the rest of the surface is
@@ -48,6 +60,13 @@ func (s *Server) registerUIRoutes() {
 	}
 	fileServer := http.FileServer(noListFS{http.FS(s.uiFS)})
 	s.mux.Handle("GET /ui/", http.StripPrefix("/ui/", fileServer))
+
+	// The two read-only endpoints the SPA boots off (RFC 0048 PR 2). Registered
+	// in the same uiFS-gated block as the static handler so they share the
+	// console's enablement: with --enable-ui off neither is registered and both
+	// are a clean 404. They ride the existing /api/v1/* middleware stack.
+	s.mux.HandleFunc("GET /api/v1/ui/config", s.handleUIConfig)
+	s.mux.HandleFunc("GET /api/v1/ui/context", s.handleUIContext)
 }
 
 // noListFS wraps an http.FileSystem so http.FileServer never renders a

--- a/internal/server/ui.go
+++ b/internal/server/ui.go
@@ -37,10 +37,19 @@ func WithUIConfig(cfg *UIConfig) ServerOption {
 	}
 }
 
-// registerUIRoutes serves the embedded web console under /ui/ when WithUI wired
-// the asset tree (orchestrator --enable-ui, default off). Absent it, the route
-// is never registered, so /ui/ is a clean 404 and the rest of the surface is
-// untouched.
+// registerUIRoutes serves the embedded web console on mux when WithUI wired the
+// asset tree (orchestrator --enable-ui, default off). Absent it, no route is
+// registered, so the console surface is a clean 404 and the rest is untouched.
+//
+// It is registered on the security-bypass root mux (alongside /healthz) rather
+// than on s.mux behind RESTRateLimitMiddleware: the console is operator/tester
+// traffic, not agent API traffic, so it must NOT be governed by the agent
+// rate-limiter / circuit-breaker. The browser calls the boot endpoints
+// anonymously (no X-Agent-ID), and the PR #244 H-01 anonymous-deny fires
+// whenever *any* agent is quarantined — routing the console through that layer
+// would 403 it and make the console unbootable exactly when an operator needs
+// it to investigate or clear the quarantine. See [Server.Handler]. (Pinned by
+// ui_quarantine_test.go; the H-01 deny stays in force for genuine /api/v1/*.)
 //
 // http.FileServer (over hash-mode routing, RFC 0048 PR plan D1) is correct
 // because every real-file request maps to an embedded asset and client routes
@@ -54,19 +63,19 @@ func WithUIConfig(cfg *UIConfig) ServerOption {
 // PR 3's Svelte/Vite bundle ships subdirectories (e.g. _app/, .vite/) whose
 // internal filenames must not be browsable. Hashed assets stay reachable by
 // their direct path.
-func (s *Server) registerUIRoutes() {
+func (s *Server) registerUIRoutes(mux *http.ServeMux) {
 	if s.uiFS == nil {
 		return
 	}
 	fileServer := http.FileServer(noListFS{http.FS(s.uiFS)})
-	s.mux.Handle("GET /ui/", http.StripPrefix("/ui/", fileServer))
+	mux.Handle("GET /ui/", http.StripPrefix("/ui/", fileServer))
 
 	// The two read-only endpoints the SPA boots off (RFC 0048 PR 2). Registered
 	// in the same uiFS-gated block as the static handler so they share the
 	// console's enablement: with --enable-ui off neither is registered and both
-	// are a clean 404. They ride the existing /api/v1/* middleware stack.
-	s.mux.HandleFunc("GET /api/v1/ui/config", s.handleUIConfig)
-	s.mux.HandleFunc("GET /api/v1/ui/context", s.handleUIContext)
+	// are a clean 404.
+	mux.HandleFunc("GET /api/v1/ui/config", s.handleUIConfig)
+	mux.HandleFunc("GET /api/v1/ui/context", s.handleUIContext)
 }
 
 // noListFS wraps an http.FileSystem so http.FileServer never renders a

--- a/internal/server/ui_config.go
+++ b/internal/server/ui_config.go
@@ -54,13 +54,16 @@ func (c *UIConfig) PanelEnabled(name string) bool {
 
 // LoadUIConfig parses config/ui.yaml from path.
 //
-// Posture mirrors channels.LoadConfig: an absent file is the expected
-// zero-config case (a flag-on binary with no ui.yaml renders the Slice-1
-// defaults), so it returns [DefaultUIConfig] with no error; a present-but-
-// malformed file is an operator bug surfaced as an error so the caller can log
-// loudly and soft-degrade. KnownFields is enabled so a stray key (e.g. an
-// authored `available:`) surfaces as a parse error rather than silently
-// loading.
+// Absent file → [DefaultUIConfig] with no error: a flag-on binary with no
+// ui.yaml is the expected zero-config case and renders the Slice-1 defaults.
+// This differs from channels.LoadConfig, which returns the not-exist error for
+// its caller to classify — here the defaults-on-absent decision lives in the
+// loader because the console always has a sensible default panel set, whereas
+// an absent channels.yaml means "no channels at all". A present-but-malformed
+// file is an operator bug returned as an error so the caller can log loudly and
+// soft-degrade; that loud-on-malformed posture is the part that matches
+// channels.yaml. KnownFields is enabled so a stray key (e.g. an authored
+// `available:`) surfaces as a parse error rather than loading silently.
 func LoadUIConfig(path string) (*UIConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -74,12 +77,13 @@ func LoadUIConfig(path string) (*UIConfig, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(cfg); err != nil {
-		if !errors.Is(err, io.EOF) {
-			// io.EOF means the file is empty / fully commented out — treat as
-			// "no overrides" and fall back to defaults, matching channels.yaml.
-			return nil, fmt.Errorf("ui: parse %s: %w", path, err)
+		// io.EOF means the file is empty / fully commented out — treat as "no
+		// overrides" and fall back to defaults, matching channels.yaml. Any
+		// other decode error is an operator bug surfaced loudly.
+		if errors.Is(err, io.EOF) {
+			return DefaultUIConfig(), nil
 		}
-		return DefaultUIConfig(), nil
+		return nil, fmt.Errorf("ui: parse %s: %w", path, err)
 	}
 
 	// An empty/partial file leaves Panels nil or partial; backfill any panel the

--- a/internal/server/ui_config.go
+++ b/internal/server/ui_config.go
@@ -1,0 +1,97 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// UIConfig is the parsed shape of config/ui.yaml (RFC 0048 §C) — the
+// feature-toggle file that decides which web-console panels render. It carries
+// only the operator-authored `enabled` toggle per panel; the companion
+// `available` flag is *runtime-derived* by the server from whether the backing
+// subsystem is wired and is never read from YAML (the schema's
+// additionalProperties:false rejects an authored `available:`). See
+// [Server.panelAvailable].
+type UIConfig struct {
+	Panels map[string]PanelToggle `yaml:"panels"`
+}
+
+// PanelToggle is the per-panel YAML entry. Only `enabled` is authored; see
+// [UIConfig] for why `available` lives on the server, not here.
+type PanelToggle struct {
+	Enabled bool `yaml:"enabled"`
+}
+
+// DefaultUIConfig is the Slice-1 default applied when config/ui.yaml is absent:
+// the chat and channel-timeline hero panels ship enabled; memory_strip (Slice 2)
+// and cost (Slice 4) ship off so they land additively with no Slice-1 rework
+// (RFC 0048 §C / §D.3).
+func DefaultUIConfig() *UIConfig {
+	return &UIConfig{
+		Panels: map[string]PanelToggle{
+			"chat":             {Enabled: true},
+			"channel_timeline": {Enabled: true},
+			"memory_strip":     {Enabled: false},
+			"cost":             {Enabled: false},
+		},
+	}
+}
+
+// PanelEnabled reports whether the named panel's `enabled` toggle is on. An
+// unknown panel is reported disabled (forward-compat: an older binary serving a
+// newer bundle simply does not render a panel it has no toggle for).
+func (c *UIConfig) PanelEnabled(name string) bool {
+	if c == nil {
+		return false
+	}
+	return c.Panels[name].Enabled
+}
+
+// LoadUIConfig parses config/ui.yaml from path.
+//
+// Posture mirrors channels.LoadConfig: an absent file is the expected
+// zero-config case (a flag-on binary with no ui.yaml renders the Slice-1
+// defaults), so it returns [DefaultUIConfig] with no error; a present-but-
+// malformed file is an operator bug surfaced as an error so the caller can log
+// loudly and soft-degrade. KnownFields is enabled so a stray key (e.g. an
+// authored `available:`) surfaces as a parse error rather than silently
+// loading.
+func LoadUIConfig(path string) (*UIConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DefaultUIConfig(), nil
+		}
+		return nil, fmt.Errorf("ui: read %s: %w", path, err)
+	}
+
+	cfg := &UIConfig{}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(cfg); err != nil {
+		if !errors.Is(err, io.EOF) {
+			// io.EOF means the file is empty / fully commented out — treat as
+			// "no overrides" and fall back to defaults, matching channels.yaml.
+			return nil, fmt.Errorf("ui: parse %s: %w", path, err)
+		}
+		return DefaultUIConfig(), nil
+	}
+
+	// An empty/partial file leaves Panels nil or partial; backfill any panel the
+	// operator did not name with its Slice-1 default so the console always sees
+	// the full known-panel set.
+	if cfg.Panels == nil {
+		cfg.Panels = map[string]PanelToggle{}
+	}
+	for name, def := range DefaultUIConfig().Panels {
+		if _, ok := cfg.Panels[name]; !ok {
+			cfg.Panels[name] = def
+		}
+	}
+	return cfg, nil
+}

--- a/internal/server/ui_config_test.go
+++ b/internal/server/ui_config_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDefaultUIConfig pins the Slice-1 panel defaults (RFC 0048 §C): chat and
+// channel_timeline ship enabled; memory_strip (Slice 2) and cost (Slice 4) ship
+// off so they land additively with no Slice-1 rework.
+func TestDefaultUIConfig(t *testing.T) {
+	cfg := DefaultUIConfig()
+	require.NotNil(t, cfg)
+
+	assert.True(t, cfg.PanelEnabled("chat"), "chat ships enabled in Slice 1")
+	assert.True(t, cfg.PanelEnabled("channel_timeline"), "channel_timeline ships enabled in Slice 1")
+	assert.False(t, cfg.PanelEnabled("memory_strip"), "memory_strip ships off (Slice 2)")
+	assert.False(t, cfg.PanelEnabled("cost"), "cost ships off (Slice 4)")
+}
+
+// TestLoadUIConfig_AbsentReturnsDefaults: an absent config/ui.yaml is the
+// expected zero-config case, not an error — the loader returns the Slice-1
+// defaults so a flag-on binary with no ui.yaml renders the hero panels.
+func TestLoadUIConfig_AbsentReturnsDefaults(t *testing.T) {
+	cfg, err := LoadUIConfig(filepath.Join(t.TempDir(), "ui.yaml"))
+	require.NoError(t, err, "an absent ui.yaml must soft-degrade to defaults, not error")
+	require.NotNil(t, cfg)
+
+	assert.True(t, cfg.PanelEnabled("chat"))
+	assert.True(t, cfg.PanelEnabled("channel_timeline"))
+	assert.False(t, cfg.PanelEnabled("memory_strip"))
+}
+
+// TestLoadUIConfig_ParsesToggles: a present ui.yaml overrides the defaults the
+// operator names and leaves the rest at their default.
+func TestLoadUIConfig_ParsesToggles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ui.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(
+		"panels:\n  chat:\n    enabled: false\n  channel_timeline:\n    enabled: true\n"), 0o600))
+
+	cfg, err := LoadUIConfig(path)
+	require.NoError(t, err)
+
+	assert.False(t, cfg.PanelEnabled("chat"), "an explicit enabled:false must turn the panel off")
+	assert.True(t, cfg.PanelEnabled("channel_timeline"))
+}
+
+// TestLoadUIConfig_Malformed: a syntactically broken ui.yaml is an operator bug
+// we surface loudly (the caller logs + soft-degrades), mirroring channels.yaml's
+// parse-error posture — distinct from the absent-file default path.
+func TestLoadUIConfig_Malformed(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ui.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("panels: [this is not a map\n"), 0o600))
+
+	_, err := LoadUIConfig(path)
+	assert.Error(t, err, "a malformed ui.yaml must return a parse error, not silently default")
+}

--- a/internal/server/ui_handlers.go
+++ b/internal/server/ui_handlers.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"net/http"
+	"os"
+	"runtime/debug"
+)
+
+// uiConfigResponse is the /api/v1/ui/config payload (RFC 0048 §C): which panels
+// the console should render and what binary is serving them. The SPA boots off
+// this — it renders only panels that are both enabled (operator toggle) and
+// available (subsystem wired), and ignores panels it does not recognise.
+type uiConfigResponse struct {
+	Panels map[string]uiPanelStatus `json:"panels"`
+	Build  uiBuildInfo              `json:"build"`
+}
+
+// uiPanelStatus pairs the operator-authored `enabled` toggle with the
+// server-derived `available` flag. `available` is never read from YAML — see
+// [Server.panelAvailable] and the config/ui.yaml schema's additionalProperties:false.
+type uiPanelStatus struct {
+	Enabled   bool `json:"enabled"`
+	Available bool `json:"available"`
+}
+
+type uiBuildInfo struct {
+	Version string `json:"version"`
+}
+
+// uiContextResponse is the /api/v1/ui/context payload (RFC 0048 §F): the single
+// source of the console's identity. Today's no-auth localhost mode is the
+// degenerate single-tenant case (principal=tenant=local, authenticated=false);
+// PR 4's chat panel derives its user_id from `principal` here rather than
+// prompting for or hard-coding a user, so the contract composes cleanly with
+// RFC 0039 auth later.
+type uiContextResponse struct {
+	Principal     string `json:"principal"`
+	Tenant        string `json:"tenant"`
+	Authenticated bool   `json:"authenticated"`
+}
+
+// handleUIConfig serves the feature-toggle + build payload the SPA boots off.
+// Registered only when the console is wired (WithUI), so it is a clean 404 when
+// --enable-ui is off. Read-only; rides the existing /api/v1/* middleware stack.
+func (s *Server) handleUIConfig(w http.ResponseWriter, _ *http.Request) {
+	cfg := s.uiConfig
+	if cfg == nil {
+		cfg = DefaultUIConfig()
+	}
+
+	panels := make(map[string]uiPanelStatus, len(cfg.Panels))
+	for name, toggle := range cfg.Panels {
+		panels[name] = uiPanelStatus{
+			Enabled:   toggle.Enabled,
+			Available: s.panelAvailable(name),
+		}
+	}
+
+	writeJSON(w, uiConfigResponse{
+		Panels: panels,
+		Build:  uiBuildInfo{Version: uiBuildVersion()},
+	}, http.StatusOK)
+}
+
+// handleUIContext serves the console's identity (RFC 0048 §F). Constant today;
+// the shape is fixed now so PR 4 and the eventual RFC 0039 auth layer slot in
+// without a client change.
+func (s *Server) handleUIContext(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, uiContextResponse{
+		Principal:     "local",
+		Tenant:        "local",
+		Authenticated: false,
+	}, http.StatusOK)
+}
+
+// panelAvailable reports whether a panel's backing subsystem is wired — the
+// runtime-derived half of the toggle contract (RFC 0048 §C). A panel ships
+// "dark" in YAML (enabled:false) and is flipped on per deployment; availability
+// is orthogonal — it reflects whether the server *can* serve the panel's data
+// regardless of the toggle. An unknown panel is unavailable (a server that does
+// not know a panel cannot vouch for its backing subsystem).
+func (s *Server) panelAvailable(name string) bool {
+	switch name {
+	case "chat":
+		// The chat/agents surface is always registered (registry + planner are
+		// required New args), so chat is always serveable.
+		return true
+	case "channel_timeline":
+		// Mirrors the channel endpoints' 503 degradation: available exactly when
+		// the channel store is wired (WithChannels).
+		return s.channelStore != nil
+	case "cost":
+		return s.costReporter != nil
+	case "memory_strip":
+		// Deferred to Slice 2: needs a new Go↔Python persona-memory read method
+		// that does not exist yet, so the panel can never be available in Slice 1
+		// even if an operator flips its toggle on.
+		return false
+	default:
+		return false
+	}
+}
+
+// uiBuildVersion resolves the version string surfaced in /api/v1/ui/config.
+// The orchestrator binary carries no compiled-in version constant, so it
+// prefers the PERSATRIX_SERVICE_VERSION env var (the same source the
+// observability runtimes read) and falls back to the module version stamped by
+// `go install`/release builds, then to "dev" for a plain `go build`/`go test`.
+func uiBuildVersion() string {
+	if v := os.Getenv("PERSATRIX_SERVICE_VERSION"); v != "" {
+		return v
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if v := info.Main.Version; v != "" && v != "(devel)" {
+			return v
+		}
+	}
+	return "dev"
+}

--- a/internal/server/ui_handlers.go
+++ b/internal/server/ui_handlers.go
@@ -101,11 +101,22 @@ func (s *Server) panelAvailable(name string) bool {
 	}
 }
 
-// uiBuildVersion resolves the version string surfaced in /api/v1/ui/config.
-// The orchestrator binary carries no compiled-in version constant, so it
+// defaultServiceVersion is the orchestrator binary's compiled-in service
+// version, used by [uiBuildVersion] when neither the PERSATRIX_SERVICE_VERSION
+// env var nor a `go install`/release module version is present (a plain
+// `go build`/Docker image, the common deployment case). It mirrors the Python
+// runtimes' _DEFAULT_SERVICE_VERSION so the console's reported version agrees
+// with the observability stack's service.version. Like that constant it is not
+// a build input, so a stale value never fails `make all` — scripts/bump_version.py
+// bumps it each release (VERSION_FILES) or it silently drifts.
+const defaultServiceVersion = "0.3.5"
+
+// uiBuildVersion resolves the version string surfaced in /api/v1/ui/config. It
 // prefers the PERSATRIX_SERVICE_VERSION env var (the same source the
-// observability runtimes read) and falls back to the module version stamped by
-// `go install`/release builds, then to "dev" for a plain `go build`/`go test`.
+// observability runtimes read), then the module version stamped by
+// `go install`/release builds, and finally the compiled-in
+// [defaultServiceVersion] — never an empty or "dev" placeholder, so an operator
+// always sees a real version and it matches the Python runtimes' default.
 func uiBuildVersion() string {
 	if v := os.Getenv("PERSATRIX_SERVICE_VERSION"); v != "" {
 		return v
@@ -115,5 +126,5 @@ func uiBuildVersion() string {
 			return v
 		}
 	}
-	return "dev"
+	return defaultServiceVersion
 }

--- a/internal/server/ui_handlers_test.go
+++ b/internal/server/ui_handlers_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"testing/fstest"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/mkhomutov/persatrix/internal/channels"
 	"github.com/mkhomutov/persatrix/internal/planner"
 	"github.com/mkhomutov/persatrix/internal/registry"
 	"github.com/mkhomutov/persatrix/internal/state"
@@ -124,4 +126,117 @@ func TestWithoutUI_ExistingRoutesUnaffected(t *testing.T) {
 
 	agents := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents", nil)
 	assert.Equal(t, http.StatusOK, agents.Code, "GET /api/v1/agents must be unaffected by the UI scaffold")
+}
+
+// uiChannelStore builds a throwaway SQLite-backed channel store so a test can
+// wire WithChannels and exercise the runtime-derived `available` flag.
+func uiChannelStore(t *testing.T) channels.ChannelStore {
+	t.Helper()
+	store, err := channels.NewSQLiteStore(":memory:", channels.SQLiteOptions{
+		MaxChannels: 50,
+		Logger:      zap.NewNop(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}
+
+// uiConfigResponseBody is the test-side mirror of the /api/v1/ui/config JSON
+// (RFC 0048 §C). Kept here, not imported from the handler, so the test pins the
+// wire shape independently of the server's internal struct.
+type uiConfigResponseBody struct {
+	Panels map[string]struct {
+		Enabled   bool `json:"enabled"`
+		Available bool `json:"available"`
+	} `json:"panels"`
+	Build struct {
+		Version string `json:"version"`
+	} `json:"build"`
+}
+
+// TestUIConfig_Shape pins the RFC 0048 §C config contract: the Slice-1 panel
+// toggles default on for chat/channel_timeline and off for memory_strip/cost,
+// and a non-empty build.version ships so the console can show what it is
+// rendering. channels wired → channel_timeline is available.
+func TestUIConfig_Shape(t *testing.T) {
+	srv := uiTestServer(t, WithUI(uiAssetFS()), WithChannels(uiChannelStore(t), nil))
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/config", nil)
+	require.Equal(t, http.StatusOK, rec.Code, "GET /api/v1/ui/config must succeed when the console is wired")
+
+	var body uiConfigResponseBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	require.Contains(t, body.Panels, "chat")
+	require.Contains(t, body.Panels, "channel_timeline")
+	require.Contains(t, body.Panels, "memory_strip")
+	require.Contains(t, body.Panels, "cost")
+
+	assert.True(t, body.Panels["chat"].Enabled, "chat ships enabled in Slice 1")
+	assert.True(t, body.Panels["channel_timeline"].Enabled, "channel_timeline ships enabled in Slice 1")
+	assert.False(t, body.Panels["memory_strip"].Enabled, "memory_strip ships off (Slice 2)")
+	assert.False(t, body.Panels["cost"].Enabled, "cost ships off (Slice 4)")
+
+	assert.True(t, body.Panels["chat"].Available, "chat is always wired")
+	assert.True(t, body.Panels["channel_timeline"].Available, "channels wired → channel_timeline available")
+	assert.False(t, body.Panels["memory_strip"].Available, "memory_strip has no backing subsystem yet (Slice 2)")
+
+	assert.NotEmpty(t, body.Build.Version, "build.version must be reported so the console can display it")
+}
+
+// TestUIConfig_AvailabilityTracksChannels is the unit-level proof of the
+// runtime-derivation contract (RFC 0048 §C / PR-plan D4): `available` is
+// computed by the server from whether the backing subsystem is wired, never
+// read from YAML. With no WithChannels, channel_timeline is unavailable.
+func TestUIConfig_AvailabilityTracksChannels(t *testing.T) {
+	srv := uiTestServer(t, WithUI(uiAssetFS())) // no WithChannels
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/config", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body uiConfigResponseBody
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.False(t, body.Panels["channel_timeline"].Available,
+		"channels absent → channel_timeline.available must be false")
+	assert.True(t, body.Panels["channel_timeline"].Enabled,
+		"the enabled toggle is independent of availability — it stays on, the client hides the slot")
+}
+
+// TestUIContext_Local pins the RFC 0048 §F identity contract for today's
+// no-auth localhost mode: the single-tenant degenerate case reports
+// principal=tenant=local and authenticated=false. PR 4's chat panel derives
+// user_id from this endpoint, never a hard-coded or free-text user.
+func TestUIContext_Local(t *testing.T) {
+	srv := uiTestServer(t, WithUI(uiAssetFS()))
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/context", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Principal     string `json:"principal"`
+		Tenant        string `json:"tenant"`
+		Authenticated bool   `json:"authenticated"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	assert.Equal(t, "local", body.Principal, "no-auth localhost principal is `local`")
+	assert.Equal(t, "local", body.Tenant, "single-tenant degenerate case tenant is `local`")
+	assert.False(t, body.Authenticated, "no auth layer today → authenticated=false")
+}
+
+// TestUIEndpoints_404WhenDisabled is the nil-safe gate for PR 2: with no WithUI
+// option (the --enable-ui=off default) neither /api/v1/ui/config nor
+// /api/v1/ui/context is registered, so both are a clean 404 and the surface is
+// unchanged.
+func TestUIEndpoints_404WhenDisabled(t *testing.T) {
+	srv := uiTestServer(t) // no WithUI
+
+	cfg := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/config", nil)
+	assert.Equal(t, http.StatusNotFound, cfg.Code,
+		"without WithUI, /api/v1/ui/config must be a clean 404")
+
+	ctx := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/context", nil)
+	assert.Equal(t, http.StatusNotFound, ctx.Code,
+		"without WithUI, /api/v1/ui/context must be a clean 404")
 }

--- a/internal/server/ui_handlers_test.go
+++ b/internal/server/ui_handlers_test.go
@@ -225,6 +225,34 @@ func TestUIContext_Local(t *testing.T) {
 	assert.False(t, body.Authenticated, "no auth layer today → authenticated=false")
 }
 
+// TestUIBuildVersion_FallsBackToCompiledDefault pins the fix for the PR-497
+// review finding: when PERSATRIX_SERVICE_VERSION is unset and the build carries
+// no module version — the plain `go build`/Docker case, and `go test`, where
+// build-info reports "(devel)" — build.version must report the compiled-in
+// defaultServiceVersion, never the old "dev" sentinel. This mirrors the Python
+// runtimes' _DEFAULT_SERVICE_VERSION so the console and the observability stack
+// agree on the version an operator sees.
+func TestUIBuildVersion_FallsBackToCompiledDefault(t *testing.T) {
+	t.Setenv("PERSATRIX_SERVICE_VERSION", "") // force the non-env path
+
+	got := uiBuildVersion()
+
+	assert.Equal(t, defaultServiceVersion, got,
+		"with no env var and no module version, the fallback must be the compiled-in default")
+	assert.Regexp(t, `^\d+\.\d+\.\d+`, got,
+		"build.version fallback must be a real semver, not the 'dev' sentinel")
+}
+
+// TestUIBuildVersion_EnvOverride guards the precedence: an explicit
+// PERSATRIX_SERVICE_VERSION (what real deployments and the observability
+// runtimes set) wins over the compiled-in default.
+func TestUIBuildVersion_EnvOverride(t *testing.T) {
+	t.Setenv("PERSATRIX_SERVICE_VERSION", "9.9.9-test")
+
+	assert.Equal(t, "9.9.9-test", uiBuildVersion(),
+		"an explicit env version must override the compiled-in default")
+}
+
 // TestUIEndpoints_404WhenDisabled is the nil-safe gate for PR 2: with no WithUI
 // option (the --enable-ui=off default) neither /api/v1/ui/config nor
 // /api/v1/ui/context is registered, so both are a clean 404 and the surface is

--- a/internal/server/ui_quarantine_test.go
+++ b/internal/server/ui_quarantine_test.go
@@ -1,0 +1,101 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mkhomutov/persatrix/internal/security"
+)
+
+// RFC 0048 review finding (PR 2): the embedded web console is operator/tester
+// traffic, not agent API traffic, so its surface must bypass the agent
+// rate-limiter / circuit-breaker exactly like /healthz does (server.go Handler
+// godoc, PR #244 H-03).
+//
+// Without the bypass, the console's boot endpoints (/api/v1/ui/config,
+// /api/v1/ui/context) and static tree sit under /api/v1/ behind
+// RESTRateLimitMiddleware. The browser calls them anonymously (no X-Agent-ID),
+// so the PR #244 H-01 anonymous-deny — which fires whenever *any* agent is
+// quarantined — would 403 them and make the console unbootable precisely when
+// an operator most needs it to investigate or clear the quarantine.
+//
+// These tests pin the bypass: the console surface stays reachable during an
+// active quarantine, while genuine /api/v1/* agent endpoints remain denied (the
+// H-01 protection must not regress).
+
+// uiTestServerWithBreaker builds a console-wired Server (WithUI) behind a
+// circuit breaker, mirroring testServerWithBreaker's post-construction
+// WithRateLimiter application.
+func uiTestServerWithBreaker(t *testing.T, cb *security.CircuitBreaker, opts ...ServerOption) *Server {
+	t.Helper()
+	srv := uiTestServer(t, append([]ServerOption{WithUI(uiAssetFS())}, opts...)...)
+	WithRateLimiter(nil, cb)(srv)
+	return srv
+}
+
+// TestUIConfig_AllowedDuringQuarantine is the load-bearing assertion: an
+// anonymous GET /api/v1/ui/config must still serve 200 while a quarantine is
+// open, so the console can boot and an operator can act on the incident.
+func TestUIConfig_AllowedDuringQuarantine(t *testing.T) {
+	cb := breakerWithThreshold(t)
+	srv := uiTestServerWithBreaker(t, cb)
+
+	cb.RecordViolation(context.Background(), "agent-bad", security.ViolationCapability)
+	require.True(t, cb.IsQuarantined("agent-bad"),
+		"precondition: agent-bad must be quarantined to exercise the bypass")
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/config", nil)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"the console's config boot endpoint must bypass the agent breaker — "+
+			"a quarantine must not make the operator console unbootable")
+}
+
+// TestUIContext_AllowedDuringQuarantine pins the same bypass for the identity
+// boot endpoint.
+func TestUIContext_AllowedDuringQuarantine(t *testing.T) {
+	cb := breakerWithThreshold(t)
+	srv := uiTestServerWithBreaker(t, cb)
+
+	cb.RecordViolation(context.Background(), "agent-bad", security.ViolationCapability)
+	require.True(t, cb.IsQuarantined("agent-bad"))
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/ui/context", nil)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"the console's context boot endpoint must bypass the agent breaker")
+}
+
+// TestUIStatic_AllowedDuringQuarantine confirms the static console tree is
+// reachable during a quarantine too — boot endpoints serving 200 is useless if
+// the SPA shell itself 403s.
+func TestUIStatic_AllowedDuringQuarantine(t *testing.T) {
+	cb := breakerWithThreshold(t)
+	srv := uiTestServerWithBreaker(t, cb)
+
+	cb.RecordViolation(context.Background(), "agent-bad", security.ViolationCapability)
+	require.True(t, cb.IsQuarantined("agent-bad"))
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/ui/", nil)
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"the static console shell must bypass the agent breaker")
+}
+
+// TestQuarantineStillBlocksAgentAPIWithConsole guards against over-correction:
+// wiring the console must not regress the H-01 anonymous-deny for genuine
+// /api/v1/* agent endpoints. With the same server and an active quarantine, an
+// anonymous agent-API call must still be denied.
+func TestQuarantineStillBlocksAgentAPIWithConsole(t *testing.T) {
+	cb := breakerWithThreshold(t)
+	srv := uiTestServerWithBreaker(t, cb)
+
+	cb.RecordViolation(context.Background(), "agent-bad", security.ViolationCapability)
+	require.True(t, cb.IsQuarantined("agent-bad"))
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents", nil)
+	assert.Equal(t, http.StatusForbidden, rec.Code,
+		"the console bypass must be scoped to /ui — agent API endpoints keep the H-01 deny")
+	assert.Contains(t, rec.Body.String(), "QUARANTINE_ACTIVE")
+}

--- a/schemas/ui.schema.json
+++ b/schemas/ui.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://persatrix.dev/schemas/ui.schema.json",
+  "title": "Persatrix Web Console Configuration (v0.3.6+)",
+  "description": "Internal-only schema until v1.0; `$id` may break across v0.x bumps without notice. Feature-toggle file for the embedded operator/tester web console (RFC 0048) served at /ui under the orchestrator's --enable-ui flag. Each panel carries a single operator-authored `enabled` toggle. The companion `available` flag is runtime-derived by the server (whether the panel's backing subsystem is wired) and reported in GET /api/v1/ui/config — it MUST NOT be authored here. The per-panel `additionalProperties:false` enforces that: an `available:` key (or any typo) fails `make validate` rather than silently having no effect.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "panels": {
+      "type": "object",
+      "description": "Per-panel toggles keyed by panel name (e.g. chat, channel_timeline, memory_strip, cost). Unknown panel names are accepted for forward-compatibility — an older binary serving a newer bundle simply ignores panels it does not recognise.",
+      "additionalProperties": { "$ref": "#/definitions/panel" }
+    }
+  },
+  "definitions": {
+    "panel": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the console offers this panel. A panel renders only when it is both enabled here and reported available at runtime."
+        }
+      }
+    }
+  }
+}

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -51,6 +51,15 @@ VERSION_FILES: list[tuple[str, str, str]] = [
         r'(\(default: ")\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?(")',
         r"\g<1>{version}\2",
     ),
+    # The Go orchestrator's compiled-in service-version fallback, surfaced by
+    # the web console's /api/v1/ui/config when PERSATRIX_SERVICE_VERSION is
+    # unset and the build carries no module version. Like the Python defaults
+    # above it is not a build input, so it must be bumped here or it drifts.
+    (
+        "internal/server/ui_handlers.go",
+        r'^(const defaultServiceVersion = ")[^"]+(")$',
+        r"\g<1>{version}\2",
+    ),
 ]
 
 SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$")

--- a/tests/unit/python/test_version_consistency.py
+++ b/tests/unit/python/test_version_consistency.py
@@ -1,0 +1,68 @@
+"""Guards the hand-maintained version constants tracked by
+``scripts/bump_version.py``'s ``VERSION_FILES`` against silent drift.
+
+``bump_version.py`` is the *sync* mechanism — running it rewrites every tracked
+version string in lockstep. But nothing *verifies* that the files actually
+agree: a manual edit to a single constant (for example the Go
+``defaultServiceVersion`` fallback the web console reports via
+``/api/v1/ui/config``, RFC 0048) leaves the others stale. Because none of these
+constants is a build input, ``make all`` stays green while the console, the
+observability stack, and the published package each report a different version.
+
+This test reads every entry in ``VERSION_FILES`` the same way ``bump()`` applies
+it (identical regex, ``re.MULTILINE``, first match only), extracts the version
+each file currently carries, and asserts they are all identical and valid
+semver. It is self-maintaining: any future ``VERSION_FILES`` entry is covered
+automatically, so the guard can never lag the sync logic it protects.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Repo root is four levels up from tests/unit/python/<this file>.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts.bump_version import ROOT, SEMVER_RE, VERSION_FILES  # noqa: E402
+
+
+def _extract_version(rel_path: str, pattern: str) -> str:
+    """Pull the version a file currently carries for one ``VERSION_FILES`` entry.
+
+    Mirrors how ``bump()`` applies each pattern (``re.MULTILINE``, first match).
+    Every ``VERSION_FILES`` pattern has the shape ``(prefix)version(suffix)``
+    with the version uncaptured between groups 1 and 2, so the version is the
+    slice between the end of group 1 and the start of group 2.
+    """
+    text = (ROOT / rel_path).read_text(encoding="utf-8")
+    match = re.search(pattern, text, flags=re.MULTILINE)
+    assert match is not None, (
+        f"{rel_path}: its VERSION_FILES pattern no longer matches — "
+        "bump_version.py can no longer update this file, fix the pattern"
+    )
+    return text[match.end(1) : match.start(2)]
+
+
+def test_all_tracked_version_strings_agree() -> None:
+    """Every file tracked by VERSION_FILES must carry the same version string."""
+    found: dict[str, str] = {}
+    for rel_path, pattern, _template in VERSION_FILES:
+        found[f"{rel_path} :: {pattern}"] = _extract_version(rel_path, pattern)
+
+    distinct = set(found.values())
+    assert len(distinct) == 1, (
+        "version constants have drifted across VERSION_FILES — run "
+        "`python scripts/bump_version.py <version>` to resync:\n"
+        + "\n".join(f"  {entry} -> {version!r}" for entry, version in found.items())
+    )
+
+
+def test_tracked_version_is_valid_semver() -> None:
+    """The shared version must be valid semver — the same check bump() enforces."""
+    rel_path, pattern, _template = VERSION_FILES[0]
+    version = _extract_version(rel_path, pattern)
+    assert SEMVER_RE.match(version), f"{version!r} (from {rel_path}) is not valid semver"


### PR DESCRIPTION
## RFC 0048 Phase 1 — PR 2: UI config/context endpoints + `config/ui.yaml` + schema

Second PR of the [RFC 0048 web-console Phase 1 plan](https://github.com/mkhomutov/Persatrix/blob/main/docs/rfcs/0048-phase1-pr-plan.md#pr-2-featurev036-rfc0048p1-config-context--feature-toggle--forward-compat-endpoints). Builds on PR 1 (#496, `WithUI` scaffold). Adds the two read-only endpoints the Svelte SPA (PR 3) boots off, plus the feature-toggle config file, its schema, and the `validate.py` wiring. **Go + config + schema only — no JS.** `--enable-ui` stays off by default, so no default-runtime behaviour changes.

### What's here

- **`GET /api/v1/ui/config`** — `{panels: {<name>: {enabled, available}}, build: {version}}` (RFC §C).
  - `enabled` is operator-authored (from `config/ui.yaml`, or the Slice-1 defaults when absent).
  - `available` is **runtime-derived by the server** from whether the backing subsystem is wired — `channel_timeline ← channelStore`, `cost ← costReporter`, `chat` always, `memory_strip` always false until Slice 2 — and is **never** read from YAML.
- **`GET /api/v1/ui/context`** — the single identity source (RFC §F): `{"principal":"local","tenant":"local","authenticated":false}` for today's no-auth localhost mode. PR 4's chat panel derives `user_id` from this rather than prompting/hard-coding.
- Both endpoints are registered in the **existing `uiFS != nil` block** from PR 1, so they 404 when `--enable-ui` is off and ride the existing `/api/v1/*` middleware stack.
- **`WithUIConfig` option + `UIConfig` loader** — absent `ui.yaml` → Slice-1 defaults (no error); malformed → loud error, orchestrator logs WARN and soft-degrades to defaults (channels.yaml-consistent posture). `KnownFields` rejects stray keys.
- **`config/ui.yaml`** (chat/channel_timeline on; memory_strip/cost off) + **`schemas/ui.schema.json`** (draft-07; per-panel `additionalProperties:false` so an authored `available:` or a typo fails `make validate`) + **`validate.py` `_SCHEMA_MAP`** entry (plan D4).

### TDD

Tests authored first (Red → Green):
- `internal/server/ui_handlers_test.go` — config shape, `available` tracks `WithChannels` presence, context `local`, both 404 when UI disabled.
- `internal/server/ui_config_test.go` — defaults, absent→defaults, parse toggles, malformed→error.
- `cmd/orchestrator/ui_test.go` — enabled path wires `WithUI`+`WithUIConfig`, serves `/api/v1/ui/config`, malformed config soft-degrades.
- `agents/tests/test_validate_ui_schema.py` — committed `ui.yaml` validates; authored `available:` and a per-panel typo are rejected.

### Checklist (from the PR plan)

- [x] `go test ./internal/server/... -run UI` passes (config shape + availability + context)
- [x] `make validate` green; negative test confirms `available:` in YAML is rejected
- [x] `agents/validate.py` `_SCHEMA_MAP` has the `ui.yaml` entry; `ruff`/`mypy` clean
- [x] Endpoints 404 when `--enable-ui` off
- [x] No write endpoints added; both new endpoints read-only
- [x] `gofmt`/`go vet` clean; `go build ./...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
