### PR TITLE
feat(v036): RFC 0030 floor-control PR 1 — floor registry + responder ordering (inert)

### DIFF
--- a/internal/channels/channels.go
+++ b/internal/channels/channels.go
@@ -151,6 +151,13 @@ var (
 	// — it is the loader's documented "use the default" sentinel
 	// honored by [ChannelRouter.SetMaxCascadeDepth].
 	ErrInvalidMaxCascadeDepth = errors.New("channels: invalid max_cascade_depth")
+	// ErrInvalidFloorTurnTimeout — a declared channel carried a negative
+	// `floor_turn_timeout_seconds:` (RFC 0030 amendment). Belt-and-
+	// suspenders for the operator who skipped `make validate` (the JSON
+	// schema's `minimum: 1` rejects this earlier). Zero is NOT an error —
+	// it is the loader's "use the default" sentinel normalized to
+	// [DefaultFloorTurnTimeoutSeconds] at load time.
+	ErrInvalidFloorTurnTimeout = errors.New("channels: invalid floor_turn_timeout_seconds")
 )
 
 // participantIDPattern is the single source of truth for legal participant

--- a/internal/channels/config.go
+++ b/internal/channels/config.go
@@ -32,11 +32,31 @@ type Config struct {
 	MaxCascadeDepth int `yaml:"max_cascade_depth"`
 }
 
+// DefaultFloorTurnTimeoutSeconds is the per-speaker turn timeout for floor
+// control when a declared channel omits `floor_turn_timeout_seconds` (RFC
+// 0030 amendment decision D2). It is distinct from the 5s
+// `channelFanoutPerRecipientTimeout` — a floor turn waits for the speaker to
+// compose and publish a full reply, which is LLM-latency-bound, so 45s is
+// the generous-but-bounded default. PR 1 only parses/normalizes the knob;
+// PR 2's serialized loop consumes it.
+const DefaultFloorTurnTimeoutSeconds = 45
+
 // ChannelConfig is a single declared group channel.
 type ChannelConfig struct {
 	Name        string         `yaml:"name"`
 	Description string         `yaml:"description"`
 	Members     []MemberConfig `yaml:"members"`
+	// FloorControl opts this channel into RFC 0030 Layer 2.5 speaker
+	// serialization: candidate responders take the floor one at a time,
+	// each reading the prior speaker's reply, instead of replying
+	// concurrently and mutually-blind. Default off in PR 1 (the schema
+	// default); PR 3 flips the resolved default on for group channels.
+	FloorControl bool `yaml:"floor_control"`
+	// FloorTurnTimeoutSeconds caps how long the floor loop waits for a
+	// single speaker's reply before advancing to the next responder
+	// (amendment D2). Zero/absent normalizes to
+	// [DefaultFloorTurnTimeoutSeconds] at load; negative is rejected.
+	FloorTurnTimeoutSeconds int `yaml:"floor_turn_timeout_seconds"`
 }
 
 // MemberConfig is a `(participant_id, respond_policy)` pair declared in
@@ -102,6 +122,16 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.MaxChannels <= 0 {
 		cfg.MaxChannels = DefaultMaxChannels
 	}
+	// Normalize the per-channel floor-turn timeout: zero/absent means "use
+	// the default" (mirroring the max_cascade_depth sentinel). Negative
+	// values are left as-is so Validate rejects them loudly rather than
+	// silently falling back. PR 1 keeps the knob inert; the normalization
+	// just guarantees PR 2's loop reads a populated value.
+	for i := range cfg.Channels {
+		if cfg.Channels[i].FloorTurnTimeoutSeconds == 0 {
+			cfg.Channels[i].FloorTurnTimeoutSeconds = DefaultFloorTurnTimeoutSeconds
+		}
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -148,6 +178,15 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("channels[%d]: duplicate name %q", i, ch.Name)
 		}
 		seenName[ch.Name] = true
