### PR TITLE
feat(v036): RFC 0048 Phase 1 — enable web console in Docker + embed bundle in image

### DIFF
--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,11 +1,40 @@
 # Persatrix Orchestrator (Go)
-FROM golang:1.25-alpine AS builder
+#
+# Multi-stage: a Node stage builds the embedded web console bundle (RFC 0048),
+# then the Go stage embeds it into the binary, so the image ALWAYS serves the
+# real Svelte console — never the committed placeholder. This makes the Docker
+# path self-contained: `docker compose build` / `make demo-*` need no host JS
+# toolchain and no prior `make ui`, even for a bare `docker compose up --build`
+# straight from a clean clone. (The committed placeholder still keeps a plain
+# `go build ./...` / the Go-only CI lane green with no Node — RFC 0048 PR plan
+# D2; only this image build overrides it with the real bundle.)
 
+# ─── Stage 1: web console bundle (Svelte/Vite) ──────────────
+FROM node:22-alpine AS ui-builder
+WORKDIR /build/web
+# Copy manifests first so the `npm ci` layer caches on the lockfile and is
+# skipped on rebuilds that only touch source.
+COPY web/package.json web/package-lock.json web/.npmrc ./
+RUN npm ci
+COPY web/ ./
+# vite.config.js sets `base: "/ui/"` and `outDir: ../internal/ui/assets` with
+# emptyOutDir, so this writes the hashed bundle (overwriting the placeholder
+# index.html) to /build/internal/ui/assets.
+RUN npm run build
+
+# ─── Stage 2: Go orchestrator ───────────────────────────────
+FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY cmd/ cmd/
 COPY internal/ internal/
+# Replace whatever asset tree arrived in the build context (the committed
+# placeholder on a clean checkout, or a stale host bundle) with the freshly
+# built one from the ui-builder stage, so the embedded //go:embed console is
+# deterministic regardless of host state.
+RUN rm -rf internal/ui/assets
+COPY --from=ui-builder /build/internal/ui/assets/ internal/ui/assets/
 RUN CGO_ENABLED=0 go build -o persatrix-server ./cmd/orchestrator
 
 FROM alpine:3.20

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-orchestrator build-orchestrator-ui ui ui-test build-cli build-agents proto proto-go proto-python proto-python-check proto-orphans-check proto-check clean reset test lint run validate help demo-offline demo-ollama generate-persona-nickname generate-sanitizer-patterns generate-sanitizer-patterns-check check-licenses check-licenses-go check-licenses-python check-licenses-rust notices notices-check bump-version issues issues-check rfcs rfcs-check
+.PHONY: all build build-orchestrator build-orchestrator-ui ui ui-test build-cli build-agents proto proto-go proto-python proto-python-check proto-orphans-check proto-check clean reset test lint run run-ui validate help demo-offline demo-ollama generate-persona-nickname generate-sanitizer-patterns generate-sanitizer-patterns-check check-licenses check-licenses-go check-licenses-python check-licenses-rust notices notices-check bump-version issues issues-check rfcs rfcs-check
 
 # ─── Config ─────────────────────────────────────────────
 GO_MODULE     := github.com/mkhomutov/persatrix
@@ -127,6 +127,10 @@ build-agents: ## Install Python agent dependencies
 run: build ## Run the orchestrator
 	$(GO_BIN)/persatrix-server$(EXE) --config config/
 
+run-ui: ui build-orchestrator ## Build the console bundle + orchestrator and run locally with the web console enabled (RFC 0048 — local UI iteration)
+	@echo "→ Web console enabled at http://localhost:8080/ui"
+	$(GO_BIN)/persatrix-server$(EXE) --config config/ --enable-ui
+
 run-agent: ## Run a Python agent process (AGENT=coder PORT=50051)
 	PYTHONPATH="agents/generated" $(PYTHON) -m persatrix_agents.server --agent $(AGENT) --port $(or $(PORT),50051)
 
@@ -245,6 +249,11 @@ validate: ## Validate all YAML configs against JSON schemas
 	@echo "✓ All configs valid"
 
 # ─── Docker ─────────────────────────────────────────────
+# NOTE(RFC 0048): the orchestrator image builds the web console bundle in a
+# Node stage inside Dockerfile.orchestrator, so docker-build / demo-* embed the
+# real console with NO host JS toolchain and no prior `make ui` — even a bare
+# `docker compose up --build` from a clean clone works. For local (non-Docker)
+# UI iteration use `make run-ui` (or `make build-orchestrator-ui`) instead.
 docker-build: ## Build Docker images
 	docker compose build
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,13 @@ services:
     # store initialize; otherwise initChannels logs "mkdir data:
     # permission denied", channels stay disabled, and chat-as-DM
     # (RFC 0011 PR 4a-ii-β-2) returns 500 'chat not available'.
