### PR TITLE
fix(v036): web console — disable chat for task agents (RFC 0048)

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -71,11 +71,9 @@ class BaseAgent(ABC):
         For task agents this is a :class:`MemoryStore` opened by
         :meth:`initialize_memory` when ``memory.enabled`` is set in
         ``config/agents.yaml`` (deny-by-default; RFC 0008 PR plan PR 2).
-        Persona-runtime subclasses override this property to expose a
-        ``MemoryNamespace`` over the three persona-memory tiers.
-
-        Read-only — internal code mutates ``self._memory``; tests that
-        need to inject a mock should do the same.
+        Persona-runtime subclasses override it to expose a ``MemoryNamespace``
+        over the three persona-memory tiers. Read-only — internal code mutates
+        ``self._memory``, and tests that inject a mock should do the same.
         """
         return self._memory
 
@@ -85,11 +83,10 @@ class BaseAgent(ABC):
 
     @abstractmethod
     async def handle(self, task: TaskInput) -> TaskOutput:
-        """
-        Process a task and return a result.
+        """Process a task and return a result.
 
-        This is the primary interface for v0.1 task agents and
-        backward-compatible entry point for persona agents.
+        The primary interface for v0.1 task agents and the backward-compatible
+        entry point for persona agents.
         """
         ...
 
@@ -130,6 +127,15 @@ class BaseAgent(ABC):
         result: str = self.config.get("role", "")
         return result
 
+    @property
+    def agent_type(self) -> str:
+        """Agent kind from config (``task``|``persona``|…), ``""`` when unset; sent
+        to the orchestrator at registration so the console can disable chat for
+        task agents (extends the RFC 0048 §A agent DTO). Display metadata only.
+        """
+        result: str = self.config.get("type", "")
+        return result
+
     async def health_check(self) -> bool:
         """Returns True if the agent is healthy and ready to accept tasks."""
         return True
@@ -143,10 +149,9 @@ class BaseAgent(ABC):
     async def initialize_memory(
         self, *, shared_pools: SharedPoolRegistry | None = None,
     ) -> None:
-        """Create and open the agent's :class:`MemoryStore` if enabled.
-
-        No-op when ``memory.enabled`` is false.  Idempotent.
-        ``shared_pools`` (RFC 0008 PR 4) wires named cross-agent pools.
+        """Create and open the agent's :class:`MemoryStore` if enabled (no-op when
+        ``memory.enabled`` is false; idempotent). ``shared_pools`` (RFC 0008 PR 4)
+        wires named cross-agent pools.
         """
         if self.memory is not None:
             return
@@ -167,15 +172,13 @@ class BaseAgent(ABC):
         await store.initialize()
         self._memory = store
         logger.info(
-            "Initialised MemoryStore for task agent %s (db=%s)",
-            self.agent_id, db_path,
+            "Initialised MemoryStore for task agent %s (db=%s)", self.agent_id, db_path
         )
 
     async def close_memory(self) -> None:
         """Close the agent's :class:`MemoryStore` if it was opened.
 
-        Persona-runtime subclasses override this to close their own
-        per-tier memory state.
+        Persona-runtime subclasses override this to close their per-tier state.
         """
         if not isinstance(self.memory, MemoryStore):
             return
@@ -189,16 +192,15 @@ class BaseAgent(ABC):
     def _build_tool_definitions(self) -> list[dict[str, Any]]:
         """Build normalized tool definitions from the tool registry.
 
-        S-12: Filters to only tools listed in agent's ``tools`` config.
-        An empty list means no tools are exposed (e.g. planner agent).
+        S-12: filters to only tools in the agent's ``tools`` config; an empty
+        list exposes no tools (e.g. planner agent).
         """
-        # F-04: early return avoids iterating the full registry when no
-        # tools are configured for this agent.
+        # F-04: early return avoids iterating the full registry when no tools
+        # are configured for this agent.
         allowed = self.config.get("tools", [])
         if not allowed:
             return []
-        # N-04: convert to set for O(1) membership checks (matters when
-        # the tool registry grows beyond the v0.1 built-in set of 4).
+        # N-04: set for O(1) membership checks as the tool registry grows.
         allowed_set = set(allowed)
         return [
             {
@@ -251,11 +253,9 @@ class BaseAgent(ABC):
                     )
                 )
             except PermissionError as exc:
-                # Defense-in-depth: normally unreachable because the @tool
-                # wrapper catches all exceptions.  Retained for MCP/custom
-                # tools that may bypass the decorator.
-                # SF-06: log full details but return generic message to the LLM
-                # (consistent with S-11 pattern for _run_llm_loop exceptions).
+                # Defense-in-depth: normally unreachable (the @tool wrapper catches
+                # all exceptions), retained for MCP/custom tools that bypass the
+                # decorator. SF-06: log full details, return a generic LLM message.
                 logger.warning("Permission denied in tool %s: %s", call.name, exc)
                 results.append(
                     LLMToolResult(

--- a/agents/server.py
+++ b/agents/server.py
@@ -230,7 +230,7 @@ class AgentServer:
     async def _self_register(self) -> None:
         """Register all hosted agents with the orchestrator (best-effort).
 
