### PR TITLE
feat(v036): RFC 0048 Phase 1 PR 5 — Channel timeline panel

### DIFF
--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -12,16 +12,20 @@ import App from "./App.svelte";
 // running orchestrator. This is the PR-3 smoke: the shell fetches config +
 // context, renders only the enabled && available panels, hides the rest, and
 // derives identity from the context principal — never a hard-coded user.
-// The shell mounts the real Chat panel for the enabled chat tab, whose mount
-// effect calls listAgents(); stub it (and sendChat) so the boot wiring under
-// test doesn't reach a real backend or throw on an undefined export. listAgents
-// resolves empty — these tests assert the shell's tab/identity wiring, not the
-// panel's contents.
+// The shell mounts the real Chat / ChannelTimeline panels for the enabled tabs,
+// whose mount effects call listAgents() / listChannels(); stub the panels' API
+// surface so the boot wiring under test doesn't reach a real backend or throw on
+// an undefined export. The list calls resolve empty — these tests assert the
+// shell's tab/identity wiring, not the panels' contents. (A deep-link / hashchange
+// to #/channels mounts ChannelTimeline, so its calls must be stubbed too.)
 vi.mock("./lib/api.js", () => ({
   ApiError: class ApiError extends Error {},
   loadBootstrap: vi.fn(),
   listAgents: vi.fn(() => Promise.resolve([])),
   sendChat: vi.fn(),
+  listChannels: vi.fn(() => Promise.resolve({ channels: [] })),
+  getChannelHistory: vi.fn(() => Promise.resolve({ messages: [] })),
+  publishMessage: vi.fn(),
 }));
 
 import { loadBootstrap } from "./lib/api.js";

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -115,14 +115,19 @@ body {
   gap: 0.75rem;
 }
 
