### PR TITLE
feat(v036): RFC 0048 amendment PR A — persona legibility (web console)

### DIFF
--- a/internal/server/agent_handlers.go
+++ b/internal/server/agent_handlers.go
@@ -64,6 +64,12 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "BAD_REQUEST", "name exceeds maximum length of 100 characters", http.StatusBadRequest)
 		return
 	}
+	// RFC 0048 amendment §A — role is a display-only persona cue (like name);
+	// cap it on the same rationale to prevent registry pollution and log bloat.
+	if len(req.Role) > 100 {
+		writeError(w, "BAD_REQUEST", "role exceeds maximum length of 100 characters", http.StatusBadRequest)
+		return
+	}
 	// TODO(v0.2): validate address format (host:port or URI scheme).
 	// Currently any non-empty string up to 253 characters is accepted per RFC 0002 v0.1 scope.
 	if req.Address == "" {
@@ -120,6 +126,7 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 	info := registry.AgentInfo{
 		ID:           req.ID,
 		Name:         req.Name,
+		Role:         req.Role, // RFC 0048 amendment §A — optional persona role, "" when unset
 		Address:      req.Address,
 		Capabilities: req.Capabilities,
 		Status:       registry.StatusHealthy, // reachable until first health check fails
@@ -366,6 +373,7 @@ func agentToResponse(a *registry.AgentInfo) agentResponse {
 	resp := agentResponse{
 		ID:      a.ID,
 		Name:    a.Name,
+		Role:    a.Role, // RFC 0048 amendment §A — persona role; "" when unset
 		Address: a.Address,
 		Status:  agentStatusString(a.Status),
 	}

--- a/internal/server/server_agent_test.go
+++ b/internal/server/server_agent_test.go
@@ -125,6 +125,45 @@ func TestRegisterAgentWithName(t *testing.T) {
 	assert.Equal(t, []string{"code_generation"}, resp.Capabilities)
 }
 
+// RFC 0048 amendment §A — role round-trips through register → response so the
+// console picker can show the persona's role, not just its name.
+func TestRegisterAgentWithRole(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "code-writer", "name": "Code Writer", "role": "Senior Engineer", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "Senior Engineer", resp.Role)
+}
+
+// An omitted role is valid (not every agent declares one) and serializes as an
+// empty string — the client falls back to showing no role, matching name→id.
+func TestRegisterAgentRoleDefaultsEmpty(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "no-role", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Role)
+	assert.Contains(t, rec.Body.String(), `"role":""`)
+}
+
+// Role is display-only and capped like name to prevent registry pollution.
+func TestRegisterAgentRoleTooLong(t *testing.T) {
+	srv, _ := testServer(t)
+	body, _ := json.Marshal(registerAgentRequest{
+		ID:      "long-role",
+		Role:    strings.Repeat("x", 101),
+		Address: "localhost:50051",
+	})
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
 func TestRegisterAgentNilCapabilities(t *testing.T) {
 	srv, _ := testServer(t)
 	body := []byte(`{"id": "test-agent", "address": "localhost:50051"}`)

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -31,6 +31,7 @@ type workflowRunResponse struct {
 type registerAgentRequest struct {
 	ID           string   `json:"id"`
 	Name         string   `json:"name"`
+	Role         string   `json:"role"` // RFC 0048 amendment §A — optional persona role; "" when unset
 	Address      string   `json:"address"`
 	Capabilities []string `json:"capabilities"`
 }
@@ -41,6 +42,7 @@ type registerAgentRequest struct {
 type agentResponse struct {
 	ID           string   `json:"id"`
 	Name         string   `json:"name"`
+	Role         string   `json:"role"` // RFC 0048 amendment §A — from registry.AgentInfo.Role; "" when unset
 	Address      string   `json:"address"`
 	Capabilities []string `json:"capabilities"`
 	Status       string   `json:"status"`

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -75,6 +75,43 @@ body {
   padding: 1.5rem;
 }
 
+/* Persona header (RFC 0048 amendment §A) — gives the conversation a face:
+   name + role + capability chips, all from fields the agent DTO already serves. */
+.persona {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid color-mix(in srgb, currentColor 15%, transparent);
+}
+
+.persona-name {
+  font-weight: 600;
+}
+
+.persona-role {
+  opacity: 0.8;
+  font-size: 0.9rem;
+}
+
+.persona-caps {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin: 0;
+  padding: 0;
+}
+
+.persona-caps li {
+  font-size: 0.75rem;
+  padding: 0.05rem 0.4rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
 /* Chat panel (RFC 0048 Phase 1 PR 4). Still deliberately minimal — enough
    structure to read a conversation and reach the composer, no design system. */
 .transcript {
@@ -227,6 +264,12 @@ body {
 
 .message .sender {
   font-weight: 600;
+}
+
+.message.from-self .sender {
+  /* The operator's own posts, distinguished from agents' (RFC 0048 §D) the same
+     way the chat panel bolds "You:" — a subtle accent, not a loud highlight. */
+  color: light-dark(#1565c0, #82b1ff);
 }
 
 .message .ts {

--- a/web/src/panels/ChannelTimeline.svelte
+++ b/web/src/panels/ChannelTimeline.svelte
@@ -7,6 +7,7 @@
   // the /ui/context-derived userId (RFC §F single identity source), so the panel
   // never prompts for or hard-codes a sender.
   import {
+    listAgents,
     listChannels,
     getChannelHistory,
     publishMessage,
@@ -43,6 +44,13 @@
   let publishContent = $state("");
   let publishing = $state(false);
   let publishError = $state("");
+
+  // agentsById maps sender_id → persona record so the timeline can show
+  // "Ada — Researcher" instead of a raw id (RFC 0048 amendment §A / §D). It is
+  // best-effort decoration: the load is fire-and-forget and a failure leaves the
+  // map empty, so senderLabel falls back to the raw id rather than blocking the
+  // timeline (which is the panel's actual job) on the agent list.
+  let agentsById = $state({});
 
   // seenIds de-dupes the head poll against messages already shown (and against a
   // just-published echo). Not reactive — it's bookkeeping the render reads
@@ -235,6 +243,24 @@
     }
   }
 
+  // Load the agent list once for sender-name decoration. Best-effort and
+  // independent of the channel/poll lifecycle: a failure is swallowed (the
+  // timeline still renders raw ids), so this never gates the panel.
+  $effect(() => {
+    let cancelled = false;
+    listAgents()
+      .then((list) => {
+        if (cancelled) return;
+        agentsById = Object.fromEntries(list.map((agent) => [agent.id, agent]));
+      })
+      .catch(() => {
+        // Decoration only — leave the map empty and fall back to raw ids.
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
+
   $effect(() => {
     loadChannels();
     return () => {
@@ -280,6 +306,22 @@
   // to its id (DMs/threads have no name — channel_types.go).
   function channelLabel(channel) {
     return channel.name ? channel.name : channel.id;
+  }
+
+  // senderLabel turns a raw sender_id into a readable name. The operator's own
+  // posts read as "You" (the human/agent distinction §D asks for); an agent
+  // resolves to "name — role" via the best-effort agent map; anything unknown
+  // falls back to the raw id rather than inventing a label.
+  function senderLabel(senderId) {
+    if (senderId === userId) {
+      return "You";
+    }
+    const agent = agentsById[senderId];
+    if (!agent) {
+      return senderId;
+    }
+    const name = agent.name || agent.id;
+    return agent.role ? `${name} — ${agent.role}` : name;
   }
 
   async function publish() {
@@ -396,8 +438,8 @@
     {:else}
       <ol class="timeline" aria-label="Channel messages">
         {#each messages as message (message.id)}
-          <li class="message">
-            <span class="sender">{message.sender_id}</span>
+          <li class="message" class:from-self={message.sender_id === userId}>
+            <span class="sender">{senderLabel(message.sender_id)}</span>
             <span class="content">{message.content}</span>
             <time class="ts" datetime={message.timestamp}
               >{formatTimestamp(message.timestamp)}</time

--- a/web/src/panels/ChannelTimeline.test.js
+++ b/web/src/panels/ChannelTimeline.test.js
@@ -22,12 +22,14 @@ vi.mock("../lib/api.js", () => ({
       this.code = options?.code;
     }
   },
+  listAgents: vi.fn(),
   listChannels: vi.fn(),
   getChannelHistory: vi.fn(),
   publishMessage: vi.fn(),
 }));
 
 import {
+  listAgents,
   listChannels,
   getChannelHistory,
   publishMessage,
@@ -57,6 +59,9 @@ function historyOf(...messages) {
 }
 
 beforeEach(() => {
+  // Sender-name decoration is best-effort; default it to a resolved empty list
+  // so the timeline renders raw ids unless a test opts into agent fixtures.
+  listAgents.mockResolvedValue([]);
   listChannels.mockResolvedValue({ channels: CHANNELS });
   getChannelHistory.mockResolvedValue(
     historyOf(msg("m2", "second"), msg("m1", "first")),
@@ -91,6 +96,28 @@ describe("Channel timeline panel", () => {
     const items = await screen.findAllByRole("listitem");
     expect(items[0].textContent).toMatch(/second/);
     expect(items[1].textContent).toMatch(/first/);
+  });
+
+  it("maps sender ids to names and marks the operator's own posts as 'You'", async () => {
+    // The agent list decorates senders (RFC 0048 §A/§D): an agent id resolves to
+    // "name — role", the operator's own id reads as "You", and an unknown id
+    // falls back to its raw value.
+    listAgents.mockResolvedValue([
+      { id: "ada", name: "Ada", role: "Researcher", status: "healthy" },
+    ]);
+    getChannelHistory.mockResolvedValue(
+      historyOf(
+        msg("m3", "from the human", "local", "2026-06-02T10:00:02Z"),
+        msg("m2", "from ada", "ada", "2026-06-02T10:00:01Z"),
+        msg("m1", "from a stranger", "ghost", "2026-06-02T10:00:00Z"),
+      ),
+    );
+
+    render(ChannelTimeline, { props: { userId: "local" } });
+
+    expect(await screen.findByText("Ada — Researcher")).toBeTruthy();
+    expect(screen.getByText("You")).toBeTruthy();
+    expect(screen.getByText("ghost")).toBeTruthy();
   });
 
   it("renders a human-readable timestamp but keeps the raw value machine-readable", async () => {

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -227,7 +227,11 @@
         {/if}
         {#if selectedAgentInfo.capabilities && selectedAgentInfo.capabilities.length > 0}
           <ul class="persona-caps" aria-label="Capabilities">
-            {#each selectedAgentInfo.capabilities as capability (capability)}
+            <!-- Unkeyed: capabilities are display-only and the registry doesn't
+                 dedupe them, so a value key would throw each_key_duplicate. The
+                 list is re-derived wholesale per selection, so there's no identity
+                 to preserve across mutations anyway. -->
+            {#each selectedAgentInfo.capabilities as capability}
               <li>{capability}</li>
             {/each}
           </ul>

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -44,6 +44,16 @@
     Boolean(selectedAgent) && message.trim().length > 0 && !sending,
   );
 
+  // selectedAgentInfo is the full persona record behind the picker selection, so
+  // the panel can render a persona header (name — role, capabilities) above the
+  // transcript rather than leaving the persona a bare dropdown entry. The DTO
+  // already carries role (RFC 0048 amendment §A) and capabilities/address
+  // (always served) — "faceless" was the client throwing those away, not the API
+  // withholding them.
+  const selectedAgentInfo = $derived(
+    agents.find((agent) => agent.id === selectedAgent) ?? null,
+  );
+
   // loadToken disambiguates concurrent/superseded loads: each call stamps a
   // token and only the latest may write state. This both guards against a
   // resolve-after-unmount (the effect cleanup bumps the token) and makes Retry
@@ -97,9 +107,13 @@
   // operator sees that before spending a send, not after.
   function agentLabel(agent) {
     const name = agent.name ? agent.name : agent.id;
+    // Fold the role into the option so the picker reads as a cast of personas
+    // ("Ada — Researcher") rather than a list of bare names (RFC 0048 §A). Role
+    // is optional; omit the separator when unset.
+    const named = agent.role ? `${name} — ${agent.role}` : name;
     return agent.status && agent.status !== "healthy"
-      ? `${name} (${agent.status})`
-      : name;
+      ? `${named} (${agent.status})`
+      : named;
   }
 
   async function send() {
@@ -200,6 +214,27 @@
   {:else if agents.length === 0}
     <p class="empty">No personas are registered yet.</p>
   {:else}
+    {#if selectedAgentInfo}
+      <!-- Persona header: gives the conversation a face. Name + role identify
+           the persona; the capability chips say what it's for — all from fields
+           the agent DTO already carries (RFC 0048 amendment §A). -->
+      <header class="persona">
+        <span class="persona-name"
+          >{selectedAgentInfo.name || selectedAgentInfo.id}</span
+        >
+        {#if selectedAgentInfo.role}
+          <span class="persona-role">{selectedAgentInfo.role}</span>
+        {/if}
+        {#if selectedAgentInfo.capabilities && selectedAgentInfo.capabilities.length > 0}
+          <ul class="persona-caps" aria-label="Capabilities">
+            {#each selectedAgentInfo.capabilities as capability (capability)}
+              <li>{capability}</li>
+            {/each}
+          </ul>
+        {/if}
+      </header>
+    {/if}
+
     <ol class="transcript" aria-label="Conversation">
       {#each transcript as turn (turn.id)}
         <li class="turn">

--- a/web/src/panels/Chat.test.js
+++ b/web/src/panels/Chat.test.js
@@ -90,21 +90,14 @@ describe("Chat panel", () => {
   });
 
   it("renders duplicate capabilities without crashing the persona header", async () => {
-    // The registry doesn't dedupe capabilities (validateCapabilities checks names
-    // but stores/serves the slice verbatim), so ["search", "search"] is a reachable
-    // DTO. The chip list must render it as display data, not key on the value — a
-    // keyed each would throw a duplicate-key error and crash the whole panel.
+    // The registry doesn't dedupe capabilities, so ["search","search"] is a
+    // reachable DTO. A value-keyed chip list would throw each_key_duplicate and
+    // crash the panel; both chips must render and the panel must mount.
     listAgents.mockResolvedValue([
-      {
-        id: "ada",
-        name: "Ada",
-        capabilities: ["search", "search"],
-        status: "healthy",
-      },
+      { id: "ada", name: "Ada", capabilities: ["search", "search"], status: "healthy" },
     ]);
     render(Chat, { props: { userId: "local" } });
 
-    // Both chips render; the key fact is that the panel mounts at all.
     expect(await screen.findAllByText("search")).toHaveLength(2);
   });
 

--- a/web/src/panels/Chat.test.js
+++ b/web/src/panels/Chat.test.js
@@ -89,6 +89,25 @@ describe("Chat panel", () => {
     ).toBeTruthy();
   });
 
+  it("renders duplicate capabilities without crashing the persona header", async () => {
+    // The registry doesn't dedupe capabilities (validateCapabilities checks names
+    // but stores/serves the slice verbatim), so ["search", "search"] is a reachable
+    // DTO. The chip list must render it as display data, not key on the value — a
+    // keyed each would throw a duplicate-key error and crash the whole panel.
+    listAgents.mockResolvedValue([
+      {
+        id: "ada",
+        name: "Ada",
+        capabilities: ["search", "search"],
+        status: "healthy",
+      },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    // Both chips render; the key fact is that the panel mounts at all.
+    expect(await screen.findAllByText("search")).toHaveLength(2);
+  });
+
   it("sends the message for the selected persona as the context-derived user", async () => {
     render(Chat, { props: { userId: "local" } });
 

--- a/web/src/panels/Chat.test.js
+++ b/web/src/panels/Chat.test.js
@@ -65,6 +65,30 @@ describe("Chat panel", () => {
     expect(listAgents).toHaveBeenCalledOnce();
   });
 
+  it("shows a persona header with role and capabilities for the selected persona", async () => {
+    listAgents.mockResolvedValue([
+      {
+        id: "ada",
+        name: "Ada",
+        role: "Researcher",
+        capabilities: ["search", "summarize"],
+        status: "healthy",
+      },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    // The header gives the conversation a face: name, role, and capability chips
+    // — all from fields the agent DTO already serves (RFC 0048 amendment §A).
+    await screen.findByText("Ada");
+    expect(screen.getByText("Researcher")).toBeTruthy();
+    expect(screen.getByText("search")).toBeTruthy();
+    expect(screen.getByText("summarize")).toBeTruthy();
+    // The picker option folds the role in too.
+    expect(
+      screen.getByRole("option", { name: "Ada — Researcher" }),
+    ).toBeTruthy();
+  });
+
   it("sends the message for the selected persona as the context-derived user", async () => {
     render(Chat, { props: { userId: "local" } });
 


### PR DESCRIPTION
## What

PR A of the [RFC 0048 Slice 1 UX amendment](docs/rfcs/0048-amendment-slice1-ux.md) (§A). Makes the persona a *face* instead of a bare id — directly serving [RFC 0048 Goal 4](docs/rfcs/0048-operator-tester-web-console.md#goals) ("make the differentiator visible — persistence and **personality**").

The use-pass found the picker shows `name (status)` only, even though the agent DTO already carries `capabilities` and `address` (silently dropped) and `registry.AgentInfo.Role` exists but the DTO discarded it. "Faceless" was the client throwing away cues the API already serves, plus one missing field.

## Backend (additive, backward-compatible)

- `agentResponse` gains **`role`**, populated from `registry.AgentInfo.Role` in `agentToResponse`.
- `registerAgentRequest` accepts an optional `role` so the field round-trips through the REST register path (omitted → `""`).
- `role` capped at 100 chars, same registry-pollution rationale as `name`.
- `model` deferred (amendment §A / Decision #3).

## Client

- **Chat:** persona header (`name — role` + capability chips) above the transcript; role folded into the picker option label.
- **Timeline:** `sender_id → "name — role"` via a best-effort agent-list fetch; the operator's own posts read as **"You"** (human/agent distinction, §D). Decoration only — a failed agent fetch falls back to raw ids and never blocks the timeline.

## Tests

- Go: role round-trip, default-empty serialization (`"role":""`), over-length rejection.
- Web: Chat persona header (role + capabilities + picker label); timeline sender mapping + self/agent distinction.
- Go server/registry suites + **91 web tests** green; `npm run build` clean.

Part of the A–F decomposition in the amendment. Independent of B–F; pure-additive API.