-        POST /api/v1/agents/register with id, name, type, address, capabilities.
+        POST /api/v1/agents/register with id, name, type, role, address, capabilities.
         Status is NOT sent — the orchestrator sets ``healthy`` on registration
         (review-fix P1).
         """
@@ -246,6 +246,12 @@ class AgentServer:
                 # Omitted by older agents; the orchestrator stores "" and the
                 # console treats that as chattable, so this is purely additive.
                 "type": agent.agent_type,
+                # RFC 0048 amendment §A DTO — the persona role so the web console
+                # can render its persona header (name — role). The orchestrator
+                # already accepts and stores role; without sending it here the
+                # field stays "" in the Docker/web deployment. Unset → "", so
+                # this is purely additive.
+                "role": agent.role,
                 "address": address,
                 "capabilities": agent.capabilities,
             }

--- a/agents/server.py
+++ b/agents/server.py
@@ -230,7 +230,7 @@ class AgentServer:
     async def _self_register(self) -> None:
         """Register all hosted agents with the orchestrator (best-effort).
 
-        POST /api/v1/agents/register with id, address, capabilities.
+        POST /api/v1/agents/register with id, name, type, address, capabilities.
         Status is NOT sent — the orchestrator sets ``healthy`` on registration
         (review-fix P1).
         """
@@ -241,6 +241,11 @@ class AgentServer:
             payload = {
                 "id": agent_id,
                 "name": agent.name,
+                # RFC 0048 amendment §A DTO — the agent kind ("task"/"persona") so the
+                # web console can disable chat for non-conversational task agents.
+                # Omitted by older agents; the orchestrator stores "" and the
+                # console treats that as chattable, so this is purely additive.
+                "type": agent.agent_type,
                 "address": address,
                 "capabilities": agent.capabilities,
             }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -18,9 +18,15 @@ var (
 
 // AgentInfo holds metadata about a registered agent.
 type AgentInfo struct {
-	ID           string
-	Name         string
-	Role         string
+	ID   string
+	Name string
+	Role string
+	// Type is the agent kind from config/agents.yaml (`task` | `persona` | …),
+	// "" when the registrant predates the field. It extends the RFC 0048
+	// amendment §A agent DTO and is display/affordance metadata only — routing
+	// and chat dispatch never read it. The web console uses it to disable chat
+	// for task agents, which execute workflow steps and do not hold a conversation.
+	Type         string
 	Capabilities []string
 	Address      string // gRPC address (host:port)
 	NodeID       string // empty for local deployment
@@ -91,6 +97,7 @@ func (r *InMemoryRegistry) Register(_ context.Context, agent AgentInfo) error {
 		ID:             agent.ID,
 		Name:           agent.Name,
 		Role:           agent.Role,
+		Type:           agent.Type,
 		Address:        agent.Address,
 		NodeID:         agent.NodeID,
 		Status:         agent.Status,
@@ -190,6 +197,7 @@ func deepCopyAgent(agent *AgentInfo) *AgentInfo {
 		ID:             agent.ID,
 		Name:           agent.Name,
 		Role:           agent.Role,
+		Type:           agent.Type,
 		Address:        agent.Address,
 		NodeID:         agent.NodeID,
 		Status:         agent.Status,

--- a/internal/server/agent_handlers.go
+++ b/internal/server/agent_handlers.go
@@ -70,6 +70,15 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		writeError(w, "BAD_REQUEST", "role exceeds maximum length of 100 characters", http.StatusBadRequest)
 		return
 	}
+	// RFC 0048 amendment §A DTO — type is a short agent-kind token ("task"/"persona"/…)
+	// used as display/affordance metadata only. Cap it tightly (a token, not prose)
+	// on the same registry-pollution rationale. An unknown or empty value is not
+	// rejected: the console treats anything other than "task" as chattable, so a
+	// new kind degrades safely without a server change.
+	if len(req.Type) > 32 {
+		writeError(w, "BAD_REQUEST", "type exceeds maximum length of 32 characters", http.StatusBadRequest)
+		return
+	}
 	// TODO(v0.2): validate address format (host:port or URI scheme).
 	// Currently any non-empty string up to 253 characters is accepted per RFC 0002 v0.1 scope.
 	if req.Address == "" {
@@ -127,6 +136,7 @@ func (s *Server) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		ID:           req.ID,
 		Name:         req.Name,
 		Role:         req.Role, // RFC 0048 amendment §A — optional persona role, "" when unset
+		Type:         req.Type, // RFC 0048 amendment §A DTO — optional agent kind, "" when unset
 		Address:      req.Address,
 		Capabilities: req.Capabilities,
 		Status:       registry.StatusHealthy, // reachable until first health check fails
@@ -374,6 +384,7 @@ func agentToResponse(a *registry.AgentInfo) agentResponse {
 		ID:      a.ID,
 		Name:    a.Name,
 		Role:    a.Role, // RFC 0048 amendment §A — persona role; "" when unset
+		Type:    a.Type, // RFC 0048 amendment §A DTO — agent kind; "" when unset
 		Address: a.Address,
 		Status:  agentStatusString(a.Status),
 	}

--- a/internal/server/server_agent_type_test.go
+++ b/internal/server/server_agent_type_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RFC 0048 amendment §A DTO — the agent `type` ("task"/"persona") round-trips through
+// register → response so the web console can tell a conversational persona from a
+// workflow task agent and disable chat for the latter. These mirror the §A `role`
+// handler tests; kept in a separate file because server_agent_test.go sits at the
+// 500-line cap.
+
+func TestRegisterAgentWithType(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "planner", "name": "Planner", "type": "task", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "task", resp.Type)
+}
+
+// An omitted type is valid (an agent predating the field) and serializes as an
+// empty string — the console treats "" as chattable, so nothing is disabled.
+func TestRegisterAgentTypeDefaultsEmpty(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "no-type", "address": "localhost:50051"}`)
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	var resp agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Type)
+	assert.Contains(t, rec.Body.String(), `"type":""`)
+}
+
+// Type is a short kind token, capped tightly to prevent registry pollution.
+func TestRegisterAgentTypeTooLong(t *testing.T) {
+	srv, _ := testServer(t)
+	body, _ := json.Marshal(registerAgentRequest{
+		ID:      "long-type",
+		Type:    strings.Repeat("x", 33),
+		Address: "localhost:50051",
+	})
+	rec := doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// List surfaces the stored type so the picker can filter — a registered task
+// agent comes back tagged "task".
+func TestListAgentsCarriesType(t *testing.T) {
+	srv, _ := testServer(t)
+	body := []byte(`{"id": "planner", "type": "task", "address": "localhost:50051"}`)
+	require.Equal(t, http.StatusCreated,
+		doRequest(srv.Handler(), http.MethodPost, "/api/v1/agents/register", body).Code)
+
+	rec := doRequest(srv.Handler(), http.MethodGet, "/api/v1/agents", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var list []agentResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &list))
+	require.Len(t, list, 1)
+	assert.Equal(t, "task", list[0].Type)
+}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -32,6 +32,7 @@ type registerAgentRequest struct {
 	ID           string   `json:"id"`
 	Name         string   `json:"name"`
 	Role         string   `json:"role"` // RFC 0048 amendment §A — optional persona role; "" when unset
+	Type         string   `json:"type"` // RFC 0048 amendment §A DTO — agent kind ("task"|"persona"|…); "" when unset
 	Address      string   `json:"address"`
 	Capabilities []string `json:"capabilities"`
 }
@@ -43,6 +44,7 @@ type agentResponse struct {
 	ID           string   `json:"id"`
 	Name         string   `json:"name"`
 	Role         string   `json:"role"` // RFC 0048 amendment §A — from registry.AgentInfo.Role; "" when unset
+	Type         string   `json:"type"` // RFC 0048 amendment §A DTO — from registry.AgentInfo.Type; "" when unset
 	Address      string   `json:"address"`
 	Capabilities []string `json:"capabilities"`
 	Status       string   `json:"status"`

--- a/tests/unit/python/test_registration.py
+++ b/tests/unit/python/test_registration.py
@@ -69,8 +69,36 @@ class TestSelfRegistration:
         assert payload["name"] == "test-agent"  # S-19: name included in payload
         assert payload["address"] == "127.0.0.1:50051"
         assert payload["capabilities"] == ["planning"]
+        # RFC 0048 §A DTO: type is sent (empty here — the stub config has none) so the
+        # web console can disable chat for task agents.
+        assert payload["type"] == ""
         # P1: status is NOT sent in payload
         assert "status" not in payload
+
+    async def test_registration_sends_agent_type(self):
+        """RFC 0048 §A DTO — a typed agent's `type` rides the register payload."""
+        server = AgentServer(
+            host="127.0.0.1",
+            port=0,
+            shutdown_grace=1,
+            orchestrator_url="http://127.0.0.1:8080",
+            advertise_address="127.0.0.1:50051",
+        )
+        server.register_agent(
+            _StubAgent(agent_id="planner", config={"type": "task"})
+        )
+        mock_resp = AsyncMock()
+        mock_resp.status = 201
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        server._session = mock_session
+
+        await server._self_register()
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["type"] == "task"
 
     async def test_successful_registration_200(self):
         """Registration succeeds on HTTP 200 (not just 201)."""