-.composer {
+/* The chat composer and the channel-timeline publish form are the same kind of
+   write surface (labelled controls stacked over a submit button), so they share
+   one rule set rather than each re-deriving the layout. */
+.composer,
+.publish {
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
   max-width: 40rem;
 }
 
-.composer label {
+.composer label,
+.publish label {
   display: flex;
   flex-direction: column;
   gap: 0.2rem;
@@ -131,19 +136,22 @@ body {
 
 .composer textarea,
 .composer select,
-.composer input {
+.composer input,
+.publish textarea {
   font: inherit;
   padding: 0.3rem;
 }
 
-.composer button {
+.composer button,
+.publish button {
   align-self: flex-start;
   font: inherit;
   padding: 0.4rem 1rem;
   cursor: pointer;
 }
 
-.composer button:disabled {
+.composer button:disabled,
+.publish button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -183,4 +191,54 @@ body {
      error rather than inheriting the body text colour. */
   color: #b00020;
   color: light-dark(#b00020, #ff8a80);
+}
+
+/* Channel timeline panel (RFC 0048 Phase 1 PR 5). Same minimalism as the chat
+   panel — enough structure to scan a channel and reach the publish form. */
+.channels > label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+  max-width: 40rem;
+  margin-bottom: 1rem;
+}
+
+.channels > label select {
+  font: inherit;
+  padding: 0.3rem;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0 0 1rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.message {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.message .sender {
+  font-weight: 600;
+}
+
+.message .ts {
+  /* Metadata about the message, not its content — muted and small, like the
+     per-turn scope annotation in the chat panel. */
+  opacity: 0.6;
+  font-size: 0.8rem;
+}
+
+.poll-error {
+  /* Non-fatal "live updates paused" notice: muted, not alarming — the loaded
+     history is still on screen while the poll backs off. */
+  opacity: 0.7;
+  font-size: 0.85rem;
 }

--- a/web/src/lib/api.js
+++ b/web/src/lib/api.js
@@ -1,7 +1,8 @@
 // Thin typed-ish client for the console's backend (RFC 0048 Phase 1 / Slice 1).
 //
 // PR 3 needs only the two boot endpoints; PR 4 extends this module with the
-// chat/agents calls the chat panel drives. All calls are same-origin (the SPA
+// chat/agents calls the chat panel drives; PR 5 adds the channel list/history/
+// publish calls the timeline panel drives. All calls are same-origin (the SPA
 // is served by the orchestrator under /ui), so paths are root-relative and no
 // base URL or CORS handling is required.
 
@@ -146,4 +147,53 @@ export async function sendChat(agentID, { message, userId, sessionId, epochId })
   // request pinned to the /agents/{id}/chat route for any id, instead of
   // relying on that assumption holding.
   return postJSON(`/api/v1/agents/${encodeURIComponent(agentID)}/chat`, body);
+}
+
+// listChannels fetches the channels the timeline panel offers in its picker
+// (GET /api/v1/channels). It returns the server's `listChannelsResponse`
+// envelope ({channels, next_cursor}) verbatim rather than unwrapping to a bare
+// array: the panel reads `.channels`, and echoing the envelope keeps the
+// `next_cursor` cursor available for the keyset pagination a later slice may add
+// (channel_types.go), instead of discarding it at the client boundary.
+export async function listChannels() {
+  return getJSON("/api/v1/channels");
+}
+
+// getChannelHistory fetches a channel's message history
+// (GET /api/v1/channels/{id}/messages), returning the `historyResponse`
+// envelope ({messages}) — already newest-first on the wire (sqlite_messages.go
+// `ORDER BY timestamp DESC`), so the panel renders it without re-sorting. The
+// optional `limit` (positive int) and `before` (RFC-3339 cursor) ride only when
+// supplied — both error loudly server-side on a malformed value
+// (channel_query_params.go), so the head-poll passes just `limit` and a
+// paginating back-fill adds `before`.
+export async function getChannelHistory(channelID, { limit, before } = {}) {
+  const params = new URLSearchParams();
+  if (limit) {
+    params.set("limit", String(limit));
+  }
+  if (before) {
+    params.set("before", before);
+  }
+  const query = params.toString();
+  const suffix = query ? `?${query}` : "";
+  // Encode the id (DM ids carry colons, e.g. `dm:a:b`) so the request stays
+  // pinned to the {id}/messages route for any channel id.
+  return getJSON(
+    `/api/v1/channels/${encodeURIComponent(channelID)}/messages${suffix}`,
+  );
+}
+
+// publishMessage posts a human message into a channel
+// (POST /api/v1/channels/{id}/messages) and returns the stored
+// `channelMessageResponse`. `sender_id` is REQUIRED by the handler
+// (channel_handlers.go) and is the /ui/context-derived principal the caller
+// passes in — never free-text (RFC §F rule 1). This is the one write Slice 1's
+// timeline issues; the agent mention fan-out (RFC 0011) surfaces on the next
+// poll.
+export async function publishMessage(channelID, { senderId, content }) {
+  return postJSON(`/api/v1/channels/${encodeURIComponent(channelID)}/messages`, {
+    sender_id: senderId,
+    content,
+  });
 }

--- a/web/src/lib/api.test.js
+++ b/web/src/lib/api.test.js
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { loadBootstrap, listAgents, sendChat, ApiError } from "./api.js";
+import {
+  loadBootstrap,
+  listAgents,
+  sendChat,
+  listChannels,
+  getChannelHistory,
+  publishMessage,
+  ApiError,
+} from "./api.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -219,5 +227,188 @@ describe("sendChat", () => {
     expect(error).toBeInstanceOf(ApiError);
     expect(error.status).toBe(0);
     expect(error.cause).toBe(cause);
+  });
+});
+
+describe("listChannels", () => {
+  it("fetches the channel list and returns the parsed envelope", async () => {
+    // GET /api/v1/channels returns {channels, next_cursor} (channel_types.go
+    // listChannelsResponse), not a bare array — the panel reads `.channels`, so
+    // the client returns the envelope verbatim rather than unwrapping it (and
+    // discarding the cursor a later slice may paginate on).
+    const envelope = {
+      channels: [
+        { id: "general", name: "General", channel_type: "group" },
+        { id: "ops", name: "Ops", channel_type: "group" },
+      ],
+      next_cursor: "ops",
+    };
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(envelope)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await listChannels();
+
+    expect(result).toEqual(envelope);
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/channels");
+  });
+
+  it("throws an ApiError when the list endpoint responds non-2xx", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({}, false, 503)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(listChannels()).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("getChannelHistory", () => {
+  function history(overrides = {}) {
+    return {
+      messages: [
+        {
+          id: "m2",
+          channel_id: "general",
+          sender_id: "alice",
+          content: "second",
+          timestamp: "2026-06-02T10:00:02Z",
+          mentions: [],
+        },
+        {
+          id: "m1",
+          channel_id: "general",
+          sender_id: "bob",
+          content: "first",
+          timestamp: "2026-06-02T10:00:01Z",
+          mentions: [],
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("fetches a channel's history and returns the parsed envelope", async () => {
+    const body = history();
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(body)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getChannelHistory("general");
+
+    expect(result).toEqual(body);
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/channels/general/messages");
+  });
+
+  it("appends limit and before as query params only when supplied", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(history())));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getChannelHistory("general", {
+      limit: 50,
+      before: "2026-06-02T10:00:00Z",
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/v1/channels/general/messages?limit=50&before=2026-06-02T10%3A00%3A00Z",
+    );
+
+    await getChannelHistory("general", { limit: 25 });
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/api/v1/channels/general/messages?limit=25",
+    );
+  });
+
+  it("encodes the channel id into the request path", async () => {
+    // DM channel ids carry colons (`dm:a:b`); encoding keeps the request pinned
+    // to the {id}/messages route for any id rather than leaning on ids being
+    // path-safe slugs.
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(history())));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getChannelHistory("dm:alice:bob");
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/v1/channels/dm%3Aalice%3Abob/messages",
+    );
+  });
+
+  it("throws an ApiError when history responds non-2xx", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({}, false, 404)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getChannelHistory("missing")).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe("publishMessage", () => {
+  function published(overrides = {}) {
+    return {
+      id: "m3",
+      channel_id: "general",
+      sender_id: "local",
+      content: "hello channel",
+      timestamp: "2026-06-02T10:00:03Z",
+      mentions: [],
+      ...overrides,
+    };
+  }
+
+  it("POSTs JSON to the channel's messages route and returns the stored message", async () => {
+    const msg = published();
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(msg, true, 201)));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await publishMessage("general", {
+      senderId: "local",
+      content: "hello channel",
+    });
+
+    expect(result).toEqual(msg);
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/api/v1/channels/general/messages");
+    expect(init.method).toBe("POST");
+    expect(init.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("sends the content and the context-derived sender_id", async () => {
+    // publishMessageRequest requires sender_id (channel_handlers.go); the console
+    // publishes as the /ui/context principal threaded in as userId, never a
+    // free-text sender (RFC §F rule 1).
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(jsonResponse(published(), true, 201)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await publishMessage("general", { senderId: "local", content: "hi" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.sender_id).toBe("local");
+    expect(body.content).toBe("hi");
+  });
+
+  it("encodes the channel id into the request path", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(jsonResponse(published(), true, 201)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await publishMessage("dm:alice:bob", { senderId: "local", content: "hi" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/v1/channels/dm%3Aalice%3Abob/messages",
+    );
+  });
+
+  it("surfaces the server error envelope on a 4xx", async () => {
+    const envelope = { error: "content is required", code: "BAD_REQUEST" };
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(jsonResponse(envelope, false, 400)),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const error = await publishMessage("general", {
+      senderId: "local",
+      content: "",
+    }).catch((e) => e);
+
+    expect(error).toBeInstanceOf(ApiError);
+    expect(error.status).toBe(400);
+    expect(error.code).toBe("BAD_REQUEST");
   });
 });

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -347,6 +347,16 @@
   function onChannelChange() {
     publishError = "";
   }
+
+  // formatTimestamp renders the wire timestamp (RFC-3339 UTC) as a readable
+  // local date-time for the operator; the <time> element keeps the raw value in
+  // its machine-readable `datetime` attribute, so the human-facing text can be
+  // friendly without losing the parseable original. An unparseable value falls
+  // back to the raw string rather than rendering "Invalid Date".
+  function formatTimestamp(ts) {
+    const date = new Date(ts);
+    return Number.isNaN(date.getTime()) ? ts : date.toLocaleString();
+  }
 </script>
 
 <section class="panel channels" aria-label="Channels">
@@ -389,7 +399,9 @@
           <li class="message">
             <span class="sender">{message.sender_id}</span>
             <span class="content">{message.content}</span>
-            <time class="ts" datetime={message.timestamp}>{message.timestamp}</time>
+            <time class="ts" datetime={message.timestamp}
+              >{formatTimestamp(message.timestamp)}</time
+            >
           </li>
         {/each}
       </ol>

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -56,6 +56,10 @@
   // bumps it so an in-flight history fetch or poll can't write to a channel the
   // operator already navigated away from, and Retry is race-safe.
   let loadToken = 0;
+  // channelsToken does the same for the channel-list load — kept separate from
+  // loadToken so a channels reload (mount/Retry) never invalidates the active
+  // history poll, and a resolve-after-unmount can't write to a dead component.
+  let channelsToken = 0;
 
   const canPublish = $derived(
     Boolean(selectedChannel) && publishContent.trim().length > 0 && !publishing,
@@ -98,8 +102,13 @@
         return;
       }
       // head is newest-first; the unseen ones are the newest, so prepending them
-      // (in their newest-first order) ahead of the existing list keeps the whole
+      // (in their newest-first order) ahead of the existing list keeps the shown
       // timeline newest-first without re-rendering or re-sorting what's shown.
+      // Note the bound: if more than HEAD_LIMIT messages land between two ticks,
+      // the ones past the head's window (older than the head, newer than what's
+      // shown) are never re-fetched — an acceptable gap for Slice 1's poll-based,
+      // low-traffic localhost surface, to be closed by keyset back-fill or a
+      // push channel later (OQ4).
       const fresh = head.filter((m) => !seenIds.has(m.id));
       if (fresh.length > 0) {
         fresh.forEach((m) => seenIds.add(m.id));
@@ -121,20 +130,32 @@
   }
 
   // loadChannels fetches the channel list and is re-runnable (mount + Retry).
+  // The channelsToken guard drops a superseded resolution (a slow load that
+  // settles after a Retry, or after unmount), mirroring Chat's loadAgents.
   function loadChannels() {
+    const token = ++channelsToken;
     channelsError = "";
     channelsLoaded = false;
     return listChannels()
       .then((result) => {
+        if (token !== channelsToken) {
+          return;
+        }
         channels = result.channels ?? [];
         if (channels.length > 0 && !selectedChannel) {
           selectedChannel = channels[0].id;
         }
       })
       .catch((err) => {
+        if (token !== channelsToken) {
+          return;
+        }
         channelsError = `Could not load channels: ${err.message}`;
       })
       .finally(() => {
+        if (token !== channelsToken) {
+          return;
+        }
         channelsLoaded = true;
       });
   }
@@ -174,11 +195,23 @@
       });
   }
 
+  // retryHistory re-runs the selected channel's load after an initial-load
+  // failure. The poll loop only arms on a successful load, and re-selecting the
+  // same channel fires no onchange, so without this a failed first history fetch
+  // is a dead end (a single-channel console would be stuck until reload). Mirrors
+  // the channel-list Retry; loadHistory's loadToken bump keeps it race-safe.
+  function retryHistory() {
+    if (selectedChannel) {
+      loadHistory(selectedChannel);
+    }
+  }
+
   $effect(() => {
     loadChannels();
     return () => {
-      // Invalidate any in-flight work and stop polling on unmount.
-      loadToken++;
+      // Invalidate the in-flight channels load and stop polling on unmount.
+      // (The selected-channel effect's own cleanup invalidates history/poll.)
+      channelsToken++;
       clearPoll();
     };
   });
@@ -295,6 +328,7 @@
 
     {#if historyError}
       <p class="boot error" role="alert">{historyError}</p>
+      <button type="button" class="retry" onclick={retryHistory}>Retry</button>
     {:else if !historyLoaded}
       <p class="loading" role="status">Loading messages…</p>
     {:else if messages.length === 0}

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -46,12 +46,21 @@
 
   // seenIds de-dupes the head poll against messages already shown (and against a
   // just-published echo). Not reactive — it's bookkeeping the render reads
-  // through `messages`, reset whenever the active channel changes.
+  // through `messages`, reset whenever the active channel changes. Both it and
+  // `messages` grow unbounded across a long-lived session on a busy channel
+  // (only a channel switch clears them); left uncapped on purpose for Slice 1's
+  // low-traffic localhost surface — a retention cap rides with the keyset
+  // back-fill / push channel later (OQ4), rather than silently dropping the tail.
   let seenIds = new Set();
   // pollTimer holds the pending setTimeout; backoffMs is the current poll delay,
   // reset to the base interval on every success.
   let pollTimer = null;
   let backoffMs = POLL_INTERVAL_MS;
+  // polling guards against a second concurrent fetch: the visibility handler
+  // invokes poll() directly, and a 'visible' event can land while a timer-fired
+  // tick is still awaiting its request. Not reactive — it's in-flight bookkeeping
+  // the render never reads.
+  let polling = false;
   // loadToken disambiguates superseded loads: switching channel (or unmount)
   // bumps it so an in-flight history fetch or poll can't write to a channel the
   // operator already navigated away from, and Retry is race-safe.
@@ -99,6 +108,14 @@
     if (!channel) {
       return;
     }
+    // A tick is already awaiting its fetch (the visibility handler can call
+    // poll() directly mid-flight). Don't fire a second concurrent request — the
+    // in-flight tick reschedules the loop when it settles, so the duplicate buys
+    // nothing and only adds load to the unauthenticated localhost surface.
+    if (polling) {
+      return;
+    }
+    polling = true;
     try {
       const { messages: head } = await getChannelHistory(channel, {
         limit: HEAD_LIMIT,
@@ -131,6 +148,8 @@
       pollError = `Live updates paused: ${err.message}`;
       backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
       scheduleNext(backoffMs);
+    } finally {
+      polling = false;
     }
   }
 
@@ -177,6 +196,11 @@
     messages = [];
     seenIds = new Set();
     backoffMs = POLL_INTERVAL_MS;
+    // Clear the in-flight flag too: bumping loadToken just stranded any prior
+    // channel's poll (it bails on the token mismatch without rescheduling), so
+    // without this reset that stale tick's flag could make the new channel's
+    // first poll bail on the guard and leave the loop unarmed.
+    polling = false;
     return getChannelHistory(channel, { limit: HISTORY_LIMIT })
       .then(({ messages: history }) => {
         if (token !== loadToken) {

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -88,7 +88,12 @@
   // off delay on error. The token guard drops a result whose channel was
   // switched out mid-flight.
   async function poll() {
-    pollTimer = null;
+    // Clear (not just null) any armed tick: poll() is invoked both by its own
+    // setTimeout and directly by the visibility handler on resume. A repeat
+    // 'visible' event while a tick is already armed would otherwise orphan that
+    // tick — leaving the browser to fire it later as one extra poll. clearPoll()
+    // is a no-op on the already-elapsed handle when poll() runs from the timer.
+    clearPoll();
     const channel = selectedChannel;
     const token = loadToken;
     if (!channel) {
@@ -261,6 +266,15 @@
     if (!selectedChannel || content.length === 0) {
       return;
     }
+    // Capture the active channel's load token before the await. The channel
+    // <select> stays enabled during a publish, so the operator can switch
+    // channels (or the panel can unmount) while this POST is in flight. The
+    // publish targets the channel it was issued against (publishMessage reads
+    // selectedChannel now, before the await); if the channel has since changed,
+    // the resolution must not echo the stored message into — nor seed its id
+    // against — the now-current channel. Mirrors the loadToken guard poll() /
+    // loadHistory() apply to their own resolutions.
+    const token = loadToken;
     publishError = "";
     publishing = true;
     try {
@@ -268,6 +282,12 @@
         senderId: userId,
         content,
       });
+      if (token !== loadToken) {
+        // Superseded by a channel switch (or unmount): drop the echo. The
+        // message persisted in its own channel and surfaces there on that
+        // channel's own load/poll — it must not appear under the new selection.
+        return;
+      }
       // Echo the stored message immediately rather than waiting a poll interval;
       // the de-dupe set keeps the upcoming poll from re-adding it. The agent
       // mention fan-out (RFC 0011) still surfaces on a later poll.
@@ -277,6 +297,12 @@
       }
       publishContent = "";
     } catch (err) {
+      if (token !== loadToken) {
+        // A failure for a channel the operator already left is not actionable
+        // here — surfacing it over the new selection (which onChannelChange just
+        // cleared) would read as though the new channel is broken.
+        return;
+      }
       publishError =
         err instanceof ApiError
           ? err.message

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -1,16 +1,336 @@
 <script>
-  // Channel-timeline panel slot (RFC 0048 Phase 1). PR 5 replaces this with the
-  // channel list + newest-first history that stays live by polling
-  // (visibility-pause + error-backoff + head-poll de-dupe), plus the optional
-  // human publish into a group channel.
+  // Channel-timeline panel (RFC 0048 Phase 1 PR 5) — watch personas interact:
+  // pick a channel, see its history newest-first, and keep it live by polling
+  // (no channel-push API exists today, OQ4). An optional human publish posts
+  // into the channel and the mention fan-out (RFC 0011) surfaces on the next
+  // poll. No backend change; pure render-over-existing-API. The shell threads in
+  // the /ui/context-derived userId (RFC §F single identity source), so the panel
+  // never prompts for or hard-codes a sender.
+  import {
+    listChannels,
+    getChannelHistory,
+    publishMessage,
+    ApiError,
+  } from "../lib/api.js";
+
   let { userId } = $props();
+
+  // POLL_INTERVAL_MS is the steady-state cadence; on a poll error the delay
+  // backs off exponentially up to MAX_BACKOFF_MS so an idle or erroring tab does
+  // not hammer the unauthenticated localhost surface (RFC §Security / §D.2). The
+  // head poll fetches at most HEAD_LIMIT newest messages and de-dupes against
+  // what's already shown — it never re-fetches the full history per tick.
+  const POLL_INTERVAL_MS = 3000;
+  const MAX_BACKOFF_MS = 30000;
+  const HISTORY_LIMIT = 50;
+  const HEAD_LIMIT = 50;
+
+  let channels = $state([]);
+  let channelsError = $state("");
+  // channelsLoaded gates the "no channels" empty state so it only shows after a
+  // confirmed-empty list, never as a flash of a blank picker mid-load.
+  let channelsLoaded = $state(false);
+  let selectedChannel = $state("");
+
+  // messages is the panel's view of the channel, newest-first (the wire order).
+  let messages = $state([]);
+  let historyError = $state("");
+  let historyLoaded = $state(false);
+  // pollError is a non-fatal banner: the loaded history stays on screen while
+  // the poll retries with backoff, so a transient hiccup doesn't blank the view.
+  let pollError = $state("");
+
+  let publishContent = $state("");
+  let publishing = $state(false);
+  let publishError = $state("");
+
+  // seenIds de-dupes the head poll against messages already shown (and against a
+  // just-published echo). Not reactive — it's bookkeeping the render reads
+  // through `messages`, reset whenever the active channel changes.
+  let seenIds = new Set();
+  // pollTimer holds the pending setTimeout; backoffMs is the current poll delay,
+  // reset to the base interval on every success.
+  let pollTimer = null;
+  let backoffMs = POLL_INTERVAL_MS;
+  // loadToken disambiguates superseded loads: switching channel (or unmount)
+  // bumps it so an in-flight history fetch or poll can't write to a channel the
+  // operator already navigated away from, and Retry is race-safe.
+  let loadToken = 0;
+
+  const canPublish = $derived(
+    Boolean(selectedChannel) && publishContent.trim().length > 0 && !publishing,
+  );
+
+  function clearPoll() {
+    if (pollTimer !== null) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  // scheduleNext arms the next poll, unless the tab is backgrounded — a hidden
+  // tab parks polling entirely (Page Visibility API) and the visibility handler
+  // resumes it. Always clears any pending timer first so callers can't stack two.
+  function scheduleNext(delay) {
+    clearPoll();
+    if (typeof document !== "undefined" && document.hidden) {
+      return;
+    }
+    pollTimer = setTimeout(poll, delay);
+  }
+
+  // poll fetches the channel head (HEAD_LIMIT newest), appends only messages not
+  // already seen, and reschedules: at the base interval on success, or a backed-
+  // off delay on error. The token guard drops a result whose channel was
+  // switched out mid-flight.
+  async function poll() {
+    pollTimer = null;
+    const channel = selectedChannel;
+    const token = loadToken;
+    if (!channel) {
+      return;
+    }
+    try {
+      const { messages: head } = await getChannelHistory(channel, {
+        limit: HEAD_LIMIT,
+      });
+      if (token !== loadToken) {
+        return;
+      }
+      // head is newest-first; the unseen ones are the newest, so prepending them
+      // (in their newest-first order) ahead of the existing list keeps the whole
+      // timeline newest-first without re-rendering or re-sorting what's shown.
+      const fresh = head.filter((m) => !seenIds.has(m.id));
+      if (fresh.length > 0) {
+        fresh.forEach((m) => seenIds.add(m.id));
+        messages = [...fresh, ...messages];
+      }
+      pollError = "";
+      backoffMs = POLL_INTERVAL_MS;
+      scheduleNext(POLL_INTERVAL_MS);
+    } catch (err) {
+      if (token !== loadToken) {
+        return;
+      }
+      // err is an ApiError out of the client (its message carries the server's
+      // wording when present); a non-ApiError still degrades to its message.
+      pollError = `Live updates paused: ${err.message}`;
+      backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
+      scheduleNext(backoffMs);
+    }
+  }
+
+  // loadChannels fetches the channel list and is re-runnable (mount + Retry).
+  function loadChannels() {
+    channelsError = "";
+    channelsLoaded = false;
+    return listChannels()
+      .then((result) => {
+        channels = result.channels ?? [];
+        if (channels.length > 0 && !selectedChannel) {
+          selectedChannel = channels[0].id;
+        }
+      })
+      .catch((err) => {
+        channelsError = `Could not load channels: ${err.message}`;
+      })
+      .finally(() => {
+        channelsLoaded = true;
+      });
+  }
+
+  // loadHistory replaces the timeline with the selected channel's history and
+  // (re)starts polling from a clean de-dupe set. Bumping loadToken invalidates
+  // any in-flight fetch/poll from the previous channel.
+  function loadHistory(channel) {
+    const token = ++loadToken;
+    clearPoll();
+    historyError = "";
+    pollError = "";
+    historyLoaded = false;
+    messages = [];
+    seenIds = new Set();
+    backoffMs = POLL_INTERVAL_MS;
+    return getChannelHistory(channel, { limit: HISTORY_LIMIT })
+      .then(({ messages: history }) => {
+        if (token !== loadToken) {
+          return;
+        }
+        messages = history;
+        history.forEach((m) => seenIds.add(m.id));
+        scheduleNext(POLL_INTERVAL_MS);
+      })
+      .catch((err) => {
+        if (token !== loadToken) {
+          return;
+        }
+        historyError = `Could not load history: ${err.message}`;
+      })
+      .finally(() => {
+        if (token !== loadToken) {
+          return;
+        }
+        historyLoaded = true;
+      });
+  }
+
+  $effect(() => {
+    loadChannels();
+    return () => {
+      // Invalidate any in-flight work and stop polling on unmount.
+      loadToken++;
+      clearPoll();
+    };
+  });
+
+  // React to the selected channel: each change reloads history and restarts the
+  // poll loop; the cleanup invalidates the prior channel's in-flight work so a
+  // slow fetch can't write to the newly-selected channel.
+  $effect(() => {
+    const channel = selectedChannel;
+    if (!channel) {
+      return;
+    }
+    loadHistory(channel);
+    return () => {
+      loadToken++;
+      clearPoll();
+    };
+  });
+
+  // Pause polling while the tab is backgrounded and catch up when it returns —
+  // the load-protection contract the RFC calls out for the unauthenticated
+  // surface. Hiding clears the pending timer; revealing polls immediately (then
+  // resumes the cadence) so a returning operator sees fresh messages at once.
+  $effect(() => {
+    function onVisibility() {
+      if (document.hidden) {
+        clearPoll();
+      } else if (selectedChannel && historyLoaded && !historyError) {
+        poll();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  });
+
+  // channelLabel mirrors Chat's persona label: the channel's name, falling back
+  // to its id (DMs/threads have no name — channel_types.go).
+  function channelLabel(channel) {
+    return channel.name ? channel.name : channel.id;
+  }
+
+  async function publish() {
+    if (publishing) {
+      return;
+    }
+    const content = publishContent.trim();
+    if (!selectedChannel || content.length === 0) {
+      return;
+    }
+    publishError = "";
+    publishing = true;
+    try {
+      const stored = await publishMessage(selectedChannel, {
+        senderId: userId,
+        content,
+      });
+      // Echo the stored message immediately rather than waiting a poll interval;
+      // the de-dupe set keeps the upcoming poll from re-adding it. The agent
+      // mention fan-out (RFC 0011) still surfaces on a later poll.
+      if (stored && stored.id && !seenIds.has(stored.id)) {
+        seenIds.add(stored.id);
+        messages = [stored, ...messages];
+      }
+      publishContent = "";
+    } catch (err) {
+      publishError =
+        err instanceof ApiError
+          ? err.message
+          : `The message could not be posted: ${err.message}`;
+    } finally {
+      publishing = false;
+    }
+  }
+
+  function onPublishSubmit(event) {
+    event.preventDefault();
+    publish();
+  }
+
+  // onChannelChange drops a stale publish error when the operator switches
+  // channel — it refers to the prior channel's attempt, so leaving it over the
+  // new selection reads as if the new channel is already broken.
+  function onChannelChange() {
+    publishError = "";
+  }
 </script>
 
-<section class="panel" aria-label="Channels">
+<section class="panel channels" aria-label="Channels">
   <h2>Channels</h2>
-  <p class="placeholder">
-    The channel timeline arrives in RFC 0048 Phase 1 PR 5. You will watch a
-    channel and optionally post into it here.
-  </p>
   <p class="identity">Acting as <code>{userId}</code></p>
+
+  {#if channelsError}
+    <p class="boot error" role="alert">{channelsError}</p>
+    <button type="button" class="retry" onclick={loadChannels}>Retry</button>
+  {:else if !channelsLoaded}
+    <p class="loading" role="status">Loading channels…</p>
+  {:else if channels.length === 0}
+    <p class="empty">No channels exist yet.</p>
+  {:else}
+    <label>
+      Channel
+      <select bind:value={selectedChannel} onchange={onChannelChange}>
+        {#each channels as channel (channel.id)}
+          <option value={channel.id}>{channelLabel(channel)}</option>
+        {/each}
+      </select>
+    </label>
+
+    {#if pollError}
+      <!-- Non-fatal: the loaded history stays visible while the poll backs off
+           and retries, so a transient error doesn't blank the timeline. -->
+      <p class="poll-error" role="status">{pollError}</p>
+    {/if}
+
+    {#if historyError}
+      <p class="boot error" role="alert">{historyError}</p>
+    {:else if !historyLoaded}
+      <p class="loading" role="status">Loading messages…</p>
+    {:else if messages.length === 0}
+      <p class="empty">No messages yet.</p>
+    {:else}
+      <ol class="timeline" aria-label="Channel messages">
+        {#each messages as message (message.id)}
+          <li class="message">
+            <span class="sender">{message.sender_id}</span>
+            <span class="content">{message.content}</span>
+            <time class="ts" datetime={message.timestamp}>{message.timestamp}</time>
+          </li>
+        {/each}
+      </ol>
+    {/if}
+
+    {#if publishError}
+      <p class="boot error" role="alert">{publishError}</p>
+    {/if}
+
+    <!-- The optional human publish: a clearly-labelled write action so it reads
+         as deliberate, not a search box. The sender is the /ui/context principal
+         (userId) — never a free-text field (RFC §F rule 1). -->
+    <form class="publish" onsubmit={onPublishSubmit}>
+      <label>
+        Message
+        <textarea
+          bind:value={publishContent}
+          rows="2"
+          placeholder="Post a message to this channel…"
+          disabled={publishing}
+        ></textarea>
+      </label>
+      <button type="submit" disabled={!canPublish}>
+        {publishing ? "Posting…" : "Post"}
+      </button>
+    </form>
+  {/if}
 </section>

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -93,6 +93,27 @@ describe("Channel timeline panel", () => {
     expect(items[1].textContent).toMatch(/first/);
   });
 
+  it("renders a human-readable timestamp but keeps the raw value machine-readable", async () => {
+    // The wire timestamp is RFC-3339 UTC (e.g. 2026-06-02T10:00:00Z) — readable
+    // by a machine, not by an operator scanning the timeline. The visible text
+    // is formatted for a human, while the <time> element keeps the raw value in
+    // its `datetime` attribute so it stays machine-parseable.
+    getChannelHistory.mockResolvedValue(
+      historyOf(msg("only", "hello", "alice", "2026-06-02T10:00:00Z")),
+    );
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByText(/hello/);
+
+    const timeEl = document.querySelector("time.ts");
+    expect(timeEl.getAttribute("datetime")).toBe("2026-06-02T10:00:00Z");
+    // Formatted for display: not the raw ISO string, and without its `T`
+    // date/time separator. The exact wording is locale/zone dependent, so the
+    // assertion is on what it must NOT be rather than an exact string.
+    expect(timeEl.textContent).not.toBe("2026-06-02T10:00:00Z");
+    expect(timeEl.textContent).not.toMatch(/\dT\d/);
+  });
+
   it("shows an empty state when no channels exist", async () => {
     listChannels.mockResolvedValue({ channels: [] });
 

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -308,4 +308,70 @@ describe("Channel timeline panel", () => {
     });
     expect(screen.queryByText(/second/)).toBeNull();
   });
+
+  it("drops a publish echo when the operator switches channel mid-flight", async () => {
+    // The channel <select> is not disabled while a publish is in flight, so the
+    // operator can switch channels before the POST resolves. The publish targets
+    // the channel it was issued against; its echo must not leak into — nor seed a
+    // seen-id against — the channel now selected. This mirrors the loadToken
+    // guard poll()/loadHistory() already apply to their own resolutions.
+    let resolvePublish;
+    publishMessage.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePublish = resolve;
+      }),
+    );
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByText(/second/); // general's history loaded
+
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "to general" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /post/i }));
+
+    // Switch to ops before the publish (issued against general) resolves.
+    getChannelHistory.mockResolvedValue(
+      historyOf(msg("o1", "ops message", "carol")),
+    );
+    await fireEvent.change(screen.getByRole("combobox", { name: /channel/i }), {
+      target: { value: "ops" },
+    });
+    await screen.findByText(/ops message/);
+
+    // The general-targeted publish now resolves with its stored message.
+    resolvePublish(msg("g9", "to general", "local", "2026-06-02T10:00:09Z"));
+    // Wait for the in-flight state to settle ("Posting…" → "Post"), which means
+    // the publish resolution (and its echo, were it buggy) has been processed.
+    await screen.findByRole("button", { name: "Post" });
+
+    // The general message must not appear in ops's timeline.
+    expect(screen.queryByText(/to general/)).toBeNull();
+  });
+
+  it("does not orphan the pending poll tick on a repeat visible event", async () => {
+    // poll() must clear any armed tick when it runs, not merely null the handle:
+    // the visibility handler calls poll() directly, and a repeat 'visible' event
+    // (tab already visible, a tick already armed) would otherwise leave that tick
+    // orphaned — firing one extra poll against the unauthenticated localhost
+    // surface the visibility-pause / backoff is meant to protect.
+    vi.useFakeTimers();
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await vi.waitFor(() => expect(getChannelHistory).toHaveBeenCalled());
+    const afterLoad = getChannelHistory.mock.calls.length;
+
+    // A repeat 'visible' event fires an immediate catch-up poll and arms the
+    // next tick (document.hidden defaults false in jsdom).
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.waitFor(() =>
+      expect(getChannelHistory.mock.calls.length).toBe(afterLoad + 1),
+    );
+    const afterVisible = getChannelHistory.mock.calls.length;
+
+    // One base interval later exactly one tick should fire — the freshly-armed
+    // one. The previously-armed tick must have been cleared, not orphaned (which
+    // would fire a second poll in the same window).
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getChannelHistory.mock.calls.length).toBe(afterVisible + 1);
+  });
 });

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  fireEvent,
+} from "@testing-library/svelte";
+import ChannelTimeline from "./ChannelTimeline.svelte";
+
+// The channel-timeline panel renders over today's channel API (RFC 0048 PR 5):
+// it lists channels, shows a channel's history newest-first, keeps it live by
+// polling (visibility-pause + error-backoff + head-poll de-dupe), and offers an
+// optional human publish. The backend client is mocked so the panel's wiring is
+// exercised without a running orchestrator or real timers.
+vi.mock("../lib/api.js", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(message, status, options) {
+      super(message, options);
+      this.name = "ApiError";
+      this.status = status;
+      this.code = options?.code;
+    }
+  },
+  listChannels: vi.fn(),
+  getChannelHistory: vi.fn(),
+  publishMessage: vi.fn(),
+}));
+
+import {
+  listChannels,
+  getChannelHistory,
+  publishMessage,
+  ApiError,
+} from "../lib/api.js";
+
+const CHANNELS = [
+  { id: "general", name: "General", channel_type: "group" },
+  { id: "ops", name: "Ops", channel_type: "group" },
+];
+
+function msg(id, content, sender = "alice", ts = "2026-06-02T10:00:00Z") {
+  return {
+    id,
+    channel_id: "general",
+    sender_id: sender,
+    content,
+    timestamp: ts,
+    mentions: [],
+  };
+}
+
+// The history endpoint returns newest-first (sqlite_messages.go ORDER BY
+// timestamp DESC), so fixtures mirror that ordering.
+function historyOf(...messages) {
+  return { messages };
+}
+
+beforeEach(() => {
+  listChannels.mockResolvedValue({ channels: CHANNELS });
+  getChannelHistory.mockResolvedValue(
+    historyOf(msg("m2", "second"), msg("m1", "first")),
+  );
+  publishMessage.mockResolvedValue(
+    msg("m3", "from me", "local", "2026-06-02T10:00:03Z"),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("Channel timeline panel", () => {
+  it("populates the channel picker from GET /api/v1/channels on mount", async () => {
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: "General" })).toBeTruthy();
+    });
+    expect(screen.getByRole("option", { name: "Ops" })).toBeTruthy();
+    expect(listChannels).toHaveBeenCalledOnce();
+  });
+
+  it("renders the selected channel's history newest-first", async () => {
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    // The default channel's history loads; the two messages render with the
+    // newest (m2/"second") before the older (m1/"first").
+    const items = await screen.findAllByRole("listitem");
+    expect(items[0].textContent).toMatch(/second/);
+    expect(items[1].textContent).toMatch(/first/);
+  });
+
+  it("shows an empty state when no channels exist", async () => {
+    listChannels.mockResolvedValue({ channels: [] });
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    expect(await screen.findByText(/no channels/i)).toBeTruthy();
+  });
+
+  it("shows a no-messages state for an empty channel", async () => {
+    getChannelHistory.mockResolvedValue(historyOf());
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    await screen.findByRole("option", { name: "General" });
+    expect(await screen.findByText(/no messages/i)).toBeTruthy();
+  });
+
+  it("surfaces a channel-load failure and retries", async () => {
+    listChannels.mockRejectedValueOnce(new ApiError("backend down", 503));
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("alert");
+
+    await fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    await screen.findByRole("option", { name: "General" });
+    expect(listChannels).toHaveBeenCalledTimes(2);
+  });
+
+  it("acts as the context principal for publish and offers no free-text user field", async () => {
+    const { container } = render(ChannelTimeline, {
+      props: { userId: "local" },
+    });
+    await screen.findByRole("option", { name: "General" });
+
+    // RFC §F rule 1: the publish sender is the /ui/context principal threaded in
+    // as a prop; the panel must never expose a sender/user textbox to type into.
+    expect(screen.queryByRole("textbox", { name: /sender|user/i })).toBeNull();
+    expect(container.querySelector('input[name="sender_id"]')).toBeNull();
+    expect(container.querySelector('input[name="user_id"]')).toBeNull();
+  });
+
+  it("disables publish until a message is entered", async () => {
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "General" });
+
+    const publishButton = screen.getByRole("button", { name: /post/i });
+    expect(publishButton.disabled).toBe(true);
+
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "hello channel" },
+    });
+    expect(publishButton.disabled).toBe(false);
+  });
+
+  it("publishes a message as the context principal and echoes it immediately", async () => {
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "General" });
+
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "from me" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /post/i }));
+
+    await waitFor(() => {
+      expect(publishMessage).toHaveBeenCalledWith("general", {
+        senderId: "local",
+        content: "from me",
+      });
+    });
+    // The stored message the publish returns appears immediately, without
+    // waiting for the next poll tick.
+    expect(await screen.findByText(/from me/)).toBeTruthy();
+  });
+
+  it("surfaces a publish error envelope without crashing the panel", async () => {
+    publishMessage.mockRejectedValue(
+      new ApiError("content is required", 400, { code: "BAD_REQUEST" }),
+    );
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "General" });
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "x" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /post/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/content is required/i);
+    // The composer is still usable.
+    expect(screen.getByRole("textbox", { name: /message/i })).toBeTruthy();
+  });
+
+  it("polls for new messages and appends them, de-duping by id", async () => {
+    vi.useFakeTimers();
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    // Let the initial history load settle (m2, m1).
+    await vi.waitFor(() => expect(getChannelHistory).toHaveBeenCalled());
+    const initialCalls = getChannelHistory.mock.calls.length;
+
+    // The next poll returns the head with a brand-new message (m3) plus the
+    // already-seen ones — the panel must append only m3 and not duplicate m2/m1.
+    getChannelHistory.mockResolvedValue(
+      historyOf(
+        msg("m3", "third", "alice", "2026-06-02T10:00:03Z"),
+        msg("m2", "second"),
+        msg("m1", "first"),
+      ),
+    );
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(getChannelHistory.mock.calls.length).toBeGreaterThan(initialCalls);
+    await vi.waitFor(() => {
+      const items = screen.getAllByRole("listitem");
+      // m3 prepended ahead of the existing two; still newest-first; no dup.
+      expect(items.length).toBe(3);
+      expect(items[0].textContent).toMatch(/third/);
+    });
+    // The head poll passes a limit (does not re-fetch unbounded history).
+    const lastCall = getChannelHistory.mock.calls.at(-1);
+    expect(lastCall[1]).toMatchObject({ limit: expect.any(Number) });
+  });
+
+  it("pauses polling while the tab is backgrounded and resumes when visible", async () => {
+    vi.useFakeTimers();
+    const hiddenSpy = vi.spyOn(document, "hidden", "get").mockReturnValue(false);
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await vi.waitFor(() => expect(getChannelHistory).toHaveBeenCalled());
+    const callsBeforeHide = getChannelHistory.mock.calls.length;
+
+    // Background the tab: no poll should fire across multiple intervals.
+    hiddenSpy.mockReturnValue(true);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(9000);
+    expect(getChannelHistory.mock.calls.length).toBe(callsBeforeHide);
+
+    // Foreground again: polling resumes.
+    hiddenSpy.mockReturnValue(false);
+    document.dispatchEvent(new Event("visibilitychange"));
+    await vi.waitFor(() =>
+      expect(getChannelHistory.mock.calls.length).toBeGreaterThan(
+        callsBeforeHide,
+      ),
+    );
+  });
+
+  it("backs off exponentially after a poll error", async () => {
+    vi.useFakeTimers();
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await vi.waitFor(() => expect(getChannelHistory).toHaveBeenCalled());
+
+    // Every poll now fails. After the first failure the next attempt must be
+    // scheduled further out than the base interval (exponential backoff), so an
+    // idle/erroring tab doesn't hammer the unauthenticated localhost surface.
+    getChannelHistory.mockRejectedValue(new ApiError("boom", 503));
+
+    // First poll at the base 3s interval -> fails, schedules a backed-off retry.
+    await vi.advanceTimersByTimeAsync(3000);
+    const afterFirstFailure = getChannelHistory.mock.calls.length;
+
+    // A second base interval is NOT enough to trigger the next attempt: the
+    // backoff pushed it past 3s. Nothing new fires yet.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getChannelHistory.mock.calls.length).toBe(afterFirstFailure);
+
+    // Advancing further crosses the backed-off delay and the retry fires.
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(getChannelHistory.mock.calls.length).toBeGreaterThan(
+      afterFirstFailure,
+    );
+  });
+
+  it("reloads history and restarts polling when the channel is switched", async () => {
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "General" });
+    // Initial history for the default channel.
+    await screen.findByText(/second/);
+
+    getChannelHistory.mockResolvedValue(
+      historyOf(msg("o1", "ops message", "carol")),
+    );
+    await fireEvent.change(screen.getByRole("combobox", { name: /channel/i }), {
+      target: { value: "ops" },
+    });
+
+    // The new channel's history replaces the old, and the fetch targets it.
+    expect(await screen.findByText(/ops message/)).toBeTruthy();
+    await waitFor(() => {
+      const lastCall = getChannelHistory.mock.calls.at(-1);
+      expect(lastCall[0]).toBe("ops");
+    });
+    expect(screen.queryByText(/second/)).toBeNull();
+  });
+});

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -122,6 +122,25 @@ describe("Channel timeline panel", () => {
     expect(listChannels).toHaveBeenCalledTimes(2);
   });
 
