### PR TITLE
docs(v036): RFC 0048 amendments — console channel creation + chat-panel retirement; RFC 0032 OQ1→3b

### DIFF
--- a/docs/rfcs/0032-channel-interaction-layer.md
+++ b/docs/rfcs/0032-channel-interaction-layer.md
@@ -211,6 +211,8 @@ Estimates are structural, not commitments — they shift with OQ resolutions.
 
 1. **Chat façade fate.** Keep `POST /api/v1/agents/{id}/chat` and `AgentService.SendChatMessage` as the ergonomic synchronous-reply path (3a), or deprecate in favor of a generic `AwaitChannelReply` primitive (3b)? Trade-off: ergonomic loss vs. one less special case. Resolution required before Phase 3 can sequence.
 
+   **Resolution (2026-06-03): 3b — deprecate the chat-specific façade.** The chat surface is being removed as a *concept* across the product: a chat is already a `dm:` channel ([chat-as-DM amendment](0011-amendment-chat-as-dm.md)), and everything it does is expressible over channel primitives. The web console retires its Chat *panel* first ([RFC 0048 amendment — Retire the Chat Panel](0048-amendment-chat-panel-retirement.md)), which removes the façade's only in-tree *browser* consumer and leaves just the Rust CLI and out-of-tree callers — precisely the precondition this branch needs. 3b is **not "no synchronous primitive"**: it keeps the generic `AwaitChannelReply` (or equivalent) on `AgentService` for one-round-trip ergonomics — the [§D tentative framing](#d-chat-façade-unification) — and re-expresses `persatrix chat` as a thin wrapper over it + channel publish. What is deprecated is the *chat-specific* REST route and gRPC RPC, on the project's standard deprecation arc (the auth checkpoint at DM creation, [§D cost 2](#d-chat-façade-unification), moves onto the generic primitive's publish-with-create path and is preserved, not dropped). This re-shapes [Phase 3](#phase-3-sketch-façade-decision-oq-1) to the **3b** branch. **Still blocking promotion:** OQ 2 (the generic primitive's reply-correlation field name rides on the `interaction_id` name decision) and OQ 3 — 3b settles *whether* the chat façade goes, not the wire-identifier shape the rest of the RFC turns on.
+
 2. **Field name.** `interaction_id` (matches RFC 0020), `conversation_id` (more familiar to API consumers), `session_id` (collides with RFC 0031 — rejected), or `thread_id` (collides with RFC 0011's reply-pointer — rejected)? Decision affects every wire surface and structured-log key.
 
 3. **Relationship to RFC 0020 internal `interaction_id`.** RFC 0020 §D defines a per-agent `interaction_id` on the `interactions` table. Is the wire id the same value (one id flowing wire→agent), or two distinct ids cross-referenced (wire id and agent-local id)? The former is simpler; the latter preserves per-agent independence if two agents need to close at different turns.
@@ -227,9 +229,11 @@ Estimates are structural, not commitments — they shift with OQ resolutions.
 
 This RFC is **🔨 Draft (stub)**. Before moving to `📋 Proposed`:
 
-1. Resolve **Open Question 1** (chat façade fate). This determines whether the RFC is additive (3a) or deprecating (3b) and re-shapes the phased plan accordingly.
-2. Resolve **Open Question 2** (field name). Touches every wire surface.
+1. ~~Resolve **Open Question 1** (chat façade fate).~~ **Resolved 2026-06-03 → 3b (deprecate the chat-specific façade)**; see [OQ 1](#open-questions). The RFC is now on the **deprecating** branch: Phase 3 sequences as 3b, keeping a generic `AwaitChannelReply` primitive and retiring the chat-specific REST/gRPC surface on the standard deprecation arc. The web console's Chat-panel retirement ([RFC 0048 amendment](0048-amendment-chat-panel-retirement.md)) removes the in-tree browser consumer first.
+2. Resolve **Open Question 2** (field name). Touches every wire surface — and, post-OQ1, the generic primitive's reply-correlation field too.
 3. Confirm **Open Question 3** (wire-id ↔ RFC 0020 per-agent id relationship) with the memory subsystem owner. Composes with [RFC 0029](0029-personal-society-storage-split.md) facade signatures.
+
+With OQ 1 settled, **OQ 2 and OQ 3 are the remaining blockers to `📋 Proposed`.**
 
 Open Questions 4–7 may be resolved during phased-implementation review without blocking promotion to `📋 Proposed`. Note that OQ 4 (generator/identifier shape) and OQ 7 (historical-row migration) gate **Phase 1 implementation** even though they do not gate proposal — they must land before Phase 1 ships, not before the document promotes.
 
@@ -240,6 +244,7 @@ This stub does not commit to wire field numbers, schema deltas, or migration seq
 - [RFC 0011 — Channels + Bridges](0011-channels-bridges.md)
 - [RFC 0011 amendment — Chat as DM](0011-amendment-chat-as-dm.md)
 - [RFC 0016 — Human-Participant Chat Interface](0016-human-participant-chat-interface.md)
+- [RFC 0048 amendment — Retire the Chat Panel](0048-amendment-chat-panel-retirement.md) — removes the façade's in-tree browser consumer; the sequencing precondition for OQ 1's 3b branch
 - [RFC 0020 — Interaction Lifecycle](0020-interaction-lifecycle.md)
 - [RFC 0029 — Personal/Society Storage Split](0029-personal-society-storage-split.md)
 - [RFC 0031 — Per-Session Namespacing for Channels and Persona Memory](0031-per-session-namespacing-channels.md)

--- a/docs/rfcs/0048-amendment-channel-creation.md
+++ b/docs/rfcs/0048-amendment-channel-creation.md
@@ -6,7 +6,7 @@
 **Trigger**: Operator/tester walk-through of the shipped Slice 1 console: a tester setting up a multi-agent scenario (the console's stated audience — *watch personas interact*) cannot create a group channel from the browser. They must either hand-edit [`config/channels.yaml`](../../config/channels.yaml) and restart the orchestrator, or leave the console for the CLI / a raw `POST`. The "watch personas interact" half of Slice 1 ([RFC 0048 §D](0048-operator-tester-web-console.md#d-slice-1--live-interactions-the-hero)) presupposes a channel exists, but the console offers no path to make one.
 **Supersedes**: nothing. It introduces the console's first **structural write** (channel creation) — a deliberate, scoped exception to [RFC 0048's Slice-1-is-read-and-interact Non-Goal](0048-operator-tester-web-console.md#non-goals) and [§F rule 5](0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility) ("write slices are auth-gated by construction"). The exception is documented as a local-mode-only carve-out (§D), ships dark behind a new toggle (§A), and **adds no backend endpoint** — it surfaces the `POST /api/v1/channels` handler that already exists ([`channel_handlers.go`](../../internal/server/channel_handlers.go) `handleCreateChannel`).
 
-> **Note on section references.** This document's own sections are lettered §A–§E. References to the base RFC are always written with the `RFC 0048` prefix (e.g. "RFC 0048 §F"). An unqualified "§D" means *this amendment's* §D.
+> **Note on section references.** This document's own sections are lettered §A–§D. References to the base RFC are always written with the `RFC 0048` prefix (e.g. "RFC 0048 §F"). An unqualified "§D" means *this amendment's* §D.
 
 ---
 

--- a/docs/rfcs/0048-amendment-channel-creation.md
+++ b/docs/rfcs/0048-amendment-channel-creation.md
@@ -1,0 +1,136 @@
+# RFC 0048 Amendment — Operator/Tester Channel Creation (Web Console)
+
+**Type**: amendment to [RFC 0048](0048-operator-tester-web-console.md) §D (Slice 1 — Live Interactions), §C (Feature-Toggle Model), §E (Later Slices — relationship to Slice 5 Control Plane), and §F (Auth/Multi-Tenancy forward-compat)
+**Status**: 📋 Proposed (one carve-out requires sign-off — see §D and [Open Questions](#open-questions))
+**Date**: 2026-06-03
+**Trigger**: Operator/tester walk-through of the shipped Slice 1 console: a tester setting up a multi-agent scenario (the console's stated audience — *watch personas interact*) cannot create a group channel from the browser. They must either hand-edit [`config/channels.yaml`](../../config/channels.yaml) and restart the orchestrator, or leave the console for the CLI / a raw `POST`. The "watch personas interact" half of Slice 1 ([RFC 0048 §D](0048-operator-tester-web-console.md#d-slice-1--live-interactions-the-hero)) presupposes a channel exists, but the console offers no path to make one.
+**Supersedes**: nothing. It introduces the console's first **structural write** (channel creation) — a deliberate, scoped exception to [RFC 0048's Slice-1-is-read-and-interact Non-Goal](0048-operator-tester-web-console.md#non-goals) and [§F rule 5](0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility) ("write slices are auth-gated by construction"). The exception is documented as a local-mode-only carve-out (§D), ships dark behind a new toggle (§A), and **adds no backend endpoint** — it surfaces the `POST /api/v1/channels` handler that already exists ([`channel_handlers.go`](../../internal/server/channel_handlers.go) `handleCreateChannel`).
+
+> **Note on section references.** This document's own sections are lettered §A–§E. References to the base RFC are always written with the `RFC 0048` prefix (e.g. "RFC 0048 §F"). An unqualified "§D" means *this amendment's* §D.
+
+---
+
+## Context
+
+Slice 1 shipped two panels — Chat and Channel Timeline — as a deliberately **read-and-interact** surface ([RFC 0048 Non-Goals](0048-operator-tester-web-console.md#non-goals): *"Slice 1 is read-and-interact, not a full control plane. Creating workflows, registering agents, and destructive admin actions are later slices, gated behind auth."*). The Channel Timeline panel ([`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte)) lists channels, renders history, polls for updates, and lets a human *publish into an existing channel*. Its empty state already tells the operator the truth: *"Chat with a persona to start a DM, or define group channels in `config/channels.yaml`, then re-check."*
+
+That empty state is the gap. The two ways to get a **group** channel today are:
+
+1. **Config-declared** — add an entry to [`config/channels.yaml`](../../config/channels.yaml) and restart the orchestrator. Members cannot change without a reboot.
+2. **REST** — `POST /api/v1/channels` ([`handleCreateChannel`](../../internal/server/channel_handlers.go)), which already exists: it takes a `name`, optional `description`, and a non-empty `members` array (each `{ id, respond? }`), derives the canonical id `group:<name>` server-side, and creates the channel + memberships atomically via `CreateChannelWithMembers`, returning `201` with the created channel.
+
+Neither is reachable from the console. For the tester the console exists to serve — *spin up a channel, drop two personas in it, watch them interact* — this forces a context switch out of the browser, which is exactly the first-contact friction [RFC 0048's Motivation](0048-operator-tester-web-console.md#motivation) exists to remove.
+
+This amendment surfaces the **existing** create endpoint in the Channel Timeline panel, behind a new dark toggle, as the console's first structural write. It is **not** the Slice 5 Control Plane — it is a single, narrow, already-exposed mutation, scoped and reconciled with the auth-forward-compat rules below. (DMs and threads are explicitly *not* in scope: both are created implicitly on first message per [RFC 0011](0011-channels-bridges.md) — a chat *is* a DM channel per the [chat-as-DM amendment](0011-amendment-chat-as-dm.md) — so there is nothing to "create" for those types.)
+
+## Why this is not a new slice
+
+A **slice** ([RFC 0048 §A](0048-operator-tester-web-console.md#a-vocabulary)) is *"a vertical, independently shippable bundle of one or more panels plus backend glue."* Channel creation is neither a panel nor a capability area — it is one write action whose natural home is the panel that already *reads* channels. Wrapping a single mutation in its own slice would over-weight it and split the channel experience across two panels (one to create, one to watch). The right unit is a **capability toggle on the existing Channel Timeline panel** (§A), not a new slice. The Slice 5 Control Plane remains the home for the *broad* write surface (workflow runs, agent registration, destructive admin); this amendment carves out the one structural write that is already exposed on the REST surface and is load-bearing for Slice 1's own reason to exist.
+
+## The amended contract
+
+### §A. A `create` capability toggle on the Channel Timeline panel (extends RFC 0048 §C)
+
+Channel creation ships **dark** behind a new per-panel capability flag, consistent with the [RFC 0048 §C](0048-operator-tester-web-console.md#c-the-feature-toggle-model) toggle model (ship dark, operator opts in, render only when both enabled *and* available).
+
+**`config/ui.yaml`** — the `channel_timeline` panel gains one nested operator knob:
+
+```yaml
+channel_timeline:
+  enabled: true          # the panel itself (Slice 1, unchanged)
+  create_enabled: false  # NEW — channel creation affordance; ships dark
+```
+
+- `create_enabled` is the **only new authored key**. Default **`false`** — creation is off until an operator opts in, exactly as Slices 2/4 ship off.
+- It is additive and namespaced under the panel it extends; the schema ([`schemas/ui.schema.json`](../../schemas/ui.schema.json)) gains `create_enabled` (boolean, default `false`) under `channel_timeline`, keeping `additionalProperties: false`.
+- As with `available`, **`create_available` is never authored** — it is runtime-derived (§D) and reported by the server.
+
+**`GET /api/v1/ui/config`** — the `channel_timeline` panel entry carries the capability as a nested object, mirroring the existing `{ enabled, available }` shape:
+
+```json
+{
+  "panels": {
+    "channel_timeline": {
+      "enabled": true,
+      "available": true,
+      "create": { "enabled": false, "available": true }
+    }
+  }
+}
+```
+
+- `create.enabled` echoes `create_enabled` from `config/ui.yaml`.
+- `create.available` is **runtime-derived** by the server (§D): the channel store must be wired, and the identity posture must permit creation. The console renders the create affordance only when `create.enabled && create.available`, exactly as it renders a panel only when `enabled && available`.
+- Older clients that do not know the `create` key ignore it and show no create affordance — the existing graceful-degradation contract ([RFC 0048 §C](0048-operator-tester-web-console.md#c-the-feature-toggle-model)) holds with no change.
+
+### §B. Client behaviour — a create affordance in the Channel Timeline panel (client-only)
+
+**No API change** — this is a render-over-existing-API addition, the same posture as the rest of Slice 1.
+
+- When `create.enabled && create.available`, the channel picker row ([`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte), beside the existing **Refresh** control) gains a **"New channel"** affordance that opens a small form:
+  - **Name** (required) — the only field the server requires. The client must **not** prepend `group:`; the server derives the canonical `group:<name>` id ([`handleCreateChannel`](../../internal/server/channel_handlers.go)), and a client-side prefix would produce `group:group:<name>`. Surface the resulting id read-only so the operator sees what will be created.
+  - **Description** (optional) — passed through verbatim.
+  - **Members** (at least one required — the endpoint rejects an empty `members` array with `400`) — a multi-select populated from `GET /api/v1/agents` (the panel already loads this list for sender decoration, [`agentsById`](../../web/src/panels/ChannelTimeline.svelte)), each with a per-member **respond policy** select (`when_mentioned` (default) / `always` / `never`, matching [RFC 0011 §D](0011-channels-bridges.md) `RespondPolicy`).
+- On submit, `POST /api/v1/channels` with `{ name, description?, members: [{ id, respond }] }`. On `201`, **reuse `loadChannels()`** to refresh the picker and select the newly-created channel (`group:<name>`) — the existing `loadChannels` already supports a one-shot "select this channel" hand-off via `nav.targetChannel` ([`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte)); the create flow sets it to the new id and reloads, landing the operator directly in the channel they just made.
+- **Error rendering rides the existing envelope.** The endpoint already returns the project's error shape: `400` (missing name / empty members), `409 CONFLICT` (a `group:<name>` already exists), `503` (store unwired). The form surfaces `err.message` verbatim through the same `ApiError` path the publish box uses, so a duplicate-name retry reads as a clear conflict, not a silent failure.
+- The create form is **collapsed by default** (an affordance, not an always-open panel) so it never crowds the newcomer's first-contact view — consistent with how the [slice1-ux amendment §C](0048-amendment-slice1-ux.md) keeps the scope control behind a disclosure.
+
+### §C. Membership is the operator's, scoped to the identity the console already carries (extends RFC 0048 §F)
+
+The creator and the channel's membership must respect the console's single identity source ([RFC 0048 §F rule 1](0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility)), not invent a second one:
+
+- Member ids come from the **agent list the server returns**, never free-typed, so the console cannot fabricate participants the backend does not know.
+- In local mode the acting principal is the `/ui/context`-derived `local` (or the [slice1-ux §E "Acting as"](0048-amendment-slice1-ux.md) override, which already exists for the publish box on this panel). The create call carries no separate identity field today — `handleCreateChannel` does not take a creator — so there is **no new identity surface**; this is purely a forward-compat note that when RFC 0039 plumbs a real principal, the creator is that principal and membership is scoped to what it can see ([RFC 0048 §F rule 2](0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility)), which is a purely additive change to the same endpoint.
+
+### §D. The carve-out: a structural write before RFC 0039 auth (the one decision needing sign-off)
+
+This is the single genuine product decision in the amendment, and it bends two base-RFC commitments. It must be signed off before implementation, exactly as the [slice1-ux §E](0048-amendment-slice1-ux.md) identity carve-out was.
+
+**What it bends.** [RFC 0048 Non-Goals](0048-operator-tester-web-console.md#non-goals) declares Slice 1 *read-and-interact, not a control plane*, and [§F rule 5](0048-operator-tester-web-console.md#f-auth--multi-tenancy-forward-compatibility) declares *write slices auth-gated by construction* (Slice 5 hard-depends on RFC 0039). Surfacing channel creation is a structural write landing before RFC 0039.
+
+**Why the carve-out is justified, and narrow:**
+
+1. **Zero new attack surface.** `POST /api/v1/channels` is **already exposed unauthenticated** on the REST surface ([RFC 0048 §Security](0048-operator-tester-web-console.md#security-considerations): the whole surface is unauthenticated until RFC 0039). Anyone who can reach the orchestrator can already create a channel with one `curl`. Surfacing it in the console changes *discoverability*, not *reachability* — the same property [RFC 0048 §Security](0048-operator-tester-web-console.md#security-considerations) already weighs for the console as a whole, and mitigates the same way (`--enable-ui` off by default, `127.0.0.1` bind, fronting proxy required for non-local exposure).
+2. **It is one narrow, non-destructive, structural write — not the control plane.** Creating a `group:<name>` channel is bounded (the global `max_channels` cap, default 50, still applies via the store) and non-destructive (no DELETE; channel deletion remains deferred per [`channel_handlers.go`](../../internal/server/channel_handlers.go)). The broad/destructive write surface (workflow runs, agent registration, deletes) stays in Slice 5 behind RFC 0039. This carve-out does not move that line for anything else.
+3. **It is load-bearing for Slice 1's own thesis.** "Watch personas interact" requires a channel with personas in it. Without browser-side creation, the console cannot deliver its own hero scenario without a CLI detour.
+
+**Guardrails (normative for the implementing PR):**
+
+- The affordance is **off by default** (`create_enabled: false`) and **gated by both** the toggle and runtime availability (§A). An operator must consciously enable it.
+- **`create.available` becomes the forward-compat hook.** Today it is `channelStore != nil`. Once `/ui/context` reports `authenticated: true` (RFC 0039), `create.available` must be driven by a **capability hint** — creation is offered only to a principal whose capabilities include channel creation, never open to any authenticated browser session. This is what keeps §D a *local-mode carve-out* rather than a permanent hole in the future auth model: pre-auth it rides the toggle on the unauthenticated localhost surface; post-auth it becomes capability-gated, and the toggle alone can never re-open it to an unprivileged principal.
+- **No new endpoint, no new privileged surface.** The console only calls the create endpoint that already exists, with the identity it already carries — exactly what a CLI caller does today. The new `/ui/config` `create` flags are read-only and ride the existing middleware.
+- **CSRF posture is inherited, and flagged.** Like the chat/publish `POST`s [RFC 0048 §Security](0048-operator-tester-web-console.md#security-considerations) already calls out, this browser-issued `POST` becomes a CSRF target the moment a fronting proxy adds cookie/session auth; the create call must send whatever CSRF mitigation the auth layer chooses, on the same footing as the existing writes.
+
+## What this amendment does NOT change
+
+- **It does not add the Slice 5 Control Plane.** This is one structural write (group-channel creation), not workflow/agent/session management or any destructive action. Slice 5 and its RFC 0039 hard-gate are untouched.
+- **It does not add a backend endpoint, store method, or schema migration.** `POST /api/v1/channels` and `CreateChannelWithMembers` already exist and are unchanged. The only backend deltas are: the `create_enabled` knob in `config/ui.yaml` + `schemas/ui.schema.json`, and the `create` object in the `/api/v1/ui/config` payload computed by [`ui_handlers.go`](../../internal/server/ui_handlers.go).
+- **It does not add DM or thread creation.** Both are implicit-on-first-message ([RFC 0011](0011-channels-bridges.md)); only `group:` channels are explicitly creatable, matching `handleCreateChannel`.
+- **It does not add channel deletion or membership editing.** Channel DELETE remains deferred; post-create membership changes (`POST /api/v1/channels/{id}/members` exists but is unwired in the console) are out of scope here.
+- **It does not add auth or multi-tenancy.** §D is a scoped local-mode carve-out that becomes capability-gated under RFC 0039; it does not ship auth itself.
+- **It does not touch the Chat panel.** Whether the console keeps a Chat panel at all is a separate question handled outside this amendment (see [Related](#related-documentation) — RFC 0032 / chat-façade fate).
+
+## Implementation
+
+Single shippable PR (the backend deltas are thin; the bulk is the Svelte form):
+
+1. **PR — Console channel creation (§A–§D).**
+   - Backend: add `create_enabled` to `config/ui.yaml` (default `false`) + `schemas/ui.schema.json`; compute and return the `channel_timeline.create` `{ enabled, available }` object in [`ui_handlers.go`](../../internal/server/ui_handlers.go) (`create.available = channelStore != nil` today; structured for the RFC 0039 capability hint per §D). No change to `handleCreateChannel`. Handler/unit test for the new config shape and availability derivation, per the [RFC 0048 test strategy](0048-operator-tester-web-console.md#test-strategy).
+   - Client: a collapsed **"New channel"** form in [`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte) (name → read-only `group:<name>` preview, optional description, member multi-select over `GET /api/v1/agents` with per-member respond policy); `POST /api/v1/channels`; on `201` reuse `loadChannels()` + `nav.targetChannel` to select the new channel; surface the server error envelope (esp. `409` duplicate). Gated on `create.enabled && create.available`. Exercised by the Svelte component tests already established for the panel.
+
+PR D's [slice1-ux §E](0048-amendment-slice1-ux.md) "Acting as" override already lives on this panel's publish box; the create form inherits the same acting principal with no extra work.
+
+## Open Questions
+
+1. **The §D carve-out — ship a structural write before RFC 0039?** Proposed: **yes**, behind a default-off toggle, justified because the endpoint is already exposed unauthenticated (zero new reachability) and creation is load-bearing for Slice 1's "watch personas interact" thesis; reconciled by making `create.available` capability-gated once auth lands. This is the one decision that needs sign-off (mirrors slice1-ux §E). *Alternative:* hold channel creation for Slice 5 and accept the CLI/`config/channels.yaml` detour until RFC 0039 — honours the Non-Goal literally at the cost of the console's own hero scenario.
+2. **Toggle shape — nested `create_enabled` on `channel_timeline`, or a flat top-level panel key?** Proposed: **nested**, because creation is a capability *of* the timeline panel, not a panel of its own (see [Why this is not a new slice](#why-this-is-not-a-new-slice)).
+3. **Member-policy default in the form — `when_mentioned`?** Proposed: **yes**, matching the server default in `handleCreateChannel` (an empty `respond` falls through to `RespondWhenMentioned`), so the form's default and the API's default never diverge.
+
+## Related documentation
+
+- [RFC 0048 — Operator & Tester Web Console](0048-operator-tester-web-console.md) — the amended spec (§C toggles, §D Slice 1, §E later slices / Control Plane, §F forward-compat, §Security).
+- [RFC 0048 amendment — Slice 1 Interaction-UX Hardening](0048-amendment-slice1-ux.md) — the sibling amendment; §E's "Acting as" override is the identity affordance this amendment's create form inherits.
+- [RFC 0011 — Channels & Bridges](0011-channels-bridges.md) — the channel model (`group`/`dm`/`thread`), `RespondPolicy`, and the store this creation writes to.
+- [RFC 0011 amendment — Chat as DM](0011-amendment-chat-as-dm.md) — why DMs/threads are implicit and not in this amendment's create scope.
+- [RFC 0032 — Wire-Level Channel Interaction Layer and Chat-Façade Unification](0032-channel-interaction-layer.md) — owns the separate question of the Chat surface's fate (its OQ 1).
+- [RFC 0039 — User Accounts & Authentication](0039-user-accounts-authentication.md) — the auth layer the §D carve-out becomes capability-gated under.

--- a/docs/rfcs/0048-amendment-chat-panel-retirement.md
+++ b/docs/rfcs/0048-amendment-chat-panel-retirement.md
@@ -24,7 +24,7 @@ The clean state is **one conversation panel**. The Channels panel already lists 
 - **It is** a console-UX consolidation: retire the Chat *panel*, absorb its DM ergonomics into the Channels panel. Client-side plus the `chat` toggle removal.
 - **It is not** removal of the chat backend façade. `POST /api/v1/agents/{id}/chat` and `GET /api/v1/agents/{id}/chat/history` (slice1-ux §B) **stay** — the consolidated panel uses them under the hood as the DM open/seed/synchronous-reply path. Whether the façade itself is ever deprecated is [RFC 0032](0032-channel-interaction-layer.md)'s OQ 1, sequenced to follow this panel retirement (this amendment removes the façade's in-tree *browser* consumer, leaving only the CLI and out-of-tree callers — which is exactly the precondition RFC 0032 §D's 3b branch needs).
 
-This is the deliberate seam the [console-now/0032-later decision] draws: **panel gone now (v0.3.x), façade fate decided later (RFC 0032, v0.4.0+).**
+This is the deliberate seam the console-now/0032-later decision draws: **panel gone now (v0.3.x), façade fate decided later (RFC 0032, v0.4.0+).**
 
 ## The amended contract
 

--- a/docs/rfcs/0048-amendment-chat-panel-retirement.md
+++ b/docs/rfcs/0048-amendment-chat-panel-retirement.md
@@ -1,0 +1,83 @@
+# RFC 0048 Amendment — Retire the Chat Panel; Consolidate on the Channels Panel
+
+**Type**: amendment to [RFC 0048](0048-operator-tester-web-console.md) §A (Vocabulary — panel set), §C (Feature-Toggle Model — `chat` toggle), and §D (Slice 1 — the two-panel structure)
+**Status**: 📋 Proposed
+**Date**: 2026-06-03
+**Trigger**: A chat *is* a `dm:` channel server-side ([chat-as-DM amendment](0011-amendment-chat-as-dm.md): `GetOrCreateDM(user_id, agent_id)`). The console therefore ships **two panels for one underlying model** — Chat (a DM with one persona) and Channel Timeline (every channel, DMs included). The [slice1-ux amendment](0048-amendment-slice1-ux.md) already documented the cost of that split (Context #7: *"the two hero panels never connect"*) and patched it with a one-way deep-link (§F). The structural fix is to stop maintaining two surfaces over one model: retire the Chat panel and let the Channels panel host both kinds of conversation.
+**Supersedes**: the two-panel framing of [RFC 0048 §D](0048-operator-tester-web-console.md#d-slice-1--live-interactions-the-hero) (Chat + Channel Timeline as separate panels). It does **not** remove any backend surface — the chat REST/gRPC façade (`POST /api/v1/agents/{id}/chat`, `GET /api/v1/agents/{id}/chat/history`, `AgentService.SendChatMessage`) is untouched here; its fate is owned by [RFC 0032](0032-channel-interaction-layer.md) (OQ 1). This amendment retires the **console panel only**.
+
+> **Note on section references.** This document's own sections are lettered §A–§D. References to the base RFC are written with the `RFC 0048` prefix. An unqualified "§B" means *this amendment's* §B.
+
+## Context
+
+[RFC 0048 §D](0048-operator-tester-web-console.md#d-slice-1--live-interactions-the-hero) shipped Slice 1 as two panels:
+
+- **Chat** ([`Chat.svelte`](../../web/src/panels/Chat.svelte)) — pick a persona, talk to it over the synchronous chat API, with a persona header (name — role — capabilities), session/epoch scope selectors, an abortable turn, transcript seeded from persisted history, and an "Acting as" identity override.
+- **Channel Timeline** ([`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte)) — pick a channel, watch its history, poll for updates, publish into it.
+
+But the [chat-as-DM amendment](0011-amendment-chat-as-dm.md) established that a chat is **not a separate transport** — it is a `dm:` channel, persisted in the same `channels` + `messages` store the timeline already reads, with the chat endpoint a synchronous-reply *façade* over it. The two panels are two views of one model. The slice1-ux amendment already felt this seam: its Context #7 names the silo as a defect and its §F bolts on a "view this conversation in the timeline" deep-link — a workaround for two panels that should be one. Subsequent fixes (the persona switcher and sticky cross-tab selection, [#512](https://github.com/mkhomutov/Persatrix/pull/512)/[#513](https://github.com/mkhomutov/Persatrix/pull/513)) are maintenance on a duplicated surface.
+
+The clean state is **one conversation panel**. The Channels panel already lists every channel (DMs included), renders history, polls, publishes, and (per the [channel-creation amendment](0048-amendment-channel-creation.md)) creates group channels. The only thing it lacks is the Chat panel's *DM-with-a-persona ergonomics*. This amendment folds those in and removes the Chat panel, so the console maintains one surface over the one model.
+
+## What this is and is not
+
+- **It is** a console-UX consolidation: retire the Chat *panel*, absorb its DM ergonomics into the Channels panel. Client-side plus the `chat` toggle removal.
+- **It is not** removal of the chat backend façade. `POST /api/v1/agents/{id}/chat` and `GET /api/v1/agents/{id}/chat/history` (slice1-ux §B) **stay** — the consolidated panel uses them under the hood as the DM open/seed/synchronous-reply path. Whether the façade itself is ever deprecated is [RFC 0032](0032-channel-interaction-layer.md)'s OQ 1, sequenced to follow this panel retirement (this amendment removes the façade's in-tree *browser* consumer, leaving only the CLI and out-of-tree callers — which is exactly the precondition RFC 0032 §D's 3b branch needs).
+
+This is the deliberate seam the [console-now/0032-later decision] draws: **panel gone now (v0.3.x), façade fate decided later (RFC 0032, v0.4.0+).**
+
+## The amended contract
+
+### §A. Panel set: `chat` is removed; Channels is the single conversation panel (amends RFC 0048 §A/§C)
+
+- [`config/ui.yaml`](../../config/ui.yaml) drops the `chat:` entry. The schema ([`schemas/ui.schema.json`](../../schemas/ui.schema.json)) needs **no change** — `panels` already accepts arbitrary panel names (`additionalProperties` → `panel`), so removal is purely deleting the authored entry (and any `chat:` override under `config/environments/*`).
+- The client allow-list `KNOWN_PANELS` ([`bootstrap.js`](../../web/src/lib/bootstrap.js)) drops the `chat` descriptor and its `#/chat` route. Per the existing [RFC 0048 §C](0048-operator-tester-web-console.md#c-the-feature-toggle-model) unknown-panel rule, a stale `chat:` still present in a deployment's `ui.yaml` is simply ignored by a client that no longer knows the panel — graceful degradation holds, so the rollout is not order-sensitive.
+- The Channels panel (`channel_timeline`) stays enabled and becomes the console's single conversation surface, hosting both **DMs** (talk to a persona) and **group channels** (watch personas interact). Renaming the panel label from "Channels" to "Conversations" is a reasonable cosmetic follow-up but is **not** required by this amendment.
+
+### §B. The Channels panel absorbs the Chat panel's DM ergonomics (client-only)
+
+**No API change.** Everything below already exists as endpoints or as components in [`Chat.svelte`](../../web/src/panels/Chat.svelte); this is a re-host, not new capability. Nothing the Chat panel did is lost:
+
+- **Start/open a DM with a persona.** The panel gains a persona entry point — the existing `PersonaPicker` filtered by `isChattable` ([`agents.js`](../../web/src/lib/agents.js)) — that resolves the persona's DM channel and selects it in the timeline. Resolution reuses slice1-ux §B's read-only `LookupDM` (via `GET /api/v1/agents/{id}/chat/history`, which returns the resolved DM channel id and seeds history); a never-messaged persona resolves to an empty conversation that the first send opens (`GetOrCreateDM`, server-side, unchanged). This is the same machinery slice1-ux §F already uses for the deep-link — now it is the panel's own entry point rather than a cross-panel hand-off.
+- **Persona legibility in DM mode.** The `PersonaHeader` (name — role — capabilities, slice1-ux §A) renders above a selected DM, so a DM is not an anonymous channel row.
+- **Synchronous send, preserved.** In DM mode the composer sends via the chat façade (`sendChat`), keeping the synchronous "thinking…" round-trip and abortable turn ([`Chat.svelte`](../../web/src/panels/Chat.svelte) `chatController`) the Chat panel had; the timeline poll keeps any follow-on agent traffic live. Group-channel mode keeps publish-and-poll (`publishMessage`) as today. (When RFC 0032 resolves the façade's fate, DM-mode send migrates to channel publish-and-await with no further console-panel change.)
+- **Scope selectors and identity override, preserved.** The `ScopeSelector` (session/epoch, slice1-ux §C) applies to DM-mode turns so the isolation-demo story RFC 0048 §D calls out survives the consolidation; the "Acting as" override (slice1-ux §E) already lives on this panel's publish box and now covers DM sends too.
+- **History continuity, preserved.** Resumed DM history comes from the channel/`chat/history` load the panel already performs; the flat-message-list + per-turn scope annotation contract from slice1-ux §B caveat 2 carries over unchanged.
+- **Sticky selection.** The cross-mount persona/channel selection ([`selection.svelte.js`](../../web/src/lib/selection.svelte.js), [#512](https://github.com/mkhomutov/Persatrix/pull/512)/[#513](https://github.com/mkhomutov/Persatrix/pull/513)) is rehomed into the single panel; with one panel there is no cross-tab persona handoff to keep in sync, which is a net simplification.
+
+### §C. The cross-panel deep-link collapses into in-panel selection (amends slice1-ux §F)
+
+slice1-ux §F's "view this conversation in the timeline" deep-link and the `nav.targetChannel` intent ([`nav.svelte.js`](../../web/src/lib/nav.svelte.js)) existed solely to bridge two panels. With one panel, "view this DM as a channel" is just selecting it — already the panel's native action. `nav.svelte.js` and the deep-link affordance are **removed**; slice1-ux §F's *intent* (a chat is a watchable channel) is satisfied more directly, by construction, because the DM and the channel are the same selection in the same panel.
+
+### §D. Empty states and onboarding merge (amends slice1-ux §F)
+
+The two panels' onboarding empty states (slice1-ux §F) merge into one. "No personas registered" and "No channels exist" become a single first-contact surface on the consolidated panel: pick a persona to start a DM, or pick/create a group channel — each still linking the [web-console quick-start](../guides/web-console.md). One panel means one dead-end-free entry point instead of two.
+
+## What this amendment does NOT change
+
+- **No backend removal.** The chat REST/gRPC façade and `chat/history` endpoint are untouched and remain the DM open/seed/synchronous-reply path. RFC 0032 owns whether they are ever deprecated.
+- **No new endpoint, store method, or schema migration.** Schema is unchanged (§A); the only config delta is deleting the `chat:` toggle entry.
+- **No change to identity, auth, or multi-tenancy posture.** The single-identity-source rule and the slice1-ux §E "Acting as" carve-out carry over verbatim onto the consolidated panel.
+- **No change to the channel-creation amendment.** This composes with the [channel-creation amendment](0048-amendment-channel-creation.md): the same Channels panel gains DM ergonomics (here) and group-channel creation (there); the two are independent and can land in either order.
+
+## Implementation
+
+Depends on the slice1-ux amendment (§A persona legibility, §B chat-history/`LookupDM`, §C scope selector, §E "Acting as", §F resolved-DM-id) being shipped — all are reused, not rebuilt.
+
+1. **PR — Consolidate conversations onto the Channels panel (§B–§D).** Client: add the persona entry point + DM mode to [`ChannelTimeline.svelte`](../../web/src/panels/ChannelTimeline.svelte) (persona picker, persona header, synchronous `sendChat` in DM mode, scope selector, abortable turn); merge onboarding empty states; rehome sticky selection; delete `nav.svelte.js` and the §F deep-link. Reuse the existing `PersonaPicker`/`PersonaHeader`/`ScopeSelector`/`ChatMessage` components from the Chat panel.
+2. **PR — Remove the Chat panel (§A).** Delete `Chat.svelte` and the `chat` entries from `KNOWN_PANELS` ([`bootstrap.js`](../../web/src/lib/bootstrap.js)), `config/ui.yaml`, and any `config/environments/*` override; drop the `#/chat` route from the shell. Exercised by the existing Svelte component/bootstrap tests (assert the panel set no longer includes `chat`; the consolidated panel covers the DM flow E2E per the [RFC 0048 test strategy](0048-operator-tester-web-console.md#test-strategy)).
+
+PR 1 must land before PR 2 so the DM flow never regresses (the consolidated panel must do everything Chat did before Chat is removed).
+
+## Open Questions
+
+1. **Panel rename.** Relabel `channel_timeline` from "Channels" to "Conversations" to reflect that it now hosts DMs + group channels? Proposed: **cosmetic follow-up, not blocking** — the `channel_timeline` panel *name* (config/route/key) stays for compatibility regardless.
+2. **DM-mode send transport.** Keep synchronous `sendChat` for DM mode now (proposed), or switch DM send to channel publish-and-poll immediately to drop the façade dependency ahead of RFC 0032? Proposed: **keep `sendChat`** — it preserves the synchronous "thinking…" ergonomics and the migration to publish-and-await is RFC 0032's to sequence; doing it here would pre-empt 0032's OQ 1 with no console-visible benefit.
+
+## Related documentation
+
+- [RFC 0048 — Operator & Tester Web Console](0048-operator-tester-web-console.md) — the amended spec (§A panel set, §C toggles, §D Slice 1).
+- [RFC 0048 amendment — Slice 1 Interaction-UX Hardening](0048-amendment-slice1-ux.md) — supplies the machinery (§A/§B/§C/§E/§F) the consolidated panel reuses; this amendment collapses its §F deep-link.
+- [RFC 0048 amendment — Operator/Tester Channel Creation](0048-amendment-channel-creation.md) — the sibling write affordance on the same panel.
+- [RFC 0011 amendment — Chat as DM](0011-amendment-chat-as-dm.md) — why a chat is a `dm:` channel, which is what makes this consolidation lossless.
+- [RFC 0032 — Wire-Level Channel Interaction Layer and Chat-Façade Unification](0032-channel-interaction-layer.md) — owns the backend chat-façade fate (OQ 1); this panel retirement is its sequencing precondition.


### PR DESCRIPTION
## What

Three **RFC-only** changes (no code, no config, no schema applied — the deltas are *specified* in the amendments) that consolidate the web console onto channels.

### 1. `0048-amendment-channel-creation.md` (new)
Surface the **existing** `POST /api/v1/channels` handler in the Channels panel so operators/testers can create group channels without editing `config/channels.yaml` + rebooting or dropping to the CLI.
- **Not a new slice** — a `create_enabled` capability toggle on the existing `channel_timeline` panel, ships dark (default off).
- **No backend endpoint** — `handleCreateChannel` already exists; group channels only (DMs/threads are implicit per RFC 0011).
- **§D carve-out (needs sign-off):** a structural write before RFC 0039 auth. Justified — the endpoint is *already* exposed unauthenticated, so this adds discoverability, not reachability — and reconciled by making `create.available` capability-gated once auth lands. Mirrors the slice1-ux §E precedent.

### 2. `0048-amendment-chat-panel-retirement.md` (new)
Retire the Chat **panel** and consolidate on the Channels panel, which absorbs "DM a persona" mode by reusing slice1-ux machinery (`LookupDM`, `PersonaHeader`, `ScopeSelector`, "Acting as", history seed).
- **Console panel only** — the chat REST/gRPC façade is untouched here.
- **Lossless** — a chat is already a `dm:` channel (chat-as-DM amendment), so nothing the Chat panel did is lost.
- Collapses slice1-ux §F's cross-panel deep-link (the DM and the channel become one selection).

### 3. `0032-channel-interaction-layer.md` (edited)
Resolve **OQ 1 → 3b**: deprecate the *chat-specific* façade, keep a generic `AwaitChannelReply` primitive for synchronous ergonomics.
- Stays **Draft** — OQ 2 (field name) and OQ 3 (wire-id ↔ RFC 0020 relationship) remain the blockers to Proposed.
- The panel retirement (#2) is the sequencing precondition: it removes the façade's in-tree browser consumer.

## Why
The console ships two panels (Chat + Channel Timeline) over one model — a chat *is* a `dm:` channel. slice1-ux already named that silo as a defect (Context #7) and patched it with a deep-link. The structural fix is one conversation surface plus a way to create channels from the browser.

## Reviewer notes
- **No code/config/schema changed** — `INDEX.md` untouched (amendments aren't listed; RFC 0032 stayed Draft).
- The **§D carve-out** in the channel-creation amendment is a genuine product decision marked Proposed/pending sign-off (like slice1-ux §E) — that's the main thing to weigh in on.