--- a/tests/unit/python/test_registration.py
+++ b/tests/unit/python/test_registration.py
@@ -72,6 +72,9 @@ class TestSelfRegistration:
         # RFC 0048 §A DTO: type is sent (empty here — the stub config has none) so the
         # web console can disable chat for task agents.
         assert payload["type"] == ""
+        # RFC 0048 §A DTO: role rides the same payload (empty here) so the console can
+        # render the persona header — collected/stored server-side but inert without it.
+        assert payload["role"] == ""
         # P1: status is NOT sent in payload
         assert "status" not in payload
 
@@ -99,6 +102,33 @@ class TestSelfRegistration:
 
         payload = mock_session.post.call_args[1]["json"]
         assert payload["type"] == "task"
+
+    async def test_registration_sends_agent_role(self):
+        """RFC 0048 §A DTO — a persona's `role` rides the register payload so the
+        console can render the persona header (name — role) in the Docker/web
+        deployment, not just in-process."""
+        server = AgentServer(
+            host="127.0.0.1",
+            port=0,
+            shutdown_grace=1,
+            orchestrator_url="http://127.0.0.1:8080",
+            advertise_address="127.0.0.1:50051",
+        )
+        server.register_agent(
+            _StubAgent(agent_id="ada", config={"role": "Researcher"})
+        )
+        mock_resp = AsyncMock()
+        mock_resp.status = 201
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        mock_session = AsyncMock(spec=aiohttp.ClientSession)
+        mock_session.post = MagicMock(return_value=mock_resp)
+        server._session = mock_session
+
+        await server._self_register()
+
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["role"] == "Researcher"
 
     async def test_successful_registration_200(self):
         """Registration succeeds on HTTP 200 (not just 201)."""

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -14,11 +14,10 @@
   let { userId } = $props();
 
   // chatMaxMessageLength mirrors the server's constant (chat_handler.go) so an
