### PR TITLE
feat(v036): RFC 0048 amendment PR D — tester identity override (web console)

### DIFF
--- a/web/src/App.identity.test.js
+++ b/web/src/App.identity.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  fireEvent,
+} from "@testing-library/svelte";
+import App from "./App.svelte";
+
+// The §E tester identity-override carve-out (RFC 0048 amendment): in LOCAL
+// (unauthenticated) mode the shell offers an "acting as" control — distinct from
+// the /ui/context principal — so a tester can switch the effective user and
+// watch per-user persistence follow the identity. Split out of App.test.js to
+// keep each spec under the review-size cap; the boot/routing smoke stays there.
+// The shell mounts the real Chat panel, whose mount effects call the client, so
+// the full api surface is stubbed (mirrors App.test.js).
+vi.mock("./lib/api.js", () => ({
+  ApiError: class ApiError extends Error {},
+  loadBootstrap: vi.fn(),
+  listAgents: vi.fn(() => Promise.resolve([])),
+  sendChat: vi.fn(),
+  getChatHistory: vi.fn(() => Promise.resolve({ messages: [] })),
+  listSessions: vi.fn(() => Promise.resolve({ sessions: [] })),
+  createSession: vi.fn(),
+  listChannels: vi.fn(() => Promise.resolve({ channels: [] })),
+  getChannelHistory: vi.fn(() => Promise.resolve({ messages: [] })),
+  publishMessage: vi.fn(),
+}));
+
+import { loadBootstrap } from "./lib/api.js";
+
+beforeEach(() => {
+  window.location.hash = "";
+});
+
+afterEach(() => {
+  // Unmount between tests. Vitest runs without `globals: true`, so
+  // @testing-library/svelte cannot auto-register its afterEach(cleanup) — left
+  // implicit, each render() leaks into jsdom and queries resolve against a
+  // prior test's DOM, making the suite order-dependent.
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("App shell — §E tester identity override", () => {
+  it("surfaces the real principal verbatim and offers the §E testing override in local mode", async () => {
+    loadBootstrap.mockResolvedValue({
+      config: { panels: { chat: { enabled: true, available: true } } },
+      context: { principal: "local", tenant: "local", authenticated: false },
+    });
+
+    const { container } = render(App);
+
+    // The topbar surfaces the principal coming from /ui/context (titled so the
+    // source is unambiguous), shown verbatim and never replaced by the override.
+    await waitFor(() => {
+      const principal = screen.getByTitle("Identity from /api/v1/ui/context");
+      expect(principal.textContent.trim()).toBe("local");
+    });
+    // RFC §F rule 1: identity comes from /ui/context, so there is still NO
+    // user_id field — the panels never prompt for the identity itself.
+    expect(container.querySelector('input[name="user_id"]')).toBeNull();
+    // §E carve-out: in LOCAL (unauthenticated) mode the shell offers a clearly
+    // distinct "acting as" testing override, defaulting to the principal, so a
+    // tester can demonstrate per-user persistence. It is a separate control, not
+    // the identity source.
+    const override = container.querySelector('input[name="acting_as"]');
+    expect(override).not.toBeNull();
+    expect(override.value).toBe("local");
+  });
+
+  it("hides the §E identity override once the principal is authenticated", async () => {
+    // The carve-out is local-only: once /ui/context reports an authenticated
+    // principal (RFC 0039), the override disappears so a real identity can never
+    // be masked from the browser.
+    loadBootstrap.mockResolvedValue({
+      config: { panels: { chat: { enabled: true, available: true } } },
+      context: { principal: "alice@example.com", tenant: "t", authenticated: true },
+    });
+
+    const { container } = render(App);
+
+    await waitFor(() => {
+      expect(
+        screen.getByTitle("Identity from /api/v1/ui/context").textContent.trim(),
+      ).toBe("alice@example.com");
+    });
+    expect(container.querySelector('input[name="acting_as"]')).toBeNull();
+  });
+
+  it("acts as the override identity so per-user persistence is demonstrable", async () => {
+    // Editing "acting as" changes the effective user threaded to the panels —
+    // the mechanism that lets a tester switch users and watch the persona's
+    // memory follow the identity (§E).
+    loadBootstrap.mockResolvedValue({
+      config: { panels: { chat: { enabled: true, available: true } } },
+      context: { principal: "local", tenant: "local", authenticated: false },
+    });
+
+    const { container } = render(App);
+
+    const override = await waitFor(() => {
+      const el = container.querySelector('input[name="acting_as"]');
+      expect(el).not.toBeNull();
+      return el;
+    });
+    // The chat panel echoes the effective identity it acts as; it starts at the
+    // principal, then follows the override.
+    await waitFor(() =>
+      expect(screen.getAllByText("local").length).toBeGreaterThan(0),
+    );
+    await fireEvent.input(override, { target: { value: "bob" } });
+    await waitFor(() => {
+      // The panel's "Acting as <code>bob</code>" reflects the override.
+      const codes = [...container.querySelectorAll("code")].map((c) =>
+        c.textContent.trim(),
+      );
+      expect(codes).toContain("bob");
+    });
+  });
+});

--- a/web/src/App.identity.test.js
+++ b/web/src/App.identity.test.js
@@ -68,6 +68,10 @@ describe("App shell — §E tester identity override", () => {
     const override = container.querySelector('input[name="acting_as"]');
     expect(override).not.toBeNull();
     expect(override.value).toBe("local");
+    // The placeholder echoes the principal so that, once a tester clears the
+    // box, the field visibly communicates "empty ⇒ acting as the principal"
+    // rather than reading as no identity at all.
+    expect(override.getAttribute("placeholder")).toBe("local");
   });
 
   it("hides the §E identity override once the principal is authenticated", async () => {
@@ -89,10 +93,15 @@ describe("App shell — §E tester identity override", () => {
     expect(container.querySelector('input[name="acting_as"]')).toBeNull();
   });
 
-  it("acts as the override identity so per-user persistence is demonstrable", async () => {
+  it("commits the override on change (not per-keystroke) so the effective identity follows it", async () => {
     // Editing "acting as" changes the effective user threaded to the panels —
     // the mechanism that lets a tester switch users and watch the persona's
-    // memory follow the identity (§E).
+    // memory follow the identity (§E). The commit is deferred to `change`
+    // (blur/Enter), not every keystroke: persistence is keyed on (user, agent)
+    // and the panels reseed history on an identity change, so committing
+    // per-keystroke would blank+refetch the transcript for each intermediate
+    // value ("b", "bo", "bob"). The contract here is the observable side of
+    // that: typing alone must NOT move the effective identity; the change does.
     loadBootstrap.mockResolvedValue({
       config: { panels: { chat: { enabled: true, available: true } } },
       context: { principal: "local", tenant: "local", authenticated: false },
@@ -105,18 +114,31 @@ describe("App shell — §E tester identity override", () => {
       expect(el).not.toBeNull();
       return el;
     });
+
+    const effectiveIds = () =>
+      [...container.querySelectorAll("code")].map((c) => c.textContent.trim());
+
     // The chat panel echoes the effective identity it acts as; it starts at the
-    // principal, then follows the override.
-    await waitFor(() =>
-      expect(screen.getAllByText("local").length).toBeGreaterThan(0),
-    );
+    // principal.
+    await waitFor(() => expect(effectiveIds()).toContain("local"));
+
+    // Typing into the box edits the draft but must not yet move the effective
+    // identity — no premature reseed.
     await fireEvent.input(override, { target: { value: "bob" } });
+    expect(effectiveIds()).not.toContain("bob");
+    expect(effectiveIds()).toContain("local");
+
+    // Committing (blur/Enter ⇒ `change`) threads the new identity to the panels.
+    await fireEvent.change(override, { target: { value: "bob" } });
+    await waitFor(() => expect(effectiveIds()).toContain("bob"));
+
+    // Clearing the override and committing falls back to the real principal —
+    // the empty box means "act as the principal", never "no identity".
+    await fireEvent.input(override, { target: { value: "" } });
+    await fireEvent.change(override, { target: { value: "" } });
     await waitFor(() => {
-      // The panel's "Acting as <code>bob</code>" reflects the override.
-      const codes = [...container.querySelectorAll("code")].map((c) =>
-        c.textContent.trim(),
-      );
-      expect(codes).toContain("bob");
+      expect(effectiveIds()).toContain("local");
+      expect(effectiveIds()).not.toContain("bob");
     });
   });
 });

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -19,8 +19,26 @@
   // single boot-error state rather than a half-configured console.
   let status = $state("loading");
   let panels = $state([]);
-  let userId = $state(null);
   let errorMessage = $state("");
+  // Identity (RFC 0048 §F + amendment §E). `principal` is the real /ui/context
+  // identity, shown verbatim and never overwritten. `authenticated` gates the
+  // §E carve-out. `actingAs` is the local tester override — it DEFAULTS to the
+  // principal and is layered on top of it (a single identity source, offset by
+  // an operator-visible value), so a tester can demonstrate per-user
+  // persistence ("greet me; now not-recognise a different user") without
+  // leaving the browser. The effective `userId` the panels act as is the
+  // override in local mode and the real principal once authenticated — at which
+  // point the override control disappears and can never mask a real principal.
+  let principal = $state(null);
+  let authenticated = $state(false);
+  let actingAs = $state("");
+  const userId = $derived(
+    principal == null
+      ? null
+      : authenticated
+        ? principal
+        : actingAs.trim() || principal,
+  );
   // Build version from /ui/config (build.version) — surfaced in the topbar so an
   // operator can tell at a glance which orchestrator build they're driving (RFC
   // 0048 amendment §D). Empty when the payload omits it; the topbar then shows
@@ -72,7 +90,9 @@
             "The console could not determine an identity (no principal in /ui/context).";
           return;
         }
-        userId = id;
+        principal = id;
+        authenticated = context?.authenticated === true;
+        actingAs = id; // the override defaults to the real principal
         version = config?.build?.version ?? "";
         panels = selectPanels(config);
         activeName = hashPanelName();
@@ -157,9 +177,27 @@
     Persatrix console
     {#if version}<span class="version" title="Orchestrator build">v{version}</span>{/if}
   </span>
-  {#if userId}
-    <span class="principal" title="Identity from /api/v1/ui/context">
-      {userId}
+  {#if principal}
+    <span class="identity">
+      <!-- The real /ui/context principal, shown verbatim — never the override.
+           Titled so its source is unambiguous (RFC 0048 §F rule 1). -->
+      <span class="principal" title="Identity from /api/v1/ui/context">
+        {principal}
+      </span>
+      {#if !authenticated}
+        <!-- §E tester identity override: a clearly-labelled LOCAL TESTING
+             control, not identity. Defaults to the principal; lets a tester act
+             as another user to make per-user persistence visible. Absent once
+             authenticated (RFC 0039) so a real principal can never be masked
+             from the browser. -->
+        <label
+          class="acting-as"
+          title="Local testing only — defaults to the principal and is ignored once authenticated"
+        >
+          acting as
+          <input name="acting_as" bind:value={actingAs} autocomplete="off" />
+        </label>
+      {/if}
     </span>
   {/if}
 </header>

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -187,7 +187,11 @@
     {#if version}<span class="version" title="Orchestrator build">v{version}</span>{/if}
   </span>
   {#if principal}
-    <span class="identity">
+    <!-- `identity-block` (not `identity`): the bare `.identity` class is the
+         Chat panel's identity line, a global rule that would otherwise also
+         match this wrapper and bleed Chat's styling into the topbar. This
+         wrapper is a *group* (principal + override), so it gets its own name. -->
+    <span class="identity-block">
       <!-- The real /ui/context principal, shown verbatim — never the override.
            Titled so its source is unambiguous (RFC 0048 §F rule 1). -->
       <span class="principal" title="Identity from /api/v1/ui/context">

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -31,7 +31,15 @@
   // point the override control disappears and can never mask a real principal.
   let principal = $state(null);
   let authenticated = $state(false);
+  // `actingAs` is the *committed* override that drives the effective identity;
+  // `actingAsDraft` is what's in the box. The draft commits to `actingAs` only
+  // on `change` (blur/Enter), never per-keystroke — persistence is keyed on
+  // (user, agent) and the panels reseed history when the identity changes, so a
+  // per-keystroke commit would blank+refetch the transcript for every
+  // intermediate value ("b", "bo", "bob"). Deferring the commit reseeds once,
+  // on the value the tester actually meant.
   let actingAs = $state("");
+  let actingAsDraft = $state("");
   const userId = $derived(
     principal == null
       ? null
@@ -93,6 +101,7 @@
         principal = id;
         authenticated = context?.authenticated === true;
         actingAs = id; // the override defaults to the real principal
+        actingAsDraft = id; // and the box shows that default
         version = config?.build?.version ?? "";
         panels = selectPanels(config);
         activeName = hashPanelName();
@@ -195,7 +204,17 @@
           title="Local testing only — defaults to the principal and is ignored once authenticated"
         >
           acting as
-          <input name="acting_as" bind:value={actingAs} autocomplete="off" />
+          <!-- Commit on `change` (blur/Enter), not per-keystroke, so the panels
+               reseed once on the intended value. The placeholder echoes the
+               principal so a cleared box reads as "acting as the principal"
+               (the userId derivation falls back to it) rather than no identity. -->
+          <input
+            name="acting_as"
+            bind:value={actingAsDraft}
+            onchange={() => (actingAs = actingAsDraft)}
+            placeholder={principal}
+            autocomplete="off"
+          />
         </label>
       {/if}
     </span>

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -70,26 +70,6 @@ describe("App shell boot", () => {
     expect(screen.queryByRole("tab", { name: /cost/i })).toBeNull();
   });
 
-  it("surfaces the context principal and never shows a free-text user field", async () => {
-    loadBootstrap.mockResolvedValue({
-      config: { panels: { chat: { enabled: true, available: true } } },
-      context: { principal: "local", tenant: "local", authenticated: false },
-    });
-
-    const { container } = render(App);
-
-    // The topbar surfaces the principal coming from /ui/context (titled so the
-    // source is unambiguous and to disambiguate it from panels that also echo
-    // the derived user id).
-    await waitFor(() => {
-      const principal = screen.getByTitle("Identity from /api/v1/ui/context");
-      expect(principal.textContent.trim()).toBe("local");
-    });
-    // RFC §F rule 1: identity comes from /ui/context, so the shell offers no
-    // user-id input the operator could type into.
-    expect(container.querySelector('input[name="user_id"]')).toBeNull();
-  });
-
   it("surfaces the orchestrator build version from config.build.version", async () => {
     // The topbar shows which orchestrator build the operator is driving (RFC 0048
     // amendment §D), read from /ui/config's build.version. Titled so the chip's

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -41,6 +41,32 @@ body {
   opacity: 0.6;
 }
 
+/* Identity block: the real principal plus the §E local-testing override. */
+.topbar .identity {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  opacity: 1;
+  font-size: inherit;
+}
+
+/* The "acting as" override is deliberately understated — a testing control, not
+   a prominent identity field. Monospace input to match the principal display. */
+.acting-as {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.acting-as input {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  padding: 0.1rem 0.3rem;
+  width: 8rem;
+}
+
 .tabs {
   display: flex;
   gap: 0.25rem;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -41,8 +41,10 @@ body {
   opacity: 0.6;
 }
 
-/* Identity block: the real principal plus the §E local-testing override. */
-.topbar .identity {
+/* Identity block: the real principal plus the §E local-testing override.
+   Named distinctly from the Chat panel's global `.identity` rule so that
+   single-class rule can't cascade into this topbar group. */
+.topbar .identity-block {
   display: flex;
   align-items: center;
   gap: 0.6rem;

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -149,6 +149,12 @@
   // so a slow load can't write into a persona the operator already switched off.
   $effect(() => {
     const agent = selectedAgent;
+    // Track userId too: the §E "acting as" override changes the effective
+    // identity, and persistence is keyed on (user, agent) — so switching the
+    // acting-as user must reseed the transcript with THAT user's conversation
+    // (the whole point of the override — different user, different/empty
+    // history). Reading it here makes the effect re-run on an identity change.
+    void userId;
     if (!agent) return;
     loadHistory(agent);
     return () => {


### PR DESCRIPTION
## What

PR D of the [RFC 0048 Slice 1 UX amendment](docs/rfcs/0048-amendment-slice1-ux.md) (§E) — the one decision that bends a forward-compat rule (Decision #5, signed off in the amendment). **No API change.**

Persistence is keyed on `(user_id, agent_id)`, but the console froze `user_id` to the `/ui/context` principal `local`, so the headline demo — *"greet me by name; now open as a different user and watch it not know you"* — was **impossible from the browser**. PR D makes per-user persistence demonstrable.

> Stacked on [PR C](https://github.com/mkhomutov/Persatrix/pull/508). Review/merge A → B → C → D in order.

## The §E carve-out (and why it's safe)

A clearly-labelled local **"acting as"** override:

- **App-level** so both panels share one effective identity.
- **Defaults to** the `/ui/context` principal and is *layered on top of it* — a single identity *source*, offset by an operator-visible value. The real principal is still shown **verbatim** and never replaced.
- **Inert/hidden once `authenticated: true`** (RFC 0039) — a real principal can never be masked from the browser. This is what keeps §E a documented local carve-out to [§F rule 1](docs/rfcs/0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility), not a hole.
- Chat **reseeds the transcript when the effective identity changes**, so switching the acting-as user shows *that* user's conversation (different user → different/empty history) — persistence made visible.

## Tests

- The §F-rule-1 test updated to reflect the carve-out honestly: still **no `user_id` field** (panels never prompt for identity), but a **distinct `acting_as` testing control** defaulting to the principal.
- New: override **hidden when authenticated**; editing the override **changes the effective identity** threaded to the panels.
- **99 web tests** green; `npm run build` clean.

Implements Decision #5. Part of the A–F decomposition.