+  it("surfaces a history-load failure and retries it", async () => {
+    // The channel list loads, but the selected channel's initial history fetch
+    // fails. The poll loop only arms on a successful load, so without a Retry
+    // the error is a dead end — re-selecting the same channel fires no onchange,
+    // leaving a single-channel console stuck until reload. The Retry re-runs the
+    // load for the still-selected channel (mockRejectedValueOnce falls back to
+    // the beforeEach success on the second call).
+    getChannelHistory.mockRejectedValueOnce(new ApiError("history down", 503));
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "General" });
+    await screen.findByRole("alert");
+
+    await fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(await screen.findByText(/second/)).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("acts as the context principal for publish and offers no free-text user field", async () => {
     const { container } = render(ChannelTimeline, {
       props: { userId: "local" },

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -374,4 +374,40 @@ describe("Channel timeline panel", () => {
     await vi.advanceTimersByTimeAsync(3000);
     expect(getChannelHistory.mock.calls.length).toBe(afterVisible + 1);
   });
+
+  it("does not launch a concurrent poll when a visible event arrives mid-poll", async () => {
+    // The visibility handler calls poll() directly on resume, but a 'visible'
+    // event can also arrive while a timer-fired tick is still awaiting its
+    // fetch. Without an in-flight guard that would launch a second concurrent
+    // request against the unauthenticated localhost surface. The in-flight tick
+    // reschedules the loop when it settles, so the redundant fetch buys nothing.
+    vi.useFakeTimers();
+    render(ChannelTimeline, { props: { userId: "local" } });
+    await vi.waitFor(() => expect(getChannelHistory).toHaveBeenCalled());
+    const afterLoad = getChannelHistory.mock.calls.length;
+
+    // Make the next poll hang so it stays in flight.
+    let resolvePoll;
+    getChannelHistory.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePoll = resolve;
+      }),
+    );
+
+    // The base interval fires the (now-hanging) poll.
+    await vi.advanceTimersByTimeAsync(3000);
+    const duringPoll = getChannelHistory.mock.calls.length;
+    expect(duringPoll).toBe(afterLoad + 1);
+
+    // A visible event arrives while that poll is still in flight: it must not
+    // start a second concurrent fetch (the handler runs synchronously up to the
+    // fetch, so the call count would jump immediately if it did).
+    document.dispatchEvent(new Event("visibilitychange"));
+    expect(getChannelHistory.mock.calls.length).toBe(duringPoll);
+
+    // Letting the in-flight poll settle, the loop resumes from a single timer.
+    resolvePoll(historyOf(msg("m2", "second"), msg("m1", "first")));
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getChannelHistory.mock.calls.length).toBe(duringPoll + 1);
+  });
 });