-  // over-length message is rejected with immediate feedback instead of burning a
-  // round-trip; the server still enforces it — this is a courtesy guard, not the
-  // authority. The server measures in runes (utf8.RuneCountInString), so the
-  // guard counts code points too (`[...text].length`) — a UTF-16 `.length` would
-  // over-count astral characters and falsely block a message the server accepts.
+  // over-length message is rejected with immediate feedback; the server still
+  // enforces it — this is a courtesy guard. It measures in runes
+  // (utf8.RuneCountInString), so the guard counts code points too
+  // (`[...text].length`) rather than over-counting astral chars via UTF-16.
   const MAX_MESSAGE_LENGTH = 4000;
 
   let agents = $state([]);
@@ -33,17 +32,14 @@
   let epochId = $state("");
   let sending = $state(false);
   let sendError = $state("");
-  // chatController backs the abortable turn (§D): a synchronous chat can block
-  // up to the 30s server timeout, so the in-flight turn is cancellable. Held
-  // across the await so the Cancel control can abort the live fetch.
+  // chatController backs the abortable turn (§D): a synchronous chat can block up
+  // to the 30s server timeout, so it is held across the await for Cancel to abort.
   let chatController = null;
-  // The transcript is a flat, conversational (oldest-top) message list — the
-  // shape RFC 0048 amendment §B migrates to. Each entry is one message:
+  // The transcript is a flat, conversational (oldest-top) message list (RFC 0048
+  // amendment §B). Each entry is one message:
   //   { id, fromUser, who, content, status?, timestamp, session?, epoch? }
   // On persona-select it is SEEDED from the persisted DM history (so a reload
