### PR TITLE
fix(v036): web console — persist selected persona across tab switch (RFC 0048)

### DIFF
--- a/web/src/lib/selection.svelte.js
+++ b/web/src/lib/selection.svelte.js
@@ -1,0 +1,19 @@
+// Sticky cross-mount panel selection (RFC 0048).
+//
+// The console mounts only the active panel (App.svelte: "Only the active panel
+// is mounted"), so a panel's local $state is destroyed every time the operator
+// switches tabs and re-created — re-running its default-selection logic — when
+// they switch back. That silently resets a deliberate choice on each Chat↔
+// Channels round-trip. This module holds those choices in module-level $state,
+// which outlives an unmount, so a panel can resume where the operator left it.
+//
+// A `.svelte.js` module so the `$state` rune is reactive across components,
+// mirroring nav.svelte.js. "" means no remembered choice — the panel then
+// applies its own default. Persistence is in-memory (per page load), matching
+// the bug it fixes (a tab switch, not a reload).
+export const selection = $state({
+  // The chat panel's last deliberately-selected persona id. Set on a user-driven
+  // persona change (not the programmatic default), so a never-chosen panel still
+  // gets the smart healthy-first default rather than a frozen first selection.
+  chatAgent: "",
+});

--- a/web/src/lib/selection.svelte.js
+++ b/web/src/lib/selection.svelte.js
@@ -17,3 +17,28 @@ export const selection = $state({
   // gets the smart healthy-first default rather than a frozen first selection.
   chatAgent: "",
 });
+
+// pickInitialAgent resolves which persona a freshly-mounted Chat panel opens on.
+// It prefers the operator's last deliberately-chosen persona (rememberedId, from
+// selection.chatAgent) when that persona is still in the list, so a Chat↔Channels
+// round-trip resumes where they left off rather than snapping to the default.
+// Otherwise it falls to the first persona that is BOTH chattable and healthy — a
+// newcomer lands on a sendable conversation, never a disabled task agent or a
+// guaranteed-503 offline one — then any chattable, then any agent at all (the
+// composer then explains why it's locked). A remembered persona that has since
+// deregistered isn't in the list, so it degrades to this default too. The caller
+// passes its own isChattable predicate so the policy stays UI-agnostic. Returns
+// null for an empty list.
+export function pickInitialAgent(list, isChattable, rememberedId) {
+  if (list.length === 0) return null;
+  const chattable = list.filter(isChattable);
+  const remembered = rememberedId
+    ? list.find((agent) => agent.id === rememberedId)
+    : null;
+  return (
+    remembered ??
+    chattable.find((agent) => agent.status === "healthy") ??
+    chattable[0] ??
+    list[0]
+  );
+}