+
+		// Reject a negative floor-turn timeout (the schema's `minimum: 1`
+		// catches it at `make validate`; this is the belt-and-suspenders
+		// for operators who skipped that step). Zero never reaches here —
+		// LoadConfig normalizes it to the default before Validate runs.
+		if ch.FloorTurnTimeoutSeconds < 0 {
+			return fmt.Errorf("channels[%d=%s]: %w: %d (must be >= 1)",
+				i, ch.Name, ErrInvalidFloorTurnTimeout, ch.FloorTurnTimeoutSeconds)
+		}
 
 		if len(ch.Members) == 0 {
 			return fmt.Errorf("channels[%d=%s]: at least one member required", i, ch.Name)

--- a/internal/channels/config_test.go
+++ b/internal/channels/config_test.go
@@ -176,6 +176,60 @@ func TestLoadConfig_AcceptsPositiveMaxCascadeDepth(t *testing.T) {
 	assert.Equal(t, 3, cfg.MaxCascadeDepth)
 }
 
+// TestLoadConfig_FloorControlDefaults — absent floor-control knobs default
+// to off with the canonical 45s per-turn timeout (RFC 0030 amendment D2).
+// PR 1 keeps the knobs inert: nothing consumes them yet, but the loader
+// must produce the documented defaults so PR 2's loop reads a populated
+// value rather than a zero.
+func TestLoadConfig_FloorControlDefaults(t *testing.T) {
+	body := `
+channels:
+  - name: planning
+    members: [alice, bob]
+`
+	cfg, err := LoadConfig(writeYAML(t, body))
+	require.NoError(t, err)
+	require.Len(t, cfg.Channels, 1)
+	assert.False(t, cfg.Channels[0].FloorControl,
+		"floor_control defaults off in PR 1 (flipped on for groups in PR 3)")
+	assert.Equal(t, DefaultFloorTurnTimeoutSeconds, cfg.Channels[0].FloorTurnTimeoutSeconds,
+		"absent floor_turn_timeout_seconds normalizes to the 45s default")
+}
+
+// TestLoadConfig_FloorControlExplicit — operators can opt a channel in and
+// override the per-turn timeout; both pass through to the parsed config.
+func TestLoadConfig_FloorControlExplicit(t *testing.T) {
+	body := `
+channels:
+  - name: planning
+    floor_control: true
+    floor_turn_timeout_seconds: 30
+    members: [alice, bob]
+`
+	cfg, err := LoadConfig(writeYAML(t, body))
+	require.NoError(t, err)
+	require.Len(t, cfg.Channels, 1)
+	assert.True(t, cfg.Channels[0].FloorControl)
+	assert.Equal(t, 30, cfg.Channels[0].FloorTurnTimeoutSeconds)
+}
+
+// TestLoadConfig_RejectsNegativeFloorTurnTimeout — a negative per-turn
+// timeout is an operator typo; reject it at the loader (belt-and-suspenders
+// for the `make validate` minimum:1 schema check), mirroring the
+// max_cascade_depth posture. Zero is the "use default" sentinel and is
+// accepted (normalized to 45).
+func TestLoadConfig_RejectsNegativeFloorTurnTimeout(t *testing.T) {
+	body := `
+channels:
+  - name: planning
+    floor_turn_timeout_seconds: -1
+    members: [alice]
+`
+	_, err := LoadConfig(writeYAML(t, body))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFloorTurnTimeout)
+}
+
 // TestLoadConfig_RejectsBadChannelName pins PR #231 review Should-Fix #6:
 // the loader's Validate() now compiles and applies the same `name` regex the
 // JSON Schema does (`schemas/channel.schema.json` →