-  // resumes the conversation rather than presenting as stateless), then live
-  // turns append to the bottom. A flat list (vs {prompt,reply} pairs) handles
-  // the persisted ordering and any non-paired messages naturally.
+  // resumes the conversation), then live turns append to the bottom.
   let transcript = $state([]);
   // Live (this-session) messages get a locally-minted id; seeded history uses
   // the server message id. The `local-` prefix can never collide with a server
@@ -67,12 +63,22 @@
   // selectedAgentInfo is the full persona record behind the picker selection, so
   // the panel can render a persona header (name — role, capabilities) above the
   // transcript rather than leaving the persona a bare dropdown entry. The DTO
-  // already carries role (RFC 0048 amendment §A) and capabilities/address
-  // (always served) — "faceless" was the client throwing those away, not the API
-  // withholding them.
+  // already carries role (RFC 0048 amendment §A) and capabilities/address.
   const selectedAgentInfo = $derived(
     agents.find((agent) => agent.id === selectedAgent) ?? null,
   );
+
+  // Task agents (agents.yaml `type: "task"`) run workflow steps and never hold a
+  // conversation, so a chat turn dead-ends in a timeout. They show in the picker
+  // but disabled (extends the §A agent DTO); any non-"task" type — incl. an unset
+  // one from an agent predating the field — stays chattable, so the guard can
+  // never regress a real conversation.
+  function isChattable(agent) {
+    return agent?.type !== "task";
+  }
+  // selectedAgentChattable gates the composer: false only when a task agent is
+  // selected (reachable just when the deployment has no persona to fall back to).
+  const selectedAgentChattable = $derived(isChattable(selectedAgentInfo));
 
   // personaName is the label shown for the agent's own messages — its name (or
   // id), mirroring agentLabel's fallback.
@@ -100,18 +106,14 @@
   }
 
   // loadHistory seeds the transcript from the selected persona's persisted DM,
-  // making a reload resume the conversation (the point of §B). The wire order is
-  // newest-first; the panel renders oldest-top (conversational), so the seed is
-  // reversed. A fresh persona returns an empty list (200, not 404) — a clean
-  // empty transcript, not an error. historyError is non-fatal: a failed seed
-  // still leaves a usable (empty) composer rather than blocking the panel.
+  // making a reload resume the conversation (§B). The wire order is newest-first;
+  // the panel renders oldest-top, so the seed is reversed. A fresh persona returns
+  // an empty list (200, not 404) — a clean empty transcript, not an error.
+  // historyError is non-fatal: a failed seed still leaves a usable composer.
   //