--- a/web/src/panels/Chat.persistence.test.js
+++ b/web/src/panels/Chat.persistence.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+} from "@testing-library/svelte";
+import Chat from "./Chat.svelte";
+import { selection } from "../lib/selection.svelte.js";
+
+// Sticky persona selection across a tab switch. The console mounts only the
+// active panel (App.svelte), so switching Chat→Channels unmounts the chat panel
+// and destroys its local `selectedAgent` state; switching back remounts it and
+// re-runs the default-selection logic. Without a cross-mount memory, a deliberate
+// persona choice is silently reset to the default on every round-trip — the bug
+// these specs pin. selection.svelte.js survives the unmount (module-level $state,
+// the nav.svelte.js pattern); loadAgents honours a remembered persona.
+vi.mock("../lib/api.js", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(message, status, options) {
+      super(message, options);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+  listAgents: vi.fn(),
+  sendChat: vi.fn(),
+  getChatHistory: vi.fn(),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+import { listAgents, sendChat, getChatHistory, listSessions, createSession } from "../lib/api.js";
+
+const AGENTS = [
+  { id: "alice", name: "Alice", status: "healthy" },
+  { id: "bob", name: "Bob", status: "healthy" },
+];
+
+beforeEach(() => {
+  listAgents.mockResolvedValue(AGENTS);
+  sendChat.mockResolvedValue({ reply: "Hi.", reply_status: "ok" });
+  getChatHistory.mockResolvedValue({ messages: [] });
+  listSessions.mockResolvedValue({ sessions: [] });
+  createSession.mockResolvedValue({ id: "sess-new", label: "New" });
+  // Reset the sticky selection so specs don't leak it into one another (the
+  // module-level $state outlives a single render, which is the whole point).
+  selection.chatAgent = "";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Chat panel — sticky persona across a tab switch", () => {
+  it("resumes the last deliberately-selected persona after a remount", async () => {
+    // First visit: pick Bob (not the default Alice), then leave the panel
+    // (cleanup() stands in for the App switching to Channels and unmounting Chat).
+    const first = render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    await fireEvent.change(screen.getByRole("combobox", { name: /persona/i }), {
+      target: { value: "bob" },
+    });
+    first.unmount();
+
+    // Switch back: a fresh mount must reopen on Bob, not snap back to the default.
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("bob");
+  });
+
+  it("still applies the healthy-first default when nothing was chosen", async () => {
+    // No deliberate choice means no remembered persona, so the default logic must
+    // still run: don't let an empty sticky value strand the picker on a blank.
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("alice");
+  });
+
+  it("falls back to the default when the remembered persona is gone", async () => {
+    // A remembered persona that has since deregistered isn't in the new list, so
+    // honouring it would select a phantom. Degrade to the healthy-first default.
+    selection.chatAgent = "ghost";
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("alice");
+  });
+});

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -10,7 +10,7 @@
   import PersonaHeader from "./PersonaHeader.svelte";
   import ChatMessage from "./ChatMessage.svelte";
   import { nav } from "../lib/nav.svelte.js";
-  import { selection } from "../lib/selection.svelte.js";
+  import { selection, pickInitialAgent } from "../lib/selection.svelte.js";
 
   let { userId } = $props();
 
@@ -214,28 +214,11 @@
         if (token !== loadToken) return;
         agents = list;
         // Resume the operator's last deliberately-chosen persona across a tab
-        // switch: the inactive panel unmounts (App.svelte mounts only the active
-        // one), so the local selection is lost on every Chat↔Channels round-trip
-        // and this re-runs. selection.svelte.js outlives the unmount, so honour a
-        // remembered persona when it's still in the list.
-        //
-        // Otherwise default to the first persona that is BOTH chattable and
-        // healthy so a newcomer lands on a sendable conversation — never a
-        // disabled task agent or a guaranteed-503 offline one. Degrade to any
-        // chattable, then to any agent at all (the composer then explains why
-        // it's locked). A remembered persona that has since deregistered isn't in
-        // the list, so it falls through to this default too.
-        if (list.length > 0) {
-          const chattable = list.filter(isChattable);
-          const remembered = selection.chatAgent
-            ? list.find((agent) => agent.id === selection.chatAgent)
-            : null;
-          selectedAgent = (
-            remembered ??
-            chattable.find((agent) => agent.status === "healthy") ??
-            chattable[0] ??
-            list[0]
-          ).id;
+        // switch (selection.svelte.js outlives the unmount that destroys the local
+        // selection), else apply the healthy-first default — see pickInitialAgent.
+        const initial = pickInitialAgent(list, isChattable, selection.chatAgent);
+        if (initial) {
+          selectedAgent = initial.id;
         }
       })
       .catch((err) => {
@@ -398,11 +381,10 @@
   // value reads as if the new persona is already broken. The transcript and the
   // in-progress message are left intact — only the transient error is dropped.
   // Scoped to the user-driven change event so the programmatic default-selection
-  // during load doesn't clear an unrelated error. It also records the choice as
-  // the sticky cross-mount selection (selection.svelte.js) so switching to
-  // Channels and back resumes THIS persona rather than snapping to the default —
-  // recording only here (not on the programmatic default) means a never-chosen
-  // panel still re-evaluates the healthy-first default on each mount.
+  // during load doesn't clear an unrelated error. Recording the choice as the
+  // sticky cross-mount selection here (not on the programmatic default) is what
+  // lets a Channels round-trip resume THIS persona while a never-chosen panel
+  // still re-evaluates the healthy-first default on each mount (pickInitialAgent).
   function onPersonaChange() {
     sendError = "";
     selection.chatAgent = selectedAgent;

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -10,6 +10,7 @@
   import PersonaHeader from "./PersonaHeader.svelte";
   import ChatMessage from "./ChatMessage.svelte";
   import { nav } from "../lib/nav.svelte.js";
+  import { selection } from "../lib/selection.svelte.js";
 
   let { userId } = $props();
 
@@ -212,13 +213,25 @@
       .then((list) => {
         if (token !== loadToken) return;
         agents = list;
-        // Default to the first persona that is BOTH chattable and healthy so a
-        // newcomer lands on a sendable conversation — never a disabled task agent
-        // (a task agent) or a guaranteed-503 offline one. Degrade to any chattable,
-        // then to any agent at all (the composer then explains why it's locked).
+        // Resume the operator's last deliberately-chosen persona across a tab
+        // switch: the inactive panel unmounts (App.svelte mounts only the active
+        // one), so the local selection is lost on every Chat↔Channels round-trip
+        // and this re-runs. selection.svelte.js outlives the unmount, so honour a
+        // remembered persona when it's still in the list.
+        //
+        // Otherwise default to the first persona that is BOTH chattable and
+        // healthy so a newcomer lands on a sendable conversation — never a
+        // disabled task agent or a guaranteed-503 offline one. Degrade to any
+        // chattable, then to any agent at all (the composer then explains why
+        // it's locked). A remembered persona that has since deregistered isn't in
+        // the list, so it falls through to this default too.
         if (list.length > 0) {
           const chattable = list.filter(isChattable);
+          const remembered = selection.chatAgent
+            ? list.find((agent) => agent.id === selection.chatAgent)
+            : null;
           selectedAgent = (
+            remembered ??
             chattable.find((agent) => agent.status === "healthy") ??
             chattable[0] ??
             list[0]
@@ -385,9 +398,14 @@
   // value reads as if the new persona is already broken. The transcript and the
   // in-progress message are left intact — only the transient error is dropped.
   // Scoped to the user-driven change event so the programmatic default-selection
-  // during load doesn't clear an unrelated error.
+  // during load doesn't clear an unrelated error. It also records the choice as
+  // the sticky cross-mount selection (selection.svelte.js) so switching to
+  // Channels and back resumes THIS persona rather than snapping to the default —
+  // recording only here (not on the programmatic default) means a never-chosen
+  // panel still re-evaluates the healthy-first default on each mount.
   function onPersonaChange() {
     sendError = "";
+    selection.chatAgent = selectedAgent;
   }
 </script>
 

--- a/web/src/panels/Chat.test.js
+++ b/web/src/panels/Chat.test.js
@@ -34,6 +34,7 @@ import {
   createSession,
   ApiError,
 } from "../lib/api.js";
+import { selection } from "../lib/selection.svelte.js";
 
 const AGENTS = [
   { id: "alice", name: "Alice", status: "healthy" },
@@ -62,6 +63,10 @@ beforeEach(() => {
   // the free-text degradation reject this instead.
   listSessions.mockResolvedValue({ sessions: [] });
   createSession.mockResolvedValue({ id: "sess-new", label: "New" });
+  // Reset the sticky cross-mount persona selection so a persona switch in one
+  // spec can't leak into another's default-selection assertion (the module-level
+  // $state outlives a single render by design — selection.svelte.js).
+  selection.chatAgent = "";
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Problem

In the web console, switching between **Chat** and **Channels** and back resets the selected persona to a different agent — the deliberate selection isn't remembered.

**Root cause:** the console mounts only the active panel (`App.svelte` — "Only the active panel is mounted"), so switching away unmounts `Chat.svelte` and destroys its local `selectedAgent` `$state`. Switching back remounts it and `loadAgents()` re-runs its default-selection logic, snapping the persona to the first healthy agent. There was no cross-mount memory of the choice.

## Fix

Follow the existing cross-panel pattern (`nav.svelte.js` — a module-level `$state` that survives unmount):

- **New** `web/src/lib/selection.svelte.js` — sticky `selection.chatAgent` that outlives an unmount.
- `Chat.svelte` — `loadAgents()` resumes a remembered persona when it's still in the list; otherwise it falls through to the existing healthy-first default. The choice is recorded in `onPersonaChange` (user-driven changes only), so a never-chosen panel still gets the smart default, and a deregistered persona degrades gracefully to it.

## Tests (TDD)

Wrote `Chat.persistence.test.js` first, confirmed it failed (missing module), then implemented to green. Specs cover: resume after remount, default still applies when nothing was chosen, and fallback when the remembered persona is gone. Also reset the shared selection in `Chat.test.js`'s `beforeEach` so module-level state can't leak between specs.

- ✅ All 131 web tests pass
- ✅ Production build compiles

## Note

The **Channels** panel has the symmetric issue (`selectedChannel` resets on remount). Scoped out of this PR since only chat was reported; tracked as a follow-up.