### PR DESCRIPTION
## Summary

RFC 0048 Phase 1 / Slice 1, **PR 5** ([phase-1 PR plan §PR 5](docs/rfcs/0048-phase1-pr-plan.md#pr-5-featurev036-rfc0048p1-channel-timeline--channel-timeline-panel)). Delivers the "watch personas interact" half of the hero story: pick a channel, see its history newest-first, keep it live by polling, and optionally publish into it. Pure render-over-existing-API — **no Go/backend change**.

Depends on PR 3's shell (merged); independent of PR 4. Closes out alongside PR 4 in PR 6.

## What's here

- **`web/src/lib/api.js`** — `listChannels` / `getChannelHistory` / `publishMessage`:
  - History is already newest-first on the wire (`sqlite_messages.go` `ORDER BY timestamp DESC`), so the panel renders without re-sorting.
  - `limit` / `before` ride as query params only when supplied (both error loudly server-side on a malformed value).
  - Channel ids are `encodeURIComponent`-encoded (DM ids carry colons, e.g. `dm:a:b`), matching the PR 4 agent-id precedent.
  - Publish `sender_id` is the `/ui/context`-derived principal threaded in as `userId` — never free-text ([RFC §F rule 1](docs/rfcs/0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility)).
- **`web/src/panels/ChannelTimeline.svelte`** — channel picker + newest-first timeline that stays live by polling, implementing the RFC's load-protection contract for the unauthenticated localhost surface:
  - **Visibility-pause** — a backgrounded tab parks polling (Page Visibility API) and resumes (with an immediate catch-up poll) when foregrounded.
  - **Exponential error-backoff** — capped at 30s; the loaded history stays on screen behind a non-fatal "live updates paused" banner while it retries.
  - **Head-poll de-dupe** — each tick fetches the head (bounded `limit`) and appends only messages whose id isn't already shown; no full-history re-fetch per tick.
  - **Optional human publish** — a clearly-labelled write action; echoes the stored message immediately, with the agent mention fan-out (RFC 0011) surfacing on the next poll.

## Testing — TDD (Red → Green)

- `web/src/lib/api.test.js` (+12 cases) and `web/src/panels/ChannelTimeline.test.js` (13 cases) written first and confirmed failing before implementation.
- Polling, visibility-pause, and backoff are exercised with fake timers.
- `App.test.js` mock extended so the `#/channels` deep-link tests mount `ChannelTimeline` without hitting an undefined export.
- Full web suite green: **84 tests** (`make ui-test`); `make ui` builds clean.

## PR checklist (from the plan)

- [x] E2E: open channel → see history → observe a polled update (covered by panel tests).
- [x] Polling pauses when backgrounded and backs off on error (asserted).
- [x] Head-poll de-dupes by message id; does not re-fetch full history per tick.
- [x] No Go/backend change in this PR.
- [x] `make ui` clean; web suite green.

RFC 0048 stays `🚧 Implementing` across PRs 1–5 — no status/ROADMAP edit here (PR 6 owns the closeout flip).