-  // Scope note: the seed fetches only the server's default-limit most-recent
-  // page (channelDefaultHistoryLimit, 50) and the panel has no "load earlier"
-  // affordance yet, so a conversation longer than that resumes from its tail
-  // with the oldest turns omitted. getChatHistory already plumbs limit/before
-  // for the paginating back-fill a later slice (§F) adds; until then the cap is
-  // intentional, not full resume.
+  // Scope note: the seed fetches only the server's default-limit page (50) and the
+  // panel has no "load earlier" yet, so a longer conversation resumes from its
+  // tail; getChatHistory already plumbs limit/before for the §F back-fill.
   function loadHistory(agentID) {
     const token = ++historyToken;
     historyError = "";
@@ -181,16 +183,12 @@
 
   // viewInTimeline hands the current conversation to the Channel Timeline (§F):
   // it records the resolved DM channel id as the pending selection and switches
-  // the hash route, so the freshly-mounted timeline opens on this conversation —
-  // making "your chat is a real, watchable channel" a click, not an assertion.
+  // the hash route, so the freshly-mounted timeline opens on this conversation.
   // Only reachable once a conversation exists (dmChannelId is set from history).
   //
-  // The affordance is a real <a href="#/channels"> (for link semantics), so we
-  // preventDefault and drive the route in JS: that guarantees the nav intent is
-  // recorded before the route changes, rather than racing the anchor's native
-  // navigation — and a modified click (new tab) would land on a fresh context
-  // without the intent anyway, so hijacking it to the in-place hand-off is the
-  // behaviour we want.
+  // The affordance is a real <a href="#/channels">, so we preventDefault and drive
+  // the route in JS: that records the nav intent before the route changes rather
+  // than racing the anchor's native navigation.
   function viewInTimeline(event) {
     event?.preventDefault();
     if (!dmChannelId) return;
@@ -214,15 +212,17 @@
       .then((list) => {
         if (token !== loadToken) return;
         agents = list;
-        // Default the picker to the first *healthy* persona so a newcomer can
-        // send immediately and the default landing isn't a guaranteed 503 (the
-        // chat route only answers for a healthy persona; an offline one is a dead
-        // end). Fall back to the first entry when none are healthy — there's
-        // nothing more sendable to offer, and the status annotation already warns
-        // why a send may fail.
+        // Default to the first persona that is BOTH chattable and healthy so a
+        // newcomer lands on a sendable conversation — never a disabled task agent
+        // (a task agent) or a guaranteed-503 offline one. Degrade to any chattable,
+        // then to any agent at all (the composer then explains why it's locked).
         if (list.length > 0) {
-          const healthy = list.find((agent) => agent.status === "healthy");
-          selectedAgent = (healthy ?? list[0]).id;
+          const chattable = list.filter(isChattable);
+          selectedAgent = (
+            chattable.find((agent) => agent.status === "healthy") ??
+            chattable[0] ??
+            list[0]
+          ).id;
         }
       })
       .catch((err) => {
@@ -255,6 +255,12 @@
     // ("Ada — Researcher") rather than a list of bare names (RFC 0048 §A). Role
     // is optional; omit the separator when unset.
     const named = agent.role ? `${name} — ${agent.role}` : name;
+    // A task agent's row carries the why ("show but explain") rather than its
+    // health — a disabled row can't be sent regardless of status, so the reason
+    // it's disabled is the useful annotation.
+    if (!isChattable(agent)) {
+      return `${named} (task agent — not chattable)`;
+    }
     return agent.status && agent.status !== "healthy"
       ? `${named} (${agent.status})`
       : named;
@@ -272,6 +278,11 @@
     sendError = "";
     const text = message.trim();
     if (!selectedAgent || text.length === 0) {
+      return;
+    }
+    // Enter-to-send bypasses the disabled button (canSend gates the button, not
+    // send()), so re-check chattability here: a task agent can never be sent to.
+    if (!isChattable(selectedAgentInfo)) {
       return;
     }
     if ([...text].length > MAX_MESSAGE_LENGTH) {
@@ -326,12 +337,10 @@
       ];
       message = "";
       // First message of a fresh conversation creates the DM server-side (§F);
-      // chatResponse omits its id, so re-resolve it from history (the source of
-      // truth — DM ids are never hand-built, see channels.CanonicalDMID) to light
-      // up the hand-off this turn. Fire-and-forget + token-guarded: it neither
-      // blocks the composer nor outlives a persona switch, and a failed capture
-      // just leaves the link hidden until the next reseed. Guarded to the first
-      // turn (dmChannelId empty) so steady-state chatting adds no extra fetch.
+      // chatResponse omits its id, so re-resolve it from history (DM ids are never
+      // hand-built — see channels.CanonicalDMID) to light up the hand-off this
+      // turn. Fire-and-forget + token-guarded, and guarded to the first turn
+      // (dmChannelId empty) so steady-state chatting adds no extra fetch.
       if (!dmChannelId && selectedAgent) {
         const token = historyToken;
         getChatHistory(selectedAgent, { userId })
@@ -450,7 +459,9 @@
           disabled={sending}
         >
           {#each agents as agent (agent.id)}
-            <option value={agent.id}>{agentLabel(agent)}</option>
+            <option value={agent.id} disabled={!isChattable(agent)}
+              >{agentLabel(agent)}</option
+            >
           {/each}
         </select>
       </label>
@@ -472,7 +483,16 @@
            composer reads back via the bindings. -->
       <ScopeSelector bind:sessionId bind:epochId {sending} />
 
-      <button type="submit" disabled={!canSend}>
+      {#if selectedAgentInfo && !selectedAgentChattable}
+        <!-- Only reachable when the deployment has no persona to fall back to:
+             explain why the composer is locked rather than leaving a dead Send. -->
+        <p class="poll-error" role="status">
+          Task agents run workflow steps and don't hold conversations — pick a
+          persona to chat.
+        </p>
+      {/if}
+
+      <button type="submit" disabled={!canSend || !selectedAgentChattable}>
         {sending ? "Sending…" : "Send"}
       </button>
     </form>

--- a/web/src/panels/Chat.taskagent.test.js
+++ b/web/src/panels/Chat.taskagent.test.js
@@ -83,6 +83,25 @@ describe("Chat panel — task agents", () => {
     await waitFor(() => expect(sendChat).toHaveBeenCalled());
   });
 
+  it("treats an unknown non-task type as chattable (only `task` is gated)", async () => {
+    // The contract is "anything other than `task` is chattable", not an allow-list
+    // of known kinds — a future agent kind the console hasn't heard of must degrade
+    // to chattable, not silently lock. The backward-compat test above covers the
+    // *unset* path; this pins the *typed-but-unknown* path.
+    listAgents.mockResolvedValue([
+      { id: "ada", name: "Ada", type: "swarm", status: "healthy" },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    const option = await screen.findByRole("option", { name: "Ada" });
+    expect(option.disabled).toBe(false);
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "Hi" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(sendChat).toHaveBeenCalled());
+  });
+
   it("locks the composer and explains when only task agents exist", async () => {
     listAgents.mockResolvedValue([
       { id: "planner", name: "Planner", type: "task", status: "healthy" },

--- a/web/src/panels/Chat.taskagent.test.js
+++ b/web/src/panels/Chat.taskagent.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+  fireEvent,
+} from "@testing-library/svelte";
+import Chat from "./Chat.svelte";
+
+// Task agents (agents.yaml `type: "task"`) execute workflow steps and never hold
+// a conversation, so a chat turn dead-ends in a timeout. The picker shows them but
+// disabled, with an explanation (extends the §A agent DTO): visible roster, no
+// dead-end selection. Anything other than "task" — including an unset type — stays
+// chattable so the guard can't regress an existing conversation.
+vi.mock("../lib/api.js", () => ({
+  ApiError: class ApiError extends Error {},
+  listAgents: vi.fn(),
+  sendChat: vi.fn(),
+  getChatHistory: vi.fn(),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+import {
+  listAgents,
+  sendChat,
+  getChatHistory,
+  listSessions,
+  createSession,
+} from "../lib/api.js";
+
+beforeEach(() => {
+  sendChat.mockResolvedValue({ reply: "hi", reply_status: "ok" });
+  getChatHistory.mockResolvedValue({ messages: [] });
+  listSessions.mockResolvedValue({ sessions: [] });
+  createSession.mockResolvedValue({ id: "s", label: "s" });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Chat panel — task agents", () => {
+  it("renders a task agent's option disabled and labeled not-chattable", async () => {
+    listAgents.mockResolvedValue([
+      { id: "ada", name: "Ada", type: "persona", status: "healthy" },
+      { id: "planner", name: "Planner", type: "task", status: "healthy" },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    const taskOption = await screen.findByRole("option", {
+      name: /Planner \(task agent — not chattable\)/,
+    });
+    expect(taskOption.disabled).toBe(true);
+    // The persona stays enabled.
+    expect(screen.getByRole("option", { name: "Ada" }).disabled).toBe(false);
+  });
+
+  it("defaults the picker to a persona, never a task agent", async () => {
+    // Task agent listed first: a naive "first healthy" default would land on it.
+    listAgents.mockResolvedValue([
+      { id: "planner", name: "Planner", type: "task", status: "healthy" },
+      { id: "ada", name: "Ada", type: "persona", status: "healthy" },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    const picker = await screen.findByRole("combobox", { name: /persona/i });
+    await waitFor(() => expect(picker.value).toBe("ada"));
+  });
+
+  it("treats an agent with no type as chattable (backward compatible)", async () => {
+    listAgents.mockResolvedValue([{ id: "ada", name: "Ada", status: "healthy" }]);
+    render(Chat, { props: { userId: "local" } });
+
+    const option = await screen.findByRole("option", { name: "Ada" });
+    expect(option.disabled).toBe(false);
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "Hi" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await waitFor(() => expect(sendChat).toHaveBeenCalled());
+  });
+
+  it("locks the composer and explains when only task agents exist", async () => {
+    listAgents.mockResolvedValue([
+      { id: "planner", name: "Planner", type: "task", status: "healthy" },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    // The lone task agent is the forced selection, so the composer must explain
+    // why it's locked rather than leaving a dead Send button.
+    await screen.findByText(/don't hold conversations/i);
+    expect(screen.getByRole("button", { name: /send/i }).disabled).toBe(true);
+  });
+
+  it("ignores Enter-to-send when a task agent is the only selection", async () => {
+    listAgents.mockResolvedValue([
+      { id: "planner", name: "Planner", type: "task", status: "healthy" },
+    ]);
+    render(Chat, { props: { userId: "local" } });
+
+    await screen.findByText(/don't hold conversations/i);
+    const message = screen.getByRole("textbox", { name: /message/i });
+    await fireEvent.input(message, { target: { value: "Hi" } });
+    // Enter bypasses the disabled button; send() must still no-op for a task agent.
+    await fireEvent.keyDown(message, { key: "Enter" });
+    expect(sendChat).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

The Chat panel ([`web/src/panels/Chat.svelte`](web/src/panels/Chat.svelte)) listed **every** registered agent in its persona picker — including the workflow **task agents** (`planner` / `code-writer` / `code-reviewer`, declared `type: "task"` in [`config/agents.yaml`](config/agents.yaml)). Those agents execute workflow steps and never hold a conversation, so picking one dead-ended the chat turn in a 30s timeout. That's the *"we can't chat with task agents"* symptom.

The API gave the console no way to distinguish them: neither `registry.AgentInfo` nor `agentResponse` carried the agent kind, so the picker couldn't filter.

## Fix

Expose the agent `type` end-to-end and use it to **show-but-disable** task agents in the picker (the chosen UX): the roster stays legible, but a task agent is never a dead-end selection.

### Backend — additive, backward-compatible (extends the amendment §A agent DTO)
- `registry.AgentInfo`, `registerAgentRequest`, and `agentResponse` gain `type`; `agentToResponse` populates it. `handleRegisterAgent` caps it at 32 chars (a short kind token) on the same registry-pollution rationale as `name`/`role`.
- [`agents/server.py`](agents/server.py) self-registration now sends `type` via a new config-driven `BaseAgent.agent_type` property. Agents that predate the field omit it → the orchestrator stores `""`, which the console treats as chattable. Purely additive.
- The same self-registration payload now also sends `role` (the orchestrator already accepted/stored it, but `server.py` never sent it, so the §A persona-header role was inert in the Docker/web deployment). Unset → `""`, so this too is purely additive.

### Client — [`Chat.svelte`](web/src/panels/Chat.svelte)
- `isChattable(agent) = agent.type !== "task"` — anything other than `"task"` (including an **unset** type) stays chattable, so the guard can never regress an existing conversation.
- Task-agent options render **disabled** and labeled `(task agent — not chattable)`.
- The default selection skips task agents in favour of a healthy persona.
- `send()` re-checks chattability (Enter-to-send bypasses the disabled button).
- When a deployment has *only* task agents, the composer locks with a plain-language explanation instead of a dead Send button.

## Tests
- **Go**: register/list round-trip, default-empty, and over-length for `type` ([`server_agent_type_test.go`](internal/server/server_agent_type_test.go)).
- **Python**: self-register sends `type`, and sends `role` ([`test_registration.py`](tests/unit/python/test_registration.py)).
- **Web**: 6 tests covering disabled+labeled option, persona-first default, unset-type-stays-chattable, typed-but-unknown-type-stays-chattable, only-task lock + explanation, and Enter no-op ([`Chat.taskagent.test.js`](web/src/panels/Chat.taskagent.test.js)).

Go + Python + **128 web tests** green; `gofmt`/`ruff` clean; file-size check passes.

## Notes
- Some adjacent comments in `agents/base.py` and `Chat.svelte` were condensed because both files sat at the 500-line cap and the additions would have tipped them over (same move the §A PR used).
- Naming: this isn't a new amendment section (the amendment is lettered §A–§F); it **extends the §A agent DTO**, so it's cited that way rather than inventing a section.
- `FILEMAP.md` was intentionally **not** regenerated — it is stale on `main` and regenerating would bundle ~67 files of unrelated drift into this PR.

## Follow-up (not in this PR)
None outstanding from the original scope. (The earlier-flagged `role`-not-sent gap is now fixed here — see the second backend bullet.)
