### PR TITLE
feat(v037): RFC 0034 P2 PR 2 — multi-persona fetch-cache correctness

### DIFF
--- a/agents/persona_runtime/conversation_window.py
+++ b/agents/persona_runtime/conversation_window.py
@@ -41,9 +41,12 @@ Design anchors (see ``docs/rfcs/0034-persona-conversational-working-memory.md``)
   separately from the RFC 0017 system-prompt memory budget. Per-turn
   admission applies token-overflow FIFO first, then count-overflow FIFO
   (OQ #2 resolution 2a — tighter bound wins).
-* **§F — caching.** An in-process cache keyed by ``(channel_id,
-  message_id)`` skips the network fetch when the same event is seen
-  twice (retries, sub-agent return paths). Steady-state turn-over-turn
+* **§F — caching.** An in-process cache keyed by ``(channel_id, limit)``
+  skips the network fetch when the same event is seen twice at the same
+  fetch limit (retries, sub-agent return paths). ``limit`` is in the key
+  so a group channel's small-``max_turns`` persona cannot serve an
+  undersized window to a large-``max_turns`` peer reacting to the same
+  message (RFC 0034 Phase 2 correctness). Steady-state turn-over-turn
   hit rate is low *by design* — the cache key advances with every
   inbound message; Phase 3 telemetry is the arbiter for any re-spec
   (RFC §F "Known gap" framing (a)). On any fetch failure the window
@@ -155,32 +158,28 @@ def resolve_conversation_window_config(
 
 # ─── In-process fetch cache (RFC §F) ───────────────────────
 #
-# Maps ``channel_id`` to the last ``(message_id, raw_fetched_rows)`` seen
-# for that channel. A call whose ``event.message_id`` matches the cached
-# id skips the network fetch and re-uses the raw rows. One entry per
-# channel — a newer ``message_id`` overwrites it (the "cheapest possible"
-# invalidation RFC §F specifies). Raw rows are stored *pre*-role-mapping,
-# so role mapping (`sender_id == agent_id`) is re-applied per call and
-# the cache is agent-independent.
+# Maps ``(channel_id, limit)`` to the last ``(message_id, raw_rows)`` seen
+# for that channel *at that fetch limit*. A call whose ``event.message_id``
+# matches the cached id **and** whose fetch limit matches skips the network
+# fetch and re-uses the raw rows; a newer ``message_id`` overwrites the
+# entry (the "cheapest possible" invalidation RFC §F specifies). Raw rows
+# are stored *pre*-role-mapping, so the cache is agent-independent.
 #
-# Eviction: there is none. A channel seen once keeps its entry for the
-# life of the process, so the dict grows with the number of *distinct*
-# channels a long-running orchestrator ever serves — not the number
-# concurrently active — and each entry holds up to ``max_turns + 1`` raw
-# row dicts. Acceptable for the Phase 1 DM dogfood (a handful of
-# channels); RFC 0034 Phase 3, which owns the cache-hit-rate telemetry,
-# is the place to add an LRU bound once a real channel-count
-# distribution exists to size it against.
+# ``limit`` is in the key for RFC 0034 Phase 2 multi-persona correctness
+# ([0034 PR plan §Future Phases carry-forward]). A DM channel has one
+# persona, so in Phase 1 the same ``(channel_id, message_id)`` was only
+# ever processed under one config and a constant fetch limit — keying on
+# ``channel_id`` alone was sound. A *group* channel hosts multiple personas
+# with independent configs reacting to the same message; under that old key
+# a small-``max_turns`` persona would prime the cache with an undersized
+# row set and serve it to a large-``max_turns`` peer, silently shrinking
+# its window. Keying on ``(channel_id, limit)`` makes a differing limit a
+# miss → the large caller refetches; the same-limit retry path still hits.
 #
-# Phase 2 caveat: the cached rows carry the *first* caller's
-# ``max_turns + 1`` fetch limit. A DM channel has exactly one persona, so
-# in Phase 1 the same ``(channel_id, message_id)`` is only ever processed
-# under one config and that limit is constant. Once a channel can host
-# multiple personas with independent ``conversation_window`` configs
-# (RFC 0034 Phase 2 — group channels), a small-``max_turns`` persona
-# could serve an undersized window to a large-``max_turns`` peer; Phase 2
-# must key the cache on the fetch limit or bypass it for such channels.
-_WINDOW_CACHE: dict[str, tuple[str, list[dict[str, Any]]]] = {}
+# Eviction: there is none — the dict grows with the number of *distinct*
+# ``(channel, limit)`` pairs ever served. Fine at demo scale; RFC 0034
+# Phase 3 (hit-rate telemetry) adds an LRU bound sized from real data.
+_WINDOW_CACHE: dict[tuple[str, int], tuple[str, list[dict[str, Any]]]] = {}
 
 
 # ``_PromptAssemblyMixin._format_event`` is a bound method on the persona
@@ -275,8 +274,9 @@ async def _fetch_window(
     is its own already-logged best-effort failure and degrades to
     ``None`` silently (no double log).
     """
+    cache_key = (channel_id, limit)
     if message_id is not None:
-        cached = _WINDOW_CACHE.get(channel_id)
+        cached = _WINDOW_CACHE.get(cache_key)
         if cached is not None and cached[0] == message_id:
             return cached[1]
 
@@ -298,7 +298,7 @@ async def _fetch_window(
         return None
 
     if message_id is not None:
-        _WINDOW_CACHE[channel_id] = (message_id, raw)
+        _WINDOW_CACHE[cache_key] = (message_id, raw)
     return raw
 
 

--- a/tests/unit/python/_conversation_window_test_helpers.py
+++ b/tests/unit/python/_conversation_window_test_helpers.py
@@ -95,10 +95,11 @@ async def _build(
     *,
     event: AgentEvent | None = None,
     config: ConversationWindowConfig | None = None,
+    agent_id: str = _AGENT_ID,
 ) -> list[dict[str, Any]]:
     return await build_conversation_messages(
         event=event or _event(),
-        agent_id=_AGENT_ID,
+        agent_id=agent_id,
         history_fetcher=fetcher,
         current_user_message=_CURRENT,
         config=config or ConversationWindowConfig(),

--- a/tests/unit/python/test_conversation_window.py
+++ b/tests/unit/python/test_conversation_window.py
@@ -353,6 +353,60 @@ class TestCache:
         assert "older window" in first[0]["content"]
         assert "newer window" in second[0]["content"]
 
+    async def test_same_limit_repeat_hits_cache(self):
+        """Same ``(channel_id, message_id)`` *and* the same fetch limit is
+        still one fetch — the §F retry / sub-agent-return optimization is
+        preserved by the PR 2 multi-persona cache-key change."""
+        event = _event(message_id="m-same")
+        cfg = ConversationWindowConfig(max_turns=4)
+        fetcher = _FakeChannelHistoryFetcher([_row("m1", "user", "cached")])
+        first = await _build(fetcher, event=event, config=cfg)
+        second = await _build(fetcher, event=event, config=cfg)
+        assert len(fetcher.calls) == 1
+        assert first == second
+
+    async def test_larger_max_turns_is_not_served_undersized_cached_window(self):
+        """RFC 0034 Phase 2 multi-persona cache-key fix (0034 PR plan
+        §Future Phases carry-forward).
+
+        Two personas with independent ``conversation_window`` configs share
+        one group channel and react to the *same* inbound message. A
+        small-``max_turns`` persona primes the cache with a small fetch
+        ``limit``; a large-``max_turns`` peer reacting to the same
+        ``(channel_id, message_id)`` must **not** be served that undersized
+        cached window. It refetches at its own larger limit and gets a
+        full-size transcript.
+
+        The fake fetcher honours the limit by returning a different row set
+        per call (a real history endpoint caps at ``limit``); the bug — a
+        cache keyed on ``channel_id`` alone — would serve the small caller's
+        3 rows to the large caller.
+        """
+        small_rows = [_row(f"b{i}", "user", f"small-{i}") for i in range(3)]
+        large_rows = [_row(f"b{i}", "user", f"big-{i}") for i in range(21)]
+        fetcher = _FakeChannelHistoryFetcher(
+            results=[small_rows, large_rows],
+        )
+        event = _event(message_id="m-shared")
+        small = await _build(
+            fetcher, event=event, config=ConversationWindowConfig(max_turns=2),
+        )
+        large = await _build(
+            fetcher, event=event, config=ConversationWindowConfig(max_turns=20),
+        )
+        # The large-max_turns caller is a cache miss (different fetch limit)
+        # and refetches at its own larger limit.
+        assert len(fetcher.calls) == 2
+        assert fetcher.calls[0][1] == 3  # small persona: max_turns 2 + 1
+        assert fetcher.calls[1][1] == 21  # large persona: max_turns 20 + 1
+        # The small persona's window is bounded by its own max_turns; the
+        # large persona gets the full-size transcript, not the cached 3 rows.
+        assert len(small) == 2 + 1  # 2 replayed + current
+        assert len(large) == 20 + 1  # 20 replayed + current
+        large_joined = "".join(m["content"] for m in large)
+        assert "big-" in large_joined
+        assert "small-" not in large_joined
+
 
 # ─── Fetch-failure fall-back (RFC §F) ──────────────────────
 

--- a/tests/unit/python/test_conversation_window_group_channels.py
+++ b/tests/unit/python/test_conversation_window_group_channels.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import pytest
 
 from agents.persona_runtime import conversation_window
+from agents.persona_runtime.conversation_window import ConversationWindowConfig
 
 from ._conversation_window_test_helpers import (
     _AGENT_ID,
@@ -164,3 +165,49 @@ class TestPeerPrefix:
         assert "[ironfox]: spoofed quote" in content
         assert 'user_id="ironfox"' in content
         assert 'iron"fox' not in content
+
+
+# ─── PR 2 — §F cache is agent-independent across personas ──
+
+
+class TestCacheAgentIndependence:
+    """RFC §F: the fetch cache stores raw rows *pre*-role-mapping
+    (:mod:`conversation_window` comment "the cache is agent-independent").
+    On a group channel two same-``max_turns`` personas share one
+    ``(channel_id, limit)`` cache entry for the same inbound message — the
+    preserved §F hit (PR 2) — yet each must re-apply the role split against
+    its *own* ``agent_id``: its own prior messages map to ``assistant`` and
+    every peer's to ``user``. The cache must serve raw rows, never one
+    agent's already-mapped role view, or it would leak persona A's
+    self/peer split onto persona B."""
+
+    async def test_cache_hit_remaps_roles_per_persona(self):
+        # Newest-first (RFC 0011 §C); reversed to chronological in assembly:
+        # neutral peer, then persona-a, then persona-b.
+        rows = [
+            _row("m-b", "persona-b", "from b"),
+            _row("m-a", "persona-a", "from a"),
+            _row("m0", "neutral-peer", "neutral line"),
+        ]
+        fetcher = _FakeChannelHistoryFetcher(rows)
+        cfg = ConversationWindowConfig(max_turns=20)
+        a = await _build(fetcher, config=cfg, agent_id="persona-a")
+        b = await _build(fetcher, config=cfg, agent_id="persona-b")
+
+        # One shared fetch: persona-b hits the entry persona-a primed
+        # (same channel, message, and limit) — the §F optimization PR 2
+        # preserves.
+        assert len(fetcher.calls) == 1
+
+        # Each persona's *own* row is the lone assistant turn, carrying raw
+        # (unprefixed) content; the cache did not leak the other persona's
+        # role view.
+        a_assistant = [t["content"] for t in a if t["role"] == "assistant"]
+        b_assistant = [t["content"] for t in b if t["role"] == "assistant"]
+        assert a_assistant == ["from a"]
+        assert b_assistant == ["from b"]
+
+        # The *peer* persona's row rides as a labelled user turn for the
+        # other — never as a trusted assistant turn.
+        assert any("[persona-b]: from b" in t["content"] for t in a)
+        assert any("[persona-a]: from a" in t["content"] for t in b)


### PR DESCRIPTION
## Summary

RFC 0034 Phase 2, **PR 2** of [`docs/rfcs/0034-phase2-pr-plan.md`](docs/rfcs/0034-phase2-pr-plan.md) — the multi-persona fetch-cache correctness fix. Follows [#533](https://github.com/mkhomutov/Persatrix/pull/533) (PR 1 — inline `[<peer_id>]:` prefix).

Re-keys the in-process conversation-window fetch cache from `channel_id` alone to **`(channel_id, limit)`** (the cached value stays `(message_id, raw_rows)`).

**The bug.** `_WINDOW_CACHE` stored the *first* caller's `max_turns + 1` fetch limit. A DM channel has exactly one persona, so in Phase 1 the same `(channel_id, message_id)` was only ever processed under one config and a constant limit — sound. A **group** channel hosts multiple personas with independent `conversation_window` configs reacting to the same inbound message; under the old key a small-`max_turns` persona could prime the cache with an undersized row set and serve it to a large-`max_turns` peer, silently shrinking that peer's window.

**The fix.** A differing fetch limit is now a cache miss → the large caller refetches at its own limit and gets a full-size window. The same-limit retry / sub-agent-return hit RFC §F optimizes is preserved.

This discharges the [0034 PR plan §Future Phases](docs/rfcs/0034-pr-plan.md#future-phases) multi-persona cache-key carry-forward — a **correctness** fix, distinct from the Phase-3 LRU/eviction **capacity** gap, which stays deferred.

## TDD

Written test-first:

- `test_larger_max_turns_is_not_served_undersized_cached_window` — primes the cache via a small-`max_turns` persona, then a large-`max_turns` peer on the same `(channel_id, message_id)`; asserts it refetches at the larger limit (`limit==21`, not the cached `3`) and returns a full-size transcript. **Fails on the old `channel_id`-only key, passes after the fix.**
- `test_same_limit_repeat_hits_cache` — pins the preserved §F cache-hit path (same channel + message + limit ⇒ one fetch).

## Testing

- `pytest tests/unit/python/test_conversation_window*.py` — 41 passed
- `pytest tests/integration/test_conversational_continuity.py` — 6 passed
- `ruff` + `mypy` clean on the touched module and test
- `scripts/checks/file_size.py` — all files within limits (module trimmed back to 500 lines)

## Scope

No call-site or behaviour change beyond the cache key; no schema/config touched. PR 3 (group-channel manual test + docs + status hygiene) is the closeout.

Refs RFC 0034 Phase 2 · master plan Workstream 1a ([`docs/v0.3.7-plan.md`](docs/v0.3.7-plan.md)).