### PR TITLE
fix(v036): web console — reachable persona switcher, exit to lobby, stable agent order (RFC 0048)

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 
 	"go.uber.org/zap"
@@ -152,6 +153,14 @@ func (r *InMemoryRegistry) List(_ context.Context) ([]AgentInfo, error) {
 	for _, agent := range r.agents {
 		result = append(result, *deepCopyAgent(agent))
 	}
+	// Sort by ID so List returns a deterministic order. The agents map has a
+	// randomized Go iteration order, so without this the sequence differed on
+	// every call — the web console re-fetches the persona list on each tab switch
+	// (RFC 0048), which reshuffled the dropdown each time. A stable order serves
+	// every consumer (web picker, channel decoration, CLI) from one place.
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ID < result[j].ID
+	})
 	return result, nil
 }
 

--- a/internal/registry/registry_list_test.go
+++ b/internal/registry/registry_list_test.go
@@ -1,0 +1,38 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSortedByID pins a stable List ordering. The agents map has a
+// randomized Go iteration order, so List returned a different sequence on every
+// call — the web console re-fetches the persona list on each tab switch (RFC
+// 0048), so the dropdown reshuffled each time. List must sort by ID so every
+// consumer (web picker, channel decoration, CLI) sees one deterministic order.
+// (Split into its own file to keep registry_test.go under the review-size cap;
+// newTestRegistry/sampleAgent are package-level test helpers.)
+func TestListSortedByID(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	// Register out of sorted order, with enough entries that a randomized map
+	// walk would essentially never return them sorted by chance (8! permutations).
+	insertion := []string{"delta", "alpha", "hotel", "charlie", "bravo", "golf", "echo", "foxtrot"}
+	for _, id := range insertion {
+		require.NoError(t, r.Register(ctx, sampleAgent(id)))
+	}
+
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+
+	ids := make([]string, len(list))
+	for i, a := range list {
+		ids[i] = a.ID
+	}
+	want := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"}
+	assert.Equal(t, want, ids, "List must return agents sorted by ID for a stable dropdown order")
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -132,33 +132,6 @@ func TestList(t *testing.T) {
 	assert.True(t, ids["agent-02"])
 }
 
-// TestListSortedByID pins a stable List ordering. The agents map has a
-// randomized Go iteration order, so List returned a different sequence on every
-// call — the web console re-fetches the persona list on each tab switch (RFC
-// 0048), so the dropdown reshuffled each time. List must sort by ID so every
-// consumer (web picker, channel decoration, CLI) sees one deterministic order.
-func TestListSortedByID(t *testing.T) {
-	r := newTestRegistry()
-	ctx := context.Background()
-
-	// Register out of sorted order, with enough entries that a randomized map
-	// walk would essentially never return them sorted by chance (8! permutations).
-	insertion := []string{"delta", "alpha", "hotel", "charlie", "bravo", "golf", "echo", "foxtrot"}
-	for _, id := range insertion {
-		require.NoError(t, r.Register(ctx, sampleAgent(id)))
-	}
-
-	list, err := r.List(ctx)
-	require.NoError(t, err)
-
-	ids := make([]string, len(list))
-	for i, a := range list {
-		ids[i] = a.ID
-	}
-	want := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"}
-	assert.Equal(t, want, ids, "List must return agents sorted by ID for a stable dropdown order")
-}
-
 func TestListEmpty(t *testing.T) {
 	r := newTestRegistry()
 	ctx := context.Background()

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -132,6 +132,33 @@ func TestList(t *testing.T) {
 	assert.True(t, ids["agent-02"])
 }
 
+// TestListSortedByID pins a stable List ordering. The agents map has a
+// randomized Go iteration order, so List returned a different sequence on every
+// call — the web console re-fetches the persona list on each tab switch (RFC
+// 0048), so the dropdown reshuffled each time. List must sort by ID so every
+// consumer (web picker, channel decoration, CLI) sees one deterministic order.
+func TestListSortedByID(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+
+	// Register out of sorted order, with enough entries that a randomized map
+	// walk would essentially never return them sorted by chance (8! permutations).
+	insertion := []string{"delta", "alpha", "hotel", "charlie", "bravo", "golf", "echo", "foxtrot"}
+	for _, id := range insertion {
+		require.NoError(t, r.Register(ctx, sampleAgent(id)))
+	}
+
+	list, err := r.List(ctx)
+	require.NoError(t, err)
+
+	ids := make([]string, len(list))
+	for i, a := range list {
+		ids[i] = a.ID
+	}
+	want := []string{"alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel"}
+	assert.Equal(t, want, ids, "List must return agents sorted by ID for a stable dropdown order")
+}
+
 func TestListEmpty(t *testing.T) {
 	r := newTestRegistry()
 	ctx := context.Background()

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -149,6 +149,48 @@ body {
 
 /* Chat panel (RFC 0048 Phase 1 PR 4). Still deliberately minimal — enough
    structure to read a conversation and reach the composer, no design system. */
+/* Persona switcher row — pinned at the top of the chat panel, mirroring the
+   channel timeline's .channel-picker, so it stays reachable above a growing
+   transcript rather than being buried at the bottom of the composer. The
+   selector and its New chat / Exit controls sit on one row. */
+.persona-picker {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  max-width: 40rem;
+  margin-bottom: 1rem;
+}
+
+.persona-picker label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+}
+
+.persona-picker select {
+  font: inherit;
+  padding: 0.3rem;
+}
+
+.persona-picker button {
+  font: inherit;
+  padding: 0.4rem 0.8rem;
+  cursor: pointer;
+}
+
+.persona-picker button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* Lobby prompt — shown when no persona is selected (a fresh start or after
+   Exit), in place of the conversation. Muted, like the other status lines. */
+.lobby {
+  opacity: 0.7;
+}
+
 .transcript {
   list-style: none;
   margin: 0 0 1rem;
@@ -156,6 +198,11 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+  /* An independent scroll region (like the channel timeline's .timeline) so a
+     long conversation scrolls within the transcript instead of pushing the
+     composer and the top persona switcher out of reach. */
+  max-height: 60vh;
+  overflow-y: auto;
 }
 
 .msg p {

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -152,7 +152,7 @@ body {
 /* Persona switcher row — pinned at the top of the chat panel, mirroring the
    channel timeline's .channel-picker, so it stays reachable above a growing
    transcript rather than being buried at the bottom of the composer. The
-   selector and its New chat / Exit controls sit on one row. */
+   selector and its Exit control sit on one row. */
 .persona-picker {
   display: flex;
   align-items: flex-end;

--- a/web/src/lib/agents.js
+++ b/web/src/lib/agents.js
@@ -1,0 +1,35 @@
+// Persona/agent display helpers shared by the Chat panel and its PersonaPicker
+// (extracted so the two render identical option labels and chattability rules
+// without the panel re-deriving them — and to keep Chat.svelte under the
+// review-size cap, the same reason PublishComposer was split out).
+
+// isChattable: task agents (agents.yaml `type: "task"`) run workflow steps and
+// never hold a conversation, so a chat turn dead-ends in a timeout. They show in
+// the picker but disabled (extends the §A agent DTO); any non-"task" type — incl.
+// an unset one from an agent predating the field — stays chattable, so the guard
+// can never regress a real conversation.
+export function isChattable(agent) {
+  return agent?.type !== "task";
+}
+
+// agentLabel is the picker's display text: the persona's name, falling back to
+// its id when unnamed (matching the server's own display-name fallback in
+// chat_handler.go). A non-healthy persona is annotated with its status, since
+// only a healthy one can actually reply (the chat route 503s otherwise) — the
+// operator sees that before spending a send, not after.
+export function agentLabel(agent) {
+  const name = agent.name ? agent.name : agent.id;
+  // Fold the role into the option so the picker reads as a cast of personas
+  // ("Ada — Researcher") rather than a list of bare names (RFC 0048 §A). Role
+  // is optional; omit the separator when unset.
+  const named = agent.role ? `${name} — ${agent.role}` : name;
+  // A task agent's row carries the why ("show but explain") rather than its
+  // health — a disabled row can't be sent regardless of status, so the reason
+  // it's disabled is the useful annotation.
+  if (!isChattable(agent)) {
+    return `${named} (task agent — not chattable)`;
+  }
+  return agent.status && agent.status !== "healthy"
+    ? `${named} (${agent.status})`
+    : named;
+}

--- a/web/src/lib/selection.svelte.js
+++ b/web/src/lib/selection.svelte.js
@@ -15,6 +15,9 @@ export const selection = $state({
   // The chat panel's last deliberately-selected persona id. Set on a user-driven
   // persona change (not the programmatic default), so a never-chosen panel still
   // gets the smart healthy-first default rather than a frozen first selection.
+  // Three states: an id (resume it), "" (never chose — apply the default), and
+  // null (the operator hit Exit — stay in the lobby across a tab switch). See
+  // pickInitialAgent.
   chatAgent: "",
 });
 
@@ -27,10 +30,16 @@ export const selection = $state({
 // guaranteed-503 offline one — then any chattable, then any agent at all (the
 // composer then explains why it's locked). A remembered persona that has since
 // deregistered isn't in the list, so it degrades to this default too. The caller
-// passes its own isChattable predicate so the policy stays UI-agnostic. Returns
-// null for an empty list.
+// passes its own isChattable predicate so the policy stays UI-agnostic.
+//
+// rememberedId === null is the EXITED sentinel: the operator deliberately left
+// the conversation (the Exit affordance), so the panel must open on no persona
+// (the lobby) and not snap to a default — that exit has to survive the unmount a
+// tab switch causes. "" is the distinct never-chosen state, which still defaults.
+// Returns null for an empty list or an explicit exit.
 export function pickInitialAgent(list, isChattable, rememberedId) {
   if (list.length === 0) return null;
+  if (rememberedId === null) return null;
   const chattable = list.filter(isChattable);
   const remembered = rememberedId
     ? list.find((agent) => agent.id === rememberedId)

--- a/web/src/lib/selection.test.js
+++ b/web/src/lib/selection.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { pickInitialAgent } from "./selection.svelte.js";
+
+// pickInitialAgent resolves which persona a freshly-mounted Chat panel opens on.
+// Three remembered-id states must be honoured:
+//   - an id  → resume that persona (when still present)
+//   - ""     → never chose; apply the healthy-first default
+//   - null   → the operator deliberately EXITED the conversation; stay in the
+//              lobby (return null) rather than snapping back to a default, so an
+//              "exit" survives a Chat↔Channels tab round-trip (the panel unmounts
+//              on a tab switch and re-runs this on the way back).
+const isChattable = (a) => a?.type !== "task";
+const LIST = [
+  { id: "alice", status: "healthy" },
+  { id: "bob", status: "healthy" },
+];
+
+describe("pickInitialAgent", () => {
+  it("returns null when the operator explicitly exited (rememberedId === null)", () => {
+    expect(pickInitialAgent(LIST, isChattable, null)).toBeNull();
+  });
+
+  it("applies the healthy-first default for a never-chosen panel (empty id)", () => {
+    expect(pickInitialAgent(LIST, isChattable, "")?.id).toBe("alice");
+  });
+
+  it("resumes a remembered persona that is still present", () => {
+    expect(pickInitialAgent(LIST, isChattable, "bob")?.id).toBe("bob");
+  });
+
+  it("returns null for an empty list regardless of the remembered id", () => {
+    expect(pickInitialAgent([], isChattable, "")).toBeNull();
+  });
+});

--- a/web/src/panels/Chat.lifecycle.test.js
+++ b/web/src/panels/Chat.lifecycle.test.js
@@ -1,22 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  render,
-  screen,
-  cleanup,
-  fireEvent,
-  waitFor,
-} from "@testing-library/svelte";
+import { render, screen, cleanup, fireEvent } from "@testing-library/svelte";
 import Chat from "./Chat.svelte";
 import { selection } from "../lib/selection.svelte.js";
 
-// True "exit chat" and "start new" (mirrors the CLI exit/restart used for memory
-// testing). Two affordances beside the persona switcher:
-//   - Exit     → leave the conversation entirely, back to a persona lobby (no
-//                conversation open). Survives a tab round-trip (selection sentinel).
-//   - New chat → clear the on-screen conversation but keep the SAME persona and
-//                identity/epoch, so the next turn is a fresh conversation while
-//                the agent's persisted memory is intact — the persistence test
-//                ("greet me" → New chat → "do you remember me?").
+// True "exit chat": leave the conversation entirely, back to a persona lobby (no
+// conversation open) — the web analogue of quitting the CLI chat REPL. The exit
+// survives a Chat↔Channels tab round-trip (selection sentinel), and the lobby is
+// the entry point for starting a conversation or switching persona.
 vi.mock("../lib/api.js", () => ({
   ApiError: class ApiError extends Error {
     constructor(message, status, options) {
@@ -101,52 +91,5 @@ describe("Chat panel — exit to lobby", () => {
     // Picking a persona enters the conversation: the composer returns.
     expect(await screen.findByRole("button", { name: /send/i })).toBeTruthy();
     expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("bob");
-  });
-});
-
-describe("Chat panel — start a new conversation", () => {
-  it("clears the transcript but keeps the persona and composer on New chat", async () => {
-    render(Chat, { props: { userId: "local" } });
-    await screen.findByRole("option", { name: "Alice" });
-
-    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
-      target: { value: "Hi" },
-    });
-    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
-    await screen.findByText(/remembered reply\./i);
-
-    await fireEvent.click(screen.getByRole("button", { name: /new chat/i }));
-
-    // The prior turn is cleared from view, but the persona and composer stay —
-    // it's a fresh conversation with the same persona, not an exit.
-    await waitFor(() =>
-      expect(screen.queryByText(/remembered reply\./i)).toBeNull(),
-    );
-    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe(
-      "alice",
-    );
-    expect(screen.getByRole("button", { name: /send/i })).toBeTruthy();
-  });
-
-  it("keeps the same identity and does not reseed server history on New chat", async () => {
-    render(Chat, { props: { userId: "local" } });
-    await screen.findByRole("option", { name: "Alice" });
-
-    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
-      target: { value: "Hi" },
-    });
-    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
-    await screen.findByText(/remembered reply\./i);
-
-    getChatHistory.mockClear();
-    await fireEvent.click(screen.getByRole("button", { name: /new chat/i }));
-
-    // A fresh conversation is a clean slate, not a reload of the persisted DM —
-    // re-seeding would repaint the very turns we just cleared. Same persona, so
-    // the selected-agent effect must not re-fire a history fetch.
-    await waitFor(() =>
-      expect(screen.queryByText(/remembered reply\./i)).toBeNull(),
-    );
-    expect(getChatHistory).not.toHaveBeenCalled();
   });
 });

--- a/web/src/panels/Chat.lifecycle.test.js
+++ b/web/src/panels/Chat.lifecycle.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from "@testing-library/svelte";
+import Chat from "./Chat.svelte";
+import { selection } from "../lib/selection.svelte.js";
+
+// True "exit chat" and "start new" (mirrors the CLI exit/restart used for memory
+// testing). Two affordances beside the persona switcher:
+//   - Exit     → leave the conversation entirely, back to a persona lobby (no
+//                conversation open). Survives a tab round-trip (selection sentinel).
+//   - New chat → clear the on-screen conversation but keep the SAME persona and
+//                identity/epoch, so the next turn is a fresh conversation while
+//                the agent's persisted memory is intact — the persistence test
+//                ("greet me" → New chat → "do you remember me?").
+vi.mock("../lib/api.js", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(message, status, options) {
+      super(message, options);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+  listAgents: vi.fn(),
+  sendChat: vi.fn(),
+  getChatHistory: vi.fn(),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+import { listAgents, sendChat, getChatHistory, listSessions, createSession } from "../lib/api.js";
+
+const AGENTS = [
+  { id: "alice", name: "Alice", status: "healthy" },
+  { id: "bob", name: "Bob", status: "healthy" },
+];
+
+beforeEach(() => {
+  listAgents.mockResolvedValue(AGENTS);
+  sendChat.mockResolvedValue({ reply: "Remembered reply.", reply_status: "ok" });
+  getChatHistory.mockResolvedValue({ messages: [] });
+  listSessions.mockResolvedValue({ sessions: [] });
+  createSession.mockResolvedValue({ id: "sess-new", label: "New" });
+  // Start each spec from a clean, never-chosen sticky selection.
+  selection.chatAgent = "";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  selection.chatAgent = "";
+});
+
+describe("Chat panel — exit to lobby", () => {
+  it("leaves the conversation and shows the persona lobby on Exit", async () => {
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    // In a conversation: the composer (Send) is present.
+    expect(screen.getByRole("button", { name: /send/i })).toBeTruthy();
+
+    await fireEvent.click(screen.getByRole("button", { name: /exit/i }));
+
+    // The conversation is gone: no composer, no header — just the lobby prompt
+    // and the persona picker so the operator can start a new conversation.
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+    // The lobby prompt — distinct from the picker's "Select a persona…"
+    // placeholder option (which also matches /select a persona/).
+    expect(screen.getByText(/start a conversation/i)).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: /persona/i })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("");
+  });
+
+  it("stays in the lobby after a remount once exited (survives a tab switch)", async () => {
+    const first = render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    await fireEvent.click(screen.getByRole("button", { name: /exit/i }));
+    first.unmount();
+
+    // Switching back must not silently re-enter a conversation: a deliberate exit
+    // is remembered across the unmount, so the lobby persists.
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("");
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+  });
+
+  it("starts a conversation when a persona is chosen from the lobby", async () => {
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+    await fireEvent.click(screen.getByRole("button", { name: /exit/i }));
+    expect(screen.queryByRole("button", { name: /send/i })).toBeNull();
+
+    await fireEvent.change(screen.getByRole("combobox", { name: /persona/i }), {
+      target: { value: "bob" },
+    });
+
+    // Picking a persona enters the conversation: the composer returns.
+    expect(await screen.findByRole("button", { name: /send/i })).toBeTruthy();
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe("bob");
+  });
+});
+
+describe("Chat panel — start a new conversation", () => {
+  it("clears the transcript but keeps the persona and composer on New chat", async () => {
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "Hi" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await screen.findByText(/remembered reply\./i);
+
+    await fireEvent.click(screen.getByRole("button", { name: /new chat/i }));
+
+    // The prior turn is cleared from view, but the persona and composer stay —
+    // it's a fresh conversation with the same persona, not an exit.
+    await waitFor(() =>
+      expect(screen.queryByText(/remembered reply\./i)).toBeNull(),
+    );
+    expect(screen.getByRole("combobox", { name: /persona/i }).value).toBe(
+      "alice",
+    );
+    expect(screen.getByRole("button", { name: /send/i })).toBeTruthy();
+  });
+
+  it("keeps the same identity and does not reseed server history on New chat", async () => {
+    render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+
+    await fireEvent.input(screen.getByRole("textbox", { name: /message/i }), {
+      target: { value: "Hi" },
+    });
+    await fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    await screen.findByText(/remembered reply\./i);
+
+    getChatHistory.mockClear();
+    await fireEvent.click(screen.getByRole("button", { name: /new chat/i }));
+
+    // A fresh conversation is a clean slate, not a reload of the persisted DM —
+    // re-seeding would repaint the very turns we just cleared. Same persona, so
+    // the selected-agent effect must not re-fire a history fetch.
+    await waitFor(() =>
+      expect(screen.queryByText(/remembered reply\./i)).toBeNull(),
+    );
+    expect(getChatHistory).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -8,9 +8,11 @@
   import ScopeSelector from "./ScopeSelector.svelte";
   import OnboardingEmpty from "./OnboardingEmpty.svelte";
   import PersonaHeader from "./PersonaHeader.svelte";
+  import PersonaPicker from "./PersonaPicker.svelte";
   import ChatMessage from "./ChatMessage.svelte";
   import { nav } from "../lib/nav.svelte.js";
   import { selection, pickInitialAgent } from "../lib/selection.svelte.js";
+  import { isChattable } from "../lib/agents.js";
 
   let { userId } = $props();
 
@@ -69,14 +71,7 @@
     agents.find((agent) => agent.id === selectedAgent) ?? null,
   );
 
-  // Task agents (agents.yaml `type: "task"`) run workflow steps and never hold a
-  // conversation, so a chat turn dead-ends in a timeout. They show in the picker
-  // but disabled (extends the §A agent DTO); any non-"task" type — incl. an unset
-  // one from an agent predating the field — stays chattable, so the guard can
-  // never regress a real conversation.
-  function isChattable(agent) {
-    return agent?.type !== "task";
-  }
+  // isChattable / agentLabel live in lib/agents.js, shared with PersonaPicker.
   // selectedAgentChattable gates the composer: false only when a task agent is
   // selected (reachable just when the deployment has no persona to fall back to).
   const selectedAgentChattable = $derived(isChattable(selectedAgentInfo));
@@ -239,28 +234,6 @@
       loadToken++;
     };
   });
-
-  // agentLabel is the picker's display text: the persona's name, falling back to
-  // its id when unnamed (matching the server's own display-name fallback in
-  // chat_handler.go). A non-healthy persona is annotated with its status, since
-  // only a healthy one can actually reply (the chat route 503s otherwise) — the
-  // operator sees that before spending a send, not after.
-  function agentLabel(agent) {
-    const name = agent.name ? agent.name : agent.id;
-    // Fold the role into the option so the picker reads as a cast of personas
-    // ("Ada — Researcher") rather than a list of bare names (RFC 0048 §A). Role
-    // is optional; omit the separator when unset.
-    const named = agent.role ? `${name} — ${agent.role}` : name;
-    // A task agent's row carries the why ("show but explain") rather than its
-    // health — a disabled row can't be sent regardless of status, so the reason
-    // it's disabled is the useful annotation.
-    if (!isChattable(agent)) {
-      return `${named} (task agent — not chattable)`;
-    }
-    return agent.status && agent.status !== "healthy"
-      ? `${named} (${agent.status})`
-      : named;
-  }
 
   async function send() {
     // Guard re-entrancy: the Send button is disabled while a reply is in flight,
@@ -428,55 +401,18 @@
       <code>config/agents.yaml</code> and restart), then re-check.
     </OnboardingEmpty>
   {:else}
-    <!-- Persona switcher pinned at the top of the panel (mirrors the channel
-         timeline's selector-at-top layout). It used to live at the bottom inside
-         the composer, below the transcript — once a conversation grew, the only
-         way to switch persona scrolled off-screen. Kept above the transcript and
-         outside the composer so it stays reachable however long the chat runs.
-         Still `disabled={sending}`: switching persona out from under an in-flight
-         synchronous turn would misattribute the pending reply. -->
-    <div class="persona-picker">
-      <label>
-        Persona
-        <select
-          bind:value={selectedAgent}
-          onchange={onPersonaChange}
-          disabled={sending}
-        >
-          {#if !selectedAgent}
-            <!-- Lobby placeholder: no conversation is open (a fresh start or
-                 after Exit). Disabled so it isn't a re-pickable value; it just
-                 labels the empty selection until the operator chooses a persona. -->
-            <option value="" disabled>Select a persona…</option>
-          {/if}
-          {#each agents as agent (agent.id)}
-            <option value={agent.id} disabled={!isChattable(agent)}
-              >{agentLabel(agent)}</option
-            >
-          {/each}
-        </select>
-      </label>
-      {#if selectedAgent}
-        <!-- Exit leaves the conversation for the persona lobby — the web analogue
-             of quitting the CLI chat REPL. Locked during a turn so it can't
-             strand an in-flight reply. -->
-        <button
-          type="button"
-          class="exit-chat"
-          onclick={exitChat}
-          disabled={sending}>Exit</button
-        >
-      {/if}
-    </div>
+    <!-- Persona switcher + Exit + lobby, pinned at the top of the panel so the
+         switcher stays reachable above a growing transcript (it used to be buried
+         in the composer). Extracted to PersonaPicker for the review-size cap. -->
+    <PersonaPicker
+      bind:selectedAgent
+      {agents}
+      {sending}
+      onChange={onPersonaChange}
+      onExit={exitChat}
+    />
 
-    {#if !selectedAgent}
-      <!-- Lobby: no persona selected (a fresh start, or after Exit). Prompt the
-           operator to pick one; the picker above is the entry point. No header /
-           transcript / composer until a conversation is open. -->
-      <p class="lobby" role="status">
-        Select a persona to start a conversation.
-      </p>
-    {:else}
+    {#if selectedAgent}
       <PersonaHeader
         info={selectedAgentInfo}
         {dmChannelId}

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -390,24 +390,6 @@
     selection.chatAgent = selectedAgent;
   }
 
-  // startNewChat begins a fresh conversation with the SAME persona, mirroring the
-  // CLI's exit-and-restart used to test memory: it clears the on-screen
-  // transcript (and the in-progress message / transient errors) while leaving the
-  // identity, persona, and isolation scope (session/epoch) untouched — so the
-  // agent's persisted memory is intact and the next turn tests whether it recalls
-  // the operator from MEMORY rather than from on-screen context. Bumping
-  // historyToken invalidates any in-flight seed; the reseed effect keys on
-  // selectedAgent (unchanged here), so a cleared transcript is NOT repainted from
-  // the persisted DM — a clean slate, not a reload.
-  function startNewChat() {
-    historyToken++;
-    transcript = [];
-    dmChannelId = "";
-    message = "";
-    sendError = "";
-    historyError = "";
-  }
-
   // exitChat leaves the conversation entirely, returning to the persona lobby (no
   // persona selected) so the operator can start fresh or pick a different persona
   // — the web analogue of quitting the CLI chat REPL. The null sentinel records a
@@ -475,16 +457,9 @@
         </select>
       </label>
       {#if selectedAgent}
-        <!-- New chat / Exit, the web analogue of the CLI's restart / quit (used
-             to test memory). New chat keeps the persona and identity but clears
-             the conversation; Exit leaves to the lobby. Both lock during a turn
-             so they can't strand an in-flight reply. -->
-        <button
-          type="button"
-          class="new-chat"
-          onclick={startNewChat}
-          disabled={sending}>New chat</button
-        >
+        <!-- Exit leaves the conversation for the persona lobby — the web analogue
+             of quitting the CLI chat REPL. Locked during a turn so it can't
+             strand an in-flight reply. -->
         <button
           type="button"
           class="exit-chat"

--- a/web/src/panels/Chat.svelte
+++ b/web/src/panels/Chat.svelte
@@ -389,6 +389,41 @@
     sendError = "";
     selection.chatAgent = selectedAgent;
   }
+
+  // startNewChat begins a fresh conversation with the SAME persona, mirroring the
+  // CLI's exit-and-restart used to test memory: it clears the on-screen
+  // transcript (and the in-progress message / transient errors) while leaving the
+  // identity, persona, and isolation scope (session/epoch) untouched — so the
+  // agent's persisted memory is intact and the next turn tests whether it recalls
+  // the operator from MEMORY rather than from on-screen context. Bumping
+  // historyToken invalidates any in-flight seed; the reseed effect keys on
+  // selectedAgent (unchanged here), so a cleared transcript is NOT repainted from
+  // the persisted DM — a clean slate, not a reload.
+  function startNewChat() {
+    historyToken++;
+    transcript = [];
+    dmChannelId = "";
+    message = "";
+    sendError = "";
+    historyError = "";
+  }
+
+  // exitChat leaves the conversation entirely, returning to the persona lobby (no
+  // persona selected) so the operator can start fresh or pick a different persona
+  // — the web analogue of quitting the CLI chat REPL. The null sentinel records a
+  // deliberate exit so it survives the unmount a tab switch causes (the panel
+  // would otherwise re-apply its healthy-first default on remount — see
+  // pickInitialAgent); clearing selectedAgent unmounts the composer/transcript.
+  function exitChat() {
+    selection.chatAgent = null;
+    selectedAgent = "";
+    historyToken++;
+    transcript = [];
+    dmChannelId = "";
+    message = "";
+    sendError = "";
+    historyError = "";
+  }
 </script>
 
 <section class="panel chat" aria-label="Chat">
@@ -411,11 +446,67 @@
       <code>config/agents.yaml</code> and restart), then re-check.
     </OnboardingEmpty>
   {:else}
-    <PersonaHeader
-      info={selectedAgentInfo}
-      {dmChannelId}
-      onViewInTimeline={viewInTimeline}
-    />
+    <!-- Persona switcher pinned at the top of the panel (mirrors the channel
+         timeline's selector-at-top layout). It used to live at the bottom inside
+         the composer, below the transcript — once a conversation grew, the only
+         way to switch persona scrolled off-screen. Kept above the transcript and
+         outside the composer so it stays reachable however long the chat runs.
+         Still `disabled={sending}`: switching persona out from under an in-flight
+         synchronous turn would misattribute the pending reply. -->
+    <div class="persona-picker">
+      <label>
+        Persona
+        <select
+          bind:value={selectedAgent}
+          onchange={onPersonaChange}
+          disabled={sending}
+        >
+          {#if !selectedAgent}
+            <!-- Lobby placeholder: no conversation is open (a fresh start or
+                 after Exit). Disabled so it isn't a re-pickable value; it just
+                 labels the empty selection until the operator chooses a persona. -->
+            <option value="" disabled>Select a persona…</option>
+          {/if}
+          {#each agents as agent (agent.id)}
+            <option value={agent.id} disabled={!isChattable(agent)}
+              >{agentLabel(agent)}</option
+            >
+          {/each}
+        </select>
+      </label>
+      {#if selectedAgent}
+        <!-- New chat / Exit, the web analogue of the CLI's restart / quit (used
+             to test memory). New chat keeps the persona and identity but clears
+             the conversation; Exit leaves to the lobby. Both lock during a turn
+             so they can't strand an in-flight reply. -->
+        <button
+          type="button"
+          class="new-chat"
+          onclick={startNewChat}
+          disabled={sending}>New chat</button
+        >
+        <button
+          type="button"
+          class="exit-chat"
+          onclick={exitChat}
+          disabled={sending}>Exit</button
+        >
+      {/if}
+    </div>
+
+    {#if !selectedAgent}
+      <!-- Lobby: no persona selected (a fresh start, or after Exit). Prompt the
+           operator to pick one; the picker above is the entry point. No header /
+           transcript / composer until a conversation is open. -->
+      <p class="lobby" role="status">
+        Select a persona to start a conversation.
+      </p>
+    {:else}
+      <PersonaHeader
+        info={selectedAgentInfo}
+        {dmChannelId}
+        onViewInTimeline={viewInTimeline}
+      />
 
     {#if historyLoading}
       <p class="loading" role="status">Loading conversation history…</p>
@@ -445,27 +536,12 @@
     {/if}
 
     <form class="composer" onsubmit={onSubmit}>
-      <!-- The whole composer locks while a turn is in flight (`sending`): the
-           chat call is synchronous, so leaving it editable lets the operator
-           keep typing into a message that the post-send reset then wipes, or
-           switch persona out from under the pending reply. Disabling for the
-           round-trip keeps the in-flight text and pins the turn to its persona;
-           the "Waiting for a reply…" status says why. -->
-      <label>
-        Persona
-        <select
-          bind:value={selectedAgent}
-          onchange={onPersonaChange}
-          disabled={sending}
-        >
-          {#each agents as agent (agent.id)}
-            <option value={agent.id} disabled={!isChattable(agent)}
-              >{agentLabel(agent)}</option
-            >
-          {/each}
-        </select>
-      </label>
-
+      <!-- The composer locks while a turn is in flight (`sending`): the chat call
+           is synchronous, so leaving it editable lets the operator keep typing
+           into a message that the post-send reset then wipes. Disabling for the
+           round-trip keeps the in-flight text; the "Waiting for a reply…" status
+           says why. The persona switcher (lifted to the top of the panel) is
+           disabled in lockstep so the turn stays pinned to its persona. -->
       <label>
         Message
         <textarea
@@ -496,5 +572,6 @@
         {sending ? "Sending…" : "Send"}
       </button>
     </form>
+    {/if}
   {/if}
 </section>

--- a/web/src/panels/Chat.switcher.test.js
+++ b/web/src/panels/Chat.switcher.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/svelte";
+import Chat from "./Chat.svelte";
+import { selection } from "../lib/selection.svelte.js";
+
+// The persona switcher must stay reachable while a conversation is open. It used
+// to live at the BOTTOM of the panel, inside <form class="composer">, below an
+// unbounded transcript — so once a chat grew, the only way to switch persona (or
+// "exit" the current one) was pushed off-screen and the operator had to scroll
+// past the whole transcript to reach it. The channel-timeline panel already puts
+// its selector at the top with a bounded message region; Chat must match. These
+// specs pin the switcher OUT of the composer so it sits above the transcript and
+// is always reachable. (RFC 0048.)
+vi.mock("../lib/api.js", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(message, status, options) {
+      super(message, options);
+      this.name = "ApiError";
+      this.status = status;
+    }
+  },
+  listAgents: vi.fn(),
+  sendChat: vi.fn(),
+  getChatHistory: vi.fn(),
+  listSessions: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+import { listAgents, sendChat, getChatHistory, listSessions, createSession } from "../lib/api.js";
+
+const AGENTS = [
+  { id: "alice", name: "Alice", status: "healthy" },
+  { id: "bob", name: "Bob", status: "healthy" },
+];
+
+beforeEach(() => {
+  listAgents.mockResolvedValue(AGENTS);
+  sendChat.mockResolvedValue({ reply: "Hi.", reply_status: "ok" });
+  getChatHistory.mockResolvedValue({ messages: [] });
+  listSessions.mockResolvedValue({ sessions: [] });
+  createSession.mockResolvedValue({ id: "sess-new", label: "New" });
+  selection.chatAgent = "";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("Chat panel — persona switcher placement", () => {
+  it("renders the persona switcher outside the composer form", async () => {
+    // Buried inside the composer (below the transcript) the switcher scrolls off
+    // once a chat grows. Lifting it out of the form keeps it at the top of the
+    // panel, reachable regardless of transcript length.
+    const { container } = render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+
+    const picker = screen.getByRole("combobox", { name: /persona/i });
+    const composer = container.querySelector("form.composer");
+    expect(composer).not.toBeNull();
+    expect(composer.contains(picker)).toBe(false);
+  });
+
+  it("places the persona switcher above the transcript in DOM order", async () => {
+    // The switcher must precede the conversation so a long transcript can't push
+    // it below the fold (it sits at the top like the channel-timeline selector).
+    const { container } = render(Chat, { props: { userId: "local" } });
+    await screen.findByRole("option", { name: "Alice" });
+
+    const picker = screen.getByRole("combobox", { name: /persona/i });
+    const transcript = container.querySelector(".transcript");
+    expect(transcript).not.toBeNull();
+    // compareDocumentPosition: FOLLOWING (4) means transcript comes after picker.
+    expect(
+      picker.compareDocumentPosition(transcript) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/web/src/panels/PersonaPicker.svelte
+++ b/web/src/panels/PersonaPicker.svelte
@@ -1,0 +1,56 @@
+<script>
+  // Persona switcher + Exit + lobby (extracted from Chat.svelte to keep the panel
+  // under the review-size cap, mirroring PublishComposer). Pinned at the top of
+  // the panel (like the channel timeline's selector-at-top layout) so it stays
+  // reachable above a growing transcript rather than buried in the composer.
+  //
+  // selectedAgent — bound to the panel's selection ("" = no conversation open).
+  // agents — the persona list to offer.
+  // sending — true while a turn is in flight; locks the controls so a switch or
+  //   exit can't strand the pending reply.
+  // onChange — user-driven persona change (records the sticky selection upstream).
+  // onExit — leave the conversation for the lobby.
+  import { isChattable, agentLabel } from "../lib/agents.js";
+
+  let {
+    selectedAgent = $bindable(),
+    agents,
+    sending,
+    onChange,
+    onExit,
+  } = $props();
+</script>
+
+<div class="persona-picker">
+  <label>
+    Persona
+    <select bind:value={selectedAgent} onchange={onChange} disabled={sending}>
+      {#if !selectedAgent}
+        <!-- Lobby placeholder: no conversation is open (a fresh start or after
+             Exit). Disabled so it isn't a re-pickable value; it just labels the
+             empty selection until the operator chooses a persona. -->
+        <option value="" disabled>Select a persona…</option>
+      {/if}
+      {#each agents as agent (agent.id)}
+        <option value={agent.id} disabled={!isChattable(agent)}
+          >{agentLabel(agent)}</option
+        >
+      {/each}
+    </select>
+  </label>
+  {#if selectedAgent}
+    <!-- Exit leaves the conversation for the persona lobby — the web analogue of
+         quitting the CLI chat REPL. Locked during a turn so it can't strand an
+         in-flight reply. -->
+    <button type="button" class="exit-chat" onclick={onExit} disabled={sending}
+      >Exit</button
+    >
+  {/if}
+</div>
+
+{#if !selectedAgent}
+  <!-- Lobby: no persona selected. Prompt the operator to pick one; the picker
+       above is the entry point. No header / transcript / composer until a
+       conversation is open. -->
+  <p class="lobby" role="status">Select a persona to start a conversation.</p>
+{/if}


### PR DESCRIPTION
## Summary

Fixes three web console (RFC 0048) issues reported while testing the Chat panel, plus the backend root cause behind one of them. All TDD.

### 1. Persona switcher was unreachable mid-chat
The only persona `<select>` lived at the **bottom** of the composer, below an **unbounded transcript** with no scroll region. Once a conversation grew, the switcher scrolled off-screen — there was effectively no way to switch persona or leave. The channel-timeline panel already does this right (selector at top, bounded message region); Chat was just inconsistent.

- Lifted the switcher to a top-of-panel `.persona-picker` row.
- Bounded `.transcript` as its own scroll region (`max-height:60vh; overflow-y:auto`), mirroring `.timeline`.

### 2. True "Exit" to a persona lobby
The web had no equivalent of quitting the CLI chat REPL.

- **Exit** → leaves the conversation to a persona **lobby** (no conversation open), from which you can start a conversation or switch persona. A `selection.chatAgent = null` sentinel records the deliberate exit so it survives the unmount a tab switch causes — `pickInitialAgent` stays in the lobby instead of re-applying its healthy-first default.

> A "New chat" button (clear transcript, keep persona/identity) was prototyped here and **removed** before merge — it wasn't useful in practice. Exit + persona switching cover the workflow.

> Wire note: on the web, `sendChat` sends no `chat_session_id` (the server mints one per turn), so a "conversation" is purely client-side transcript state. Memory isolation is governed by `user_id` / `epoch_id` / `session_id`, not the RFC 0016 token.

### 3. Dropdown order reshuffled on every tab switch
`InMemoryRegistry.List()` iterated the agents map, whose Go iteration order is randomized per call. Every `listAgents()` refetch (each tab mount) returned a different order, reshuffling the picker.

- Sort by ID in `List()` — one deterministic order for **every** consumer (web picker, channel decoration, CLI), fixed at the source.

## Tests
- `internal/registry`: `TestListSortedByID` (8 agents inserted out of order, asserts sorted output).
- `web/src/lib/selection.test.js`: the `null` / `""` / id resolution in `pickInitialAgent`.
- `web/src/panels/Chat.switcher.test.js`: switcher is outside the composer and precedes the transcript.
- `web/src/panels/Chat.lifecycle.test.js`: Exit→lobby, lobby survives remount, pick-from-lobby re-enters.

**Verification:** full web suite **140/140** (16 files), registry suite green, `gofmt` clean, `vite build` compiles.

## Reviewer notes
- No backend API/wire change beyond the deterministic sort in `List()`.
- jsdom can't assert real layout/scroll, so the switcher test pins DOM structure (lifted out + above transcript) rather than pixels.
- The committed `internal/ui/assets/index.html` placeholder is intentionally left untouched (release builds via `make ui` overwrite it; hashed bundles are gitignored).