--- a/internal/channels/floor_control.go
+++ b/internal/channels/floor_control.go
@@ -48,6 +48,12 @@ func newFloorRegistry() *floorRegistry {
 // available state) on first use. Guarded by the registry mutex; the
 // returned chan is then operated on outside the lock so a parked [acquire]
 // never holds the registry mutex.
+//
+// Entries are never evicted, but the key space is `channel_id` — bounded by
+// the declared channel count (itself capped by `max_channels`) — so the map
+// cannot grow without bound. The post-v0.3.6 re-key onto `interaction_id`
+// noted on [floorRegistry] would make the key space unbounded; that follow-up
+// must add eviction (e.g. drop a floor once its round completes).
 func (f *floorRegistry) floorFor(channelID string) chan struct{} {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -63,6 +69,12 @@ func (f *floorRegistry) floorFor(channelID string) chan struct{} {
 // acquire blocks until this channel's floor is free, then takes it. Pair
 // every acquire with exactly one [release] (the redundant-release case is a
 // safe no-op).
+//
+// acquire takes no [context.Context] and so cannot be cancelled or
+// time-bounded: it parks until a [release] frees the floor. That is
+// deliberate for the primitive — the per-turn timeout and any cancellation
+// are the caller's responsibility (PR 2's serialized loop wraps the round in
+// the `floor_turn_timeout_seconds` budget), not the registry's.
 func (f *floorRegistry) acquire(channelID string) {
 	<-f.floorFor(channelID)
 }
@@ -97,10 +109,21 @@ func (f *floorRegistry) release(channelID string) {
 // and `never` members are excluded from both sets (they read history on
 // demand and never receive a dispatch, matching today's fanout).
 //
-// Correctness does not depend on perfectly replicating the receiver-side
-// response gate: a candidate the gate ultimately suppresses simply yields no
-// reply and the per-turn timeout advances the loop (amendment §"Candidate
-// responder set vs. delivery").
+// This candidate set is a *superset* of the receiver-side response gate's
+// respond-true set ([agents/response_gate.py] — always; when_mentioned &
+// mentioned; when_mentioned & thread-reply-to-self), which is what matters
+// for correctness in both directions:
+//   - No false negatives: a member the gate would let respond is never
+//     dropped from the round, so nobody is silently denied the floor. The
+//     thread-reply-to-self branch looks looser here (`threadParentSenderID
+//     != ""` vs. the gate's `thread_id != "" && parent == self`), but the
+//     router only resolves a non-empty `threadParentSenderID` for thread
+//     events ([ChannelRouter.resolveThreadParentSenderID] returns "" when
+//     `msg.ThreadID == ""`), so the two conditions are equivalent in
+//     practice — do not let that invariant rot.
+//   - False positives are harmless: a candidate the gate ultimately
+//     suppresses simply yields no reply and the per-turn timeout advances
+//     the loop (amendment §"Candidate responder set vs. delivery").
 func orderResponders(members []Member, msg ChannelMessage, threadParentSenderID string) (responders, nonResponders []Member) {
 	mentioned := make(map[string]bool, len(msg.Mentions))
 	for _, id := range msg.Mentions {

--- a/internal/channels/floor_control.go
+++ b/internal/channels/floor_control.go
@@ -1,0 +1,146 @@
+package channels
+
+import "sync"
+
+// floor_control.go — RFC 0030 Layer 2.5 (floor control / speaker
+// serialization). This file ships the *inert* primitives in PR 1: the
+// per-channel floor registry and the responder-ordering helper, both with
+// full unit coverage and no call site yet. PR 2 rewires
+// [ChannelRouter.fanout] to drive a serialized speaker round through these;
+// PR 3 flips the per-channel `floor_control` flag default on for group
+// channels. See `docs/rfcs/0030-amendment-floor-control-pr-plan.md`.
+//
+// Why serialize at all: today a channel message is fanned out to every
+// responder concurrently and fire-and-forget ([fanout.go]), so each persona
+// composes against a transcript containing none of its peers' replies — N
+// overlapping, mutually-blind replies to one stimulus. Floor control makes
+// the responders take the floor one at a time, each reading the prior
+// speaker's reply.
+
+// floorRegistry is the orchestrator-side, in-process table that grants at
+// most one floor round per channel at a time. It mirrors [replyWaiter]'s
+// single-replica constraint: the floor state lives in this process, so a
+// horizontally-scaled orchestrator where an agent's REST publish lands on a
+// different replica than the one holding the floor would not serialize
+// correctly — single-replica is the v0.3.x contract (see the replyWaiter
+// doc-string for the same caveat).
+//
+// Keyed by `channel_id` per amendment decision D5 — the floor is a property
+// of the channel, not of any one stimulus or interaction id (RFC 0020 is not
+// wired Go-side; re-keying onto `interaction_id` is a post-v0.3.6 follow-up).
+//
+// Each channel's floor is a capacity-1 buffered chan used as a mutex: a
+// single token in the chan means "available". [acquire] receives the token
+// (blocking while another round holds it); [release] returns it. Using a
+// token chan rather than a [sync.Mutex] makes [release] idempotent — a
+// redundant release is a non-blocking no-op rather than a panic, so the
+// loop's deferred release is safe even on paths that already released.
+type floorRegistry struct {
+	mu     sync.Mutex
+	floors map[string]chan struct{}
+}
+
+func newFloorRegistry() *floorRegistry {
+	return &floorRegistry{floors: make(map[string]chan struct{})}
+}
+
+// floorFor returns the per-channel token chan, creating it (in the
+// available state) on first use. Guarded by the registry mutex; the
+// returned chan is then operated on outside the lock so a parked [acquire]
+// never holds the registry mutex.
+func (f *floorRegistry) floorFor(channelID string) chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch, ok := f.floors[channelID]
+	if !ok {
+		ch = make(chan struct{}, 1)
+		ch <- struct{}{} // seed the available token
+		f.floors[channelID] = ch
+	}
+	return ch
+}
+
+// acquire blocks until this channel's floor is free, then takes it. Pair
+// every acquire with exactly one [release] (the redundant-release case is a
+// safe no-op).
+func (f *floorRegistry) acquire(channelID string) {
+	<-f.floorFor(channelID)
+}
+
+// release returns the floor to the available state. Idempotent: releasing
+// an already-free floor is a no-op rather than a panic, so a deferred
+// release on a path that already released cannot double-fault.
+func (f *floorRegistry) release(channelID string) {
+	ch := f.floorFor(channelID)
+	select {
+	case ch <- struct{}{}:
+	default:
+		// Already available — redundant release, ignore.
+	}
+}
+
+// orderResponders splits a channel's membership into the **candidate
+// responders** (which enter the serialized floor round) and the
+// **non-responders** (delivered fire-and-forget for memory ingestion only,
+// off the critical path), and orders the responders mentioned-first then by
+// the incoming member order (amendment decision D3 — the round order is
+// frozen at round start with a stable tie-break).
+//
+// `members` is expected in the deterministic [ChannelStore.GetMembers]
+// order (joined_at ASC, participant_id ASC); the helper preserves that
+// order within each group rather than re-sorting.
+//
+// Candidate responders = `always` members ∪ `when_mentioned` members that
+// are mentioned ∪ thread-reply-to-self members (a `when_mentioned` member
+// whose own message this stimulus is a thread reply to — `threadParentSenderID`
+// pre-resolved by the router). The sender is always filtered (no self-reply)
+// and `never` members are excluded from both sets (they read history on
+// demand and never receive a dispatch, matching today's fanout).
+//
+// Correctness does not depend on perfectly replicating the receiver-side
+// response gate: a candidate the gate ultimately suppresses simply yields no
+// reply and the per-turn timeout advances the loop (amendment §"Candidate
+// responder set vs. delivery").
+func orderResponders(members []Member, msg ChannelMessage, threadParentSenderID string) (responders, nonResponders []Member) {
+	mentioned := make(map[string]bool, len(msg.Mentions))
+	for _, id := range msg.Mentions {
+		mentioned[id] = true
+	}
+
+	// Split into mentioned vs. unmentioned responders so the final
+	// concatenation is mentioned-first while preserving member order
+	// within each group (stable tie-break).
+	var mentionedResp, unmentionedResp []Member
+	for _, m := range members {
+		if m.ParticipantID == msg.SenderID {
+			continue // never reply to self
+		}
+		if m.RespondPolicy == RespondNever {
+			continue // read-on-demand; no dispatch, off both sets
+		}
+
+		isMentioned := mentioned[m.ParticipantID]
+		isCandidate := false
+		switch m.RespondPolicy {
+		case RespondAlways:
+			isCandidate = true
+		case RespondWhenMentioned:
+			// Mentioned, or a thread reply to a message this member sent.
+			isCandidate = isMentioned ||
+				(threadParentSenderID != "" && m.ParticipantID == threadParentSenderID)
+		}
+
+		if !isCandidate {
+			nonResponders = append(nonResponders, m)
+			continue
+		}
+		if isMentioned {
+			mentionedResp = append(mentionedResp, m)
+		} else {
+			unmentionedResp = append(unmentionedResp, m)
+		}
+	}
+
+	responders = append(mentionedResp, unmentionedResp...)
+	return responders, nonResponders
+}

--- a/internal/channels/floor_control_test.go
+++ b/internal/channels/floor_control_test.go
@@ -1,0 +1,213 @@
+package channels
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// member is a tiny constructor so the ordering tests read as a list of
+// `(id, policy)` pairs without the JoinedAt noise — JoinedAt is the
+// store-side tiebreak already reflected in the slice order the helper
+// receives, so the tests pass members in the order GetMembers would
+// return them and assert the helper preserves it.
+func member(id string, policy RespondPolicy) Member {
+	return Member{ParticipantID: id, RespondPolicy: policy}
+}
+
+// ---------------------------------------------------------------------------
+// floorRegistry — per-channel mutual exclusion (D5: keyed by channel_id)
+// ---------------------------------------------------------------------------
+
+// TestFloorRegistry_AcquireBlocksUntilRelease pins the core contract: a
+// second acquire on the same channel parks until the first release, so at
+// most one floor round runs per channel at a time.
+func TestFloorRegistry_AcquireBlocksUntilRelease(t *testing.T) {
+	reg := newFloorRegistry()
+	reg.acquire("group:planning")
+
+	acquired := make(chan struct{})
+	go func() {
+		reg.acquire("group:planning")
+		close(acquired)
+	}()
+
+	// The second acquire must still be parked while we hold the floor.
+	select {
+	case <-acquired:
+		t.Fatal("second acquire returned while the floor was held")
+	case <-time.After(50 * time.Millisecond):
+		// expected: still blocked
+	}
+
+	reg.release("group:planning")
+
+	select {
+	case <-acquired:
+		// expected: release handed the floor to the waiter
+	case <-time.After(time.Second):
+		t.Fatal("second acquire did not unblock after release")
+	}
+	reg.release("group:planning")
+}
+
+// TestFloorRegistry_DistinctChannelsIndependent — a held floor on one
+// channel must not block acquiring a different channel's floor.
+func TestFloorRegistry_DistinctChannelsIndependent(t *testing.T) {
+	reg := newFloorRegistry()
+	reg.acquire("group:planning")
+
+	done := make(chan struct{})
+	go func() {
+		reg.acquire("group:design") // different channel — must not block
+		reg.release("group:design")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// expected: independent channel acquired immediately
+	case <-time.After(time.Second):
+		t.Fatal("acquire on a distinct channel blocked behind an unrelated floor")
+	}
+	reg.release("group:planning")
+}
+
+// TestFloorRegistry_ReleaseIdempotent — releasing a floor that is already
+// free is a safe no-op (the loop's deferred release must not panic if the
+// round already released on a prior path).
+func TestFloorRegistry_ReleaseIdempotent(t *testing.T) {
+	reg := newFloorRegistry()
+	reg.acquire("group:planning")
+	reg.release("group:planning")
+	assert.NotPanics(t, func() { reg.release("group:planning") },
+		"double release must be a safe no-op")
+
+	// The floor is still acquirable after the redundant release.
+	acquired := make(chan struct{})
+	go func() {
+		reg.acquire("group:planning")
+		close(acquired)
+	}()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("floor not acquirable after idempotent release")
+	}
+	reg.release("group:planning")
+}
+
+// ---------------------------------------------------------------------------
+// orderResponders — candidate split + mentioned-first ordering (D3)
+// ---------------------------------------------------------------------------
+
+func ids(members []Member) []string {
+	out := make([]string, len(members))
+	for i, m := range members {
+		out[i] = m.ParticipantID
+	}
+	return out
+}
+
+// TestOrderResponders_AlwaysAreResponders — `always` members are candidate
+// responders; the sender is filtered; `never` is excluded from both sets.
+func TestOrderResponders_AlwaysAreResponders(t *testing.T) {
+	members := []Member{
+		member("alice", RespondAlways),
+		member("bob", RespondAlways),
+		member("muted", RespondNever),
+		member("user", RespondAlways), // the sender
+	}
+	msg := ChannelMessage{SenderID: "user"}
+
+	responders, nonResponders := orderResponders(members, msg, "")
+
+	assert.Equal(t, []string{"alice", "bob"}, ids(responders),
+		"always members (minus sender) are responders in member order")
+	assert.Empty(t, nonResponders,
+		"never is excluded entirely; no when_mentioned-not-mentioned members here")
+}
+
+// TestOrderResponders_WhenMentionedSplit — a `when_mentioned` member that is
+// mentioned becomes a responder; one that is not becomes a non-responder
+// (delivered for ingestion only, off the floor queue).
+func TestOrderResponders_WhenMentionedSplit(t *testing.T) {
+	members := []Member{
+		member("alice", RespondWhenMentioned),
+		member("bob", RespondWhenMentioned),
+	}
+	msg := ChannelMessage{SenderID: "user", Mentions: []string{"bob"}}
+
+	responders, nonResponders := orderResponders(members, msg, "")
+
+	assert.Equal(t, []string{"bob"}, ids(responders))
+	assert.Equal(t, []string{"alice"}, ids(nonResponders))
+}
+
+// TestOrderResponders_MentionedFirst — among responders, mentioned members
+// take the floor before unmentioned `always` members; within each group the
+// original member order is preserved (D3 stable tie-break).
+func TestOrderResponders_MentionedFirst(t *testing.T) {
+	members := []Member{
+		member("alice", RespondAlways),        // always, not mentioned
+		member("bob", RespondAlways),          // always, mentioned
+		member("carol", RespondWhenMentioned), // when_mentioned, mentioned
+		member("dave", RespondAlways),         // always, not mentioned
+	}
+	msg := ChannelMessage{SenderID: "user", Mentions: []string{"bob", "carol"}}
+
+	responders, _ := orderResponders(members, msg, "")
+
+	// mentioned-first (bob, carol in member order), then the rest in
+	// member order (alice, dave).
+	assert.Equal(t, []string{"bob", "carol", "alice", "dave"}, ids(responders))
+}
+
+// TestOrderResponders_ThreadReplyToSelf — a `when_mentioned` member who is
+// not mentioned is still a responder when the stimulus is a thread reply to
+// a message they sent (mirrors the receiver gate's thread-reply-to-self
+// branch). They are unmentioned, so they order after mentioned responders.
+func TestOrderResponders_ThreadReplyToSelf(t *testing.T) {
+	members := []Member{
+		member("alice", RespondWhenMentioned),
+		member("bob", RespondWhenMentioned),
+	}
+	// Reply in a thread whose parent was sent by alice; bob is mentioned.
+	msg := ChannelMessage{
+		SenderID: "user",
+		ThreadID: "m-parent",
+		Mentions: []string{"bob"},
+	}
+
+	responders, nonResponders := orderResponders(members, msg, "alice")
+
+	// bob mentioned → first; alice thread-reply-to-self → responder, after.
+	assert.Equal(t, []string{"bob", "alice"}, ids(responders))
+	assert.Empty(t, nonResponders)
+}
+
+// TestOrderResponders_SingleResponderAndEmpty — degenerate inputs the loop
+// must tolerate: a lone responder and a members slice that yields none.
+func TestOrderResponders_SingleResponderAndEmpty(t *testing.T) {
+	single := []Member{member("alice", RespondAlways), member("user", RespondAlways)}
+	responders, nonResponders := orderResponders(single, ChannelMessage{SenderID: "user"}, "")
+	assert.Equal(t, []string{"alice"}, ids(responders))
+	assert.Empty(t, nonResponders)
+
+	// Only the sender and a muted member → no responders, no non-responders.
+	none := []Member{member("user", RespondAlways), member("muted", RespondNever)}
+	responders, nonResponders = orderResponders(none, ChannelMessage{SenderID: "user"}, "")
+	assert.Empty(t, responders)
+	assert.Empty(t, nonResponders)
+
+	// Empty membership slice.
+	responders, nonResponders = orderResponders(nil, ChannelMessage{SenderID: "user"}, "")
+	assert.Empty(t, responders)
+	assert.Empty(t, nonResponders)
+}
+
+func TestNewFloorRegistry_NotNil(t *testing.T) {
+	require.NotNil(t, newFloorRegistry())
+}

--- a/schemas/channel.schema.json
+++ b/schemas/channel.schema.json
@@ -35,6 +35,17 @@
           "description": "Group-channel name. Canonical address is `group:<name>`."
         },
         "description": { "type": "string" },
+        "floor_control": {
+          "type": "boolean",
+          "default": false,
+          "description": "Opt this channel into RFC 0030 Layer 2.5 speaker serialization (floor control): candidate responders take the floor one at a time, each reading the prior speaker's reply, instead of replying concurrently and mutually-blind. Default off; the resolved default flips on for group channels in the floor-control PR 3. DMs (single responder) are unaffected."
+        },
+        "floor_turn_timeout_seconds": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 45,
+          "description": "Per-speaker turn timeout for floor control (RFC 0030 amendment decision D2): how long the serialized loop waits for one speaker's reply before advancing to the next responder. Distinct from the 5s per-recipient fanout timeout — a floor turn is LLM-latency-bound. Absent uses the 45s default; the Go loader treats a zero/absent value as 'use the default' and rejects negatives at load time."
+        },
         "members": {
           "type": "array",
           "minItems": 1,


### PR DESCRIPTION
## What & why

PR 1 of the four-PR floor-control workstream from [`0030-amendment-floor-control-pr-plan.md`](docs/rfcs/0030-amendment-floor-control-pr-plan.md) (folded into [v0.3.6](docs/v0.3.6-plan.md) as a release blocker — under today's concurrent fanout the web console's channel timeline renders N mutually-blind personas "shouting" over one stimulus).

This PR lands the **pure data structures with full unit coverage, before any `fanout` rewire**, so PR 2's load-bearing diff stays reviewable. It is **inert**: nothing references the new helpers yet and the per-channel flag defaults off — **no behaviour change**.

## Changes

- **`internal/channels/floor_control.go`** (new):
  - `floorRegistry` — per-channel mutual exclusion keyed by `channel_id` (amendment **D5**), mirroring `replyWaiter`'s in-process single-replica constraint. Built on a cap-1 token chan so `release()` is **idempotent** (a redundant deferred release is a no-op, not a panic).
  - `orderResponders` — splits **candidate responders** (`always` ∪ `when_mentioned`&mentioned ∪ thread-reply-to-self) from **non-responders**, orders responders **mentioned-first then by `GetMembers` order**, frozen at round start (amendment **D3**). Sender filtered; `never` excluded from both sets.
- **`internal/channels/config.go`** — per-channel `FloorControl` (default off) + `FloorTurnTimeoutSeconds` (default 45 — amendment **D2**) knobs; zero→default at load, negatives rejected at `Validate`.
- **`schemas/channel.schema.json`** — `floor_control` (bool) + `floor_turn_timeout_seconds` (int ≥ 1) per-channel keys.

## Tests (TDD — written first, red→green)

- **Registry**: acquire blocks a second acquire until release; distinct channels independent; release idempotent.
- **Ordering**: always-are-responders + sender/never filtered; when_mentioned split; mentioned-first + stable tie-break; thread-reply-to-self; single-responder & empty degenerate cases.
- **Config**: defaults (off / 45s), explicit override, negative-timeout rejection.

## Verification

- `go test ./internal/channels/...` ✅ (incl. `-race` on the new tests)
- `go vet ./internal/channels/` ✅ · `go build ./...` ✅ · `gofmt` clean
- `make validate` (schema) ✅ — positive + `timeout:0` rejection confirmed
- `scripts/checks/file_size.py` ✅
- No production call site references the new helpers (acceptance criterion).

## Scope / sequencing

Per the [PR plan](docs/rfcs/0030-amendment-floor-control-pr-plan.md): **PR 1 (this) → PR 2** (rewire `fanout` into the serialized loop behind the flag) **→ PR 3** (default on for groups + docs + manual test) **→ PR 4** (telemetry). Amendment stays 📋 Proposed until PR 3.