-    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--grpc-bind", "0.0.0.0", "--port", "9090", "--workflows-dir", "/app/workflows/", "--env", "development", "--channels-db", "/var/lib/persatrix/channels.db"]
+    # NOTE(RFC 0048): --enable-ui serves the embedded operator/tester web
+    # console at /ui (default off). The host publish of :8080 below stays the
+    # one boundary; keep it as-is (do not expose beyond localhost) until the
+    # REST surface is authenticated (RFC 0039). The Svelte bundle is baked into
+    # the binary from internal/ui/assets (run `make ui` before `compose build`
+    # to refresh it; a placeholder ships if the JS toolchain never ran).
+    command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--grpc-bind", "0.0.0.0", "--port", "9090", "--workflows-dir", "/app/workflows/", "--env", "development", "--channels-db", "/var/lib/persatrix/channels.db", "--enable-ui"]
     ports:
       # NOTE(review-PR187, Should-Fix S1): the gRPC LogService is currently
       # unauthenticated (auth deferred to RFC 0009). --grpc-bind 0.0.0.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -45,8 +45,9 @@ services:
     # console at /ui (default off). The host publish of :8080 below stays the
     # one boundary; keep it as-is (do not expose beyond localhost) until the
     # REST surface is authenticated (RFC 0039). The Svelte bundle is baked into
-    # the binary from internal/ui/assets (run `make ui` before `compose build`
-    # to refresh it; a placeholder ships if the JS toolchain never ran).
+    # the binary from internal/ui/assets, built in-image by Dockerfile.orchestrator's
+    # Node stage — `compose build` always embeds the real console with no host JS
+    # toolchain and no prior `make ui`. (`make run-ui` is the local, non-Docker path.)
     command: ["--config", "/app/config/", "--http-bind", "0.0.0.0", "--http-port", "8080", "--grpc-bind", "0.0.0.0", "--port", "9090", "--workflows-dir", "/app/workflows/", "--env", "development", "--channels-db", "/var/lib/persatrix/channels.db", "--enable-ui"]
     ports:
       # NOTE(review-PR187, Should-Fix S1): the gRPC LogService is currently


### PR DESCRIPTION
## Summary

The Docker/demo path served the **committed placeholder**, not the real Svelte console (RFC 0048). Two gaps caused it, both fixed here:

1. The compose orchestrator `command` never set `--enable-ui`, so `/ui` 404'd.
2. `Dockerfile.orchestrator` embedded whatever was in `internal/ui/assets/` at build time — the placeholder on a clean checkout, since the real bundle is gitignored and only `make ui` / the release lane built it.

The release CI lane already ran `make ui`; the Docker and `make demo-*` entry points were the missed paths.

## Changes

- **`docker-compose.yaml`** — add `--enable-ui` to the orchestrator command. The `:8080` host publish stays the single boundary (loopback); do not expose beyond localhost until the REST surface is authenticated (RFC 0039).
- **`Dockerfile.orchestrator`** — now **multi-stage**. A `node:22-alpine` stage runs `npm ci` + `vite build` (the `npm ci` layer caches on the lockfile); the Go stage `rm`s the embed dir and `COPY`s the freshly built bundle from the ui-builder stage before `go build`, so the embedded console is deterministic regardless of host state. `docker compose build` / `make demo-*` / a bare `docker compose up --build` from a clean clone now embed the real console with **zero host JS toolchain**. The committed placeholder still keeps `go build ./...` and the Go-only CI lane green (PR plan D2) — only the image build overrides it.
- **`Makefile`** — add `run-ui` (build bundle + orchestrator, run locally with `--enable-ui`) as the local-iteration counterpart to `build-orchestrator-ui`; register in `.PHONY`; document in the Docker section that demos build the UI in-image. Deliberately **not** adding `ui` as a prerequisite of `demo-*` — that would re-impose a host Node requirement and defeat the self-contained image. Go-only `build`/`run` stay Node-free.

## Verification

- `--no-cache` orchestrator image build with **only the placeholder on the host** still produced a container serving the real SPA at `/ui/` (`<div id="app">` + module script; `/ui/assets/index-*.js` → HTTP 200).
- Full `make demo-offline` stack healthy; `/api/v1/ui/config` reports Chat + Channel Timeline `enabled` and `available`; chat lists all six agents after they register.

## Notes / out of scope

- Observed during testing: recreating the orchestrator container empties the in-memory agent registry and **agents do not re-register** (registration is a one-shot POST at agent startup), so `/api/v1/agents` reads empty until agents are restarted. Not addressed here — flagging as a possible resilience follow-up.