### PR TITLE
fix(v037): emit the `@everyone` sentinel for `channel send --mention-all` (D3)

### DIFF
--- a/cli/src/commands/channel.rs
+++ b/cli/src/commands/channel.rs
@@ -107,8 +107,10 @@ pub(crate) fn validate_send_inputs(sender_id: &str, mentions: &[String]) -> Resu
     validate_resource_id(sender_id, "sender id")?;
     for m in mentions {
         // The `@everyone` broadcast sentinel (D3) is not a participant id —
-        // carve it out so `--mention-all` (and an explicit `--mention
-        // @everyone`) is not rejected client-side before it reaches the wire.
+        // carve it out so an explicit `--mention @everyone` is not rejected
+        // client-side before it reaches the wire. (`--mention-all` does not
+        // rely on this branch: its sentinel is appended in `expand_mentions`
+        // *after* this check, which only ever sees the explicit inputs.)
         // Mirrors the server-side carve-out (ISSUE-0094). `sender_id` carries a
         // stronger trust claim and is intentionally NOT exempt.
         if m == MENTION_EVERYONE {

--- a/cli/src/commands/channel.rs
+++ b/cli/src/commands/channel.rs
@@ -15,8 +15,7 @@ use serde_json::json;
 
 use crate::commands::channel_render::{fetch_agent_display_names, format_message_line};
 use crate::commands::channel_types::{
-    AddMemberRequest, ChannelMember, ChannelMessage, ChannelView, HistoryResponse,
-    ListChannelsResponse, PublishMessageRequest,
+    AddMemberRequest, ChannelMessage, HistoryResponse, ListChannelsResponse, PublishMessageRequest,
 };
 use crate::commands::channel_watch::{watch_seen_cap_for, WatchState, FULL_PAGE_WARNING_TEXT};
 use crate::types::{api_error_message, validate_path_param, validate_resource_id};
@@ -30,6 +29,15 @@ pub(crate) const DEFAULT_HISTORY_LIMIT: u32 = 50;
 /// Mirrors `channelMaxMentionsPerPublish` so the CLI fails fast with a
 /// clear message instead of round-tripping a generic 400.
 pub(crate) const MAX_MENTIONS_PER_PUBLISH: usize = 10;
+
+/// The broadcast sentinel (RFC 0030 relevance amendment Tier A, decision D3).
+/// `--mention-all` emits this rather than enumerating the roster: the server's
+/// directed-elsewhere filter keys on its presence to admit every `participant`,
+/// so the broadcast is roster-independent (no member fetch) and survives the
+/// server's mention cap. Mirrors `internal/channels/channels.go`'s
+/// `MentionEveryone` and `agents.response_gate.MENTION_EVERYONE`; it is NOT a
+/// participant id, so it is carved out of [`validate_send_inputs`].
+pub(crate) const MENTION_EVERYONE: &str = "@everyone";
 
 // ─── Pure helpers (testable without an HTTP server) ─────────────────────
 
@@ -48,15 +56,18 @@ pub(crate) fn canonicalize_channel_id(input: &str) -> String {
 
 /// Resolve the `mentions` array sent on a publish request.
 ///
-/// `--mention-all` resolves client-side (RFC 0011 PR plan PR 6) so the
-/// orchestrator surface stays unchanged. The sender is excluded — the
-/// gate would only fan the message back to the same actor. Order is
-/// stable: explicit flags first (input order), then remaining members
-/// (server order); duplicates collapse.
+/// `--mention-all` emits the roster-independent [`MENTION_EVERYONE`] broadcast
+/// sentinel (RFC 0030 Tier A, decision D3) rather than enumerating members:
+/// the server's directed-elsewhere filter keys on the sentinel's presence to
+/// admit every `participant`, so no member fetch is needed and the server's
+/// mention cap cannot be tripped by a large roster. The sender is dropped from
+/// the explicit list (the gate would only fan the message back to the same
+/// actor; on a broadcast the gate excludes the sender on its side). Order is
+/// stable: explicit flags first (input order, so the gate addresses them
+/// first), then the sentinel; duplicates collapse.
 pub(crate) fn expand_mentions(
     explicit: &[String],
     mention_all: bool,
-    members: &[ChannelMember],
     sender_id: &str,
 ) -> Vec<String> {
     let mut seen: HashSet<String> = HashSet::new();
@@ -67,13 +78,8 @@ pub(crate) fn expand_mentions(
         }
         out.push(m.clone());
     }
-    if mention_all {
-        for m in members {
-            if m.id == sender_id || !seen.insert(m.id.clone()) {
-                continue;
-            }
-            out.push(m.id.clone());
-        }
+    if mention_all && seen.insert(MENTION_EVERYONE.to_string()) {
+        out.push(MENTION_EVERYONE.to_string());
     }
     out
 }
@@ -100,6 +106,14 @@ pub(crate) fn validate_message_id(input: &str) -> Result<(), String> {
 pub(crate) fn validate_send_inputs(sender_id: &str, mentions: &[String]) -> Result<(), String> {
     validate_resource_id(sender_id, "sender id")?;
     for m in mentions {
+        // The `@everyone` broadcast sentinel (D3) is not a participant id —
+        // carve it out so `--mention-all` (and an explicit `--mention
+        // @everyone`) is not rejected client-side before it reaches the wire.
+        // Mirrors the server-side carve-out (ISSUE-0094). `sender_id` carries a
+        // stronger trust claim and is intentionally NOT exempt.
+        if m == MENTION_EVERYONE {
+            continue;
+        }
         validate_resource_id(m, "mention")?;
     }
     Ok(())
@@ -107,10 +121,10 @@ pub(crate) fn validate_send_inputs(sender_id: &str, mentions: &[String]) -> Resu
 
 /// Reject mention arrays that exceed the server cap.
 ///
-/// `--mention-all` resolves to every channel member client-side; on a
-/// channel with > [`MAX_MENTIONS_PER_PUBLISH`] members the server's
-/// `BAD_REQUEST` is opaque. Failing fast names both the actual count
-/// and the cap so the user can pivot to explicit `--mention <id>`.
+/// `--mention-all` now emits a single `@everyone` sentinel so it cannot trip
+/// the cap on its own, but a caller can still pass > [`MAX_MENTIONS_PER_PUBLISH`]
+/// explicit `--mention <id>` flags; the server's `BAD_REQUEST` is opaque, so
+/// fail fast naming both the actual count and the cap.
 pub(crate) fn validate_mention_count(mentions: &[String]) -> Result<(), String> {
     if mentions.len() > MAX_MENTIONS_PER_PUBLISH {
         return Err(format!(
@@ -224,8 +238,8 @@ pub(crate) async fn cmd_channel_send(
 ) -> Result<(), String> {
     let canonical = canonicalize_channel_id(name);
     validate_path_param(&canonical, "channel id")?;
-    // `--mention-all` resolves from the server's member list (already
-    // validated at join time); only the explicit inputs need a check.
+    // `--mention-all` emits the `@everyone` sentinel client-side (no roster
+    // fetch); only the explicit `--mention` inputs need a shape check.
     validate_send_inputs(sender_id, explicit_mentions)?;
     // RFC 0031 Phase 3 `--session` override (OQ #6 precedence; see session_resolve).
     let session_id = crate::session_resolve::resolve_for_invocation(client, server, session_flag)
@@ -234,12 +248,7 @@ pub(crate) async fn cmd_channel_send(
     // ISSUE-0085 PR 5 `--epoch` override (flag > PERSATRIX_EPOCH env; see
     // epoch_resolve). No registry lookup — epoch has no lifecycle.
     let epoch_id = crate::epoch_resolve::resolve_epoch(epoch_flag).unwrap_or_default();
-    let mentions = if mention_all {
-        let members = fetch_channel_members(client, server, &canonical).await?;
-        expand_mentions(explicit_mentions, true, &members, sender_id)
-    } else {
-        expand_mentions(explicit_mentions, false, &[], sender_id)
-    };
+    let mentions = expand_mentions(explicit_mentions, mention_all, sender_id);
     // Server caps mentions at MAX_MENTIONS_PER_PUBLISH; failing fast
     // here surfaces a clear message instead of an opaque 400 from the
     // unauthenticated REST surface.
@@ -384,26 +393,6 @@ pub(crate) async fn cmd_channel_watch(
         first_poll = false;
         tokio::time::sleep(interval).await;
     }
-}
-
-async fn fetch_channel_members(
-    client: &reqwest::Client,
-    server: &str,
-    canonical_id: &str,
-) -> Result<Vec<ChannelMember>, String> {
-    let resp = client
-        .get(format!("{server}/api/v1/channels/{canonical_id}"))
-        .send()
-        .await
-        .map_err(|e| format!("connection failed: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(api_error_message(resp).await);
-    }
-    let view: ChannelView = resp
-        .json()
-        .await
-        .map_err(|e| format!("invalid response: {e}"))?;
-    Ok(view.members)
 }
 
 #[cfg(test)]

--- a/cli/src/commands/channel_tests.rs
+++ b/cli/src/commands/channel_tests.rs
@@ -5,20 +5,12 @@
 //! `tests/`.
 
 use super::*;
-use crate::commands::channel_types::{ChannelMember, ChannelMessage};
+use crate::commands::channel_types::ChannelMessage;
 // WatchState + watch-ring constants moved to `channel_watch` (RFC 0031 Phase 3
 // PR 4 size-cap relief); import them here so the watch tests keep resolving.
 use crate::commands::channel_watch::{
     watch_seen_cap_for, WatchState, FULL_PAGE_WARNING_TEXT, WATCH_SEEN_CAP, WATCH_SEEN_CAP_CEILING,
 };
-
-fn member(id: &str, respond: &str) -> ChannelMember {
-    ChannelMember {
-        id: id.to_string(),
-        respond_policy: respond.to_string(),
-        joined_at: "2026-05-09T10:00:00Z".to_string(),
-    }
-}
 
 fn message(id: &str, ts: &str) -> ChannelMessage {
     ChannelMessage {
@@ -54,33 +46,37 @@ fn canonicalize_passthrough_for_qualified_id() {
 
 #[test]
 fn expand_mentions_explicit_only() {
-    let mentions = expand_mentions(
-        &["bob".to_string(), "carol".to_string()],
-        false,
-        &[],
-        "alice",
+    let mentions = expand_mentions(&["bob".to_string(), "carol".to_string()], false, "alice");
+    assert_eq!(mentions, vec!["bob".to_string(), "carol".to_string()]);
+}
+
+#[test]
+fn expand_mentions_mention_all_emits_everyone_sentinel() {
+    // `--mention-all` is the broadcast: it emits the roster-independent
+    // `@everyone` sentinel (RFC 0030 Tier A, decision D3), NOT an
+    // enumerated member list. The server's directed-elsewhere filter keys
+    // on the sentinel's presence, so an un-named `participant` is admitted
+    // without the CLI having to fetch and list the roster.
+    let mentions = expand_mentions(&[], true, "alice");
+    assert_eq!(mentions, vec![MENTION_EVERYONE.to_string()]);
+}
+
+#[test]
+fn expand_mentions_mention_all_keeps_explicit_then_sentinel() {
+    // `--mention bob --mention-all`: the explicit id (addressed first under
+    // the gate's mentioned-first ordering) precedes the broadcast sentinel.
+    let mentions = expand_mentions(&["bob".to_string()], true, "alice");
+    assert_eq!(
+        mentions,
+        vec!["bob".to_string(), MENTION_EVERYONE.to_string()]
     );
-    assert_eq!(mentions, vec!["bob".to_string(), "carol".to_string()]);
 }
 
 #[test]
-fn expand_mentions_mention_all_excludes_sender() {
-    // `--mention-all` expands to every member except the sender.
-    let members = vec![
-        member("alice", "always"),
-        member("bob", "when_mentioned"),
-        member("carol", "when_mentioned"),
-    ];
-    let mentions = expand_mentions(&[], true, &members, "alice");
-    assert_eq!(mentions, vec!["bob".to_string(), "carol".to_string()]);
-}
-
-#[test]
-fn expand_mentions_dedupes_overlap() {
-    // `--mention bob --mention-all` does not list bob twice.
-    let members = vec![member("bob", "when_mentioned"), member("carol", "always")];
-    let mentions = expand_mentions(&["bob".to_string()], true, &members, "alice");
-    assert_eq!(mentions, vec!["bob".to_string(), "carol".to_string()]);
+fn expand_mentions_mention_all_dedupes_explicit_sentinel() {
+    // `--mention @everyone --mention-all` must not list the sentinel twice.
+    let mentions = expand_mentions(&[MENTION_EVERYONE.to_string()], true, "alice");
+    assert_eq!(mentions, vec![MENTION_EVERYONE.to_string()]);
 }
 
 #[test]
@@ -89,35 +85,24 @@ fn expand_mentions_explicit_dedupes_repeats() {
     let mentions = expand_mentions(
         &["bob".to_string(), "bob".to_string(), "carol".to_string()],
         false,
-        &[],
         "alice",
     );
     assert_eq!(mentions, vec!["bob".to_string(), "carol".to_string()]);
 }
 
 #[test]
-fn expand_mentions_drops_self_mention() {
-    // Sender cannot @-mention themselves — the gate would just fan the
-    // message back to the same actor.
-    let members = vec![member("alice", "always"), member("bob", "always")];
-    let mentions = expand_mentions(&["alice".to_string()], true, &members, "alice");
-    assert_eq!(mentions, vec!["bob".to_string()]);
+fn expand_mentions_mention_all_drops_self_then_adds_sentinel() {
+    // Sender cannot @-mention themselves; the broadcast sentinel still
+    // lands (the gate excludes the sender from a broadcast on its side).
+    let mentions = expand_mentions(&["alice".to_string()], true, "alice");
+    assert_eq!(mentions, vec![MENTION_EVERYONE.to_string()]);
 }
 
 #[test]
 fn expand_mentions_drops_explicit_self_mention_without_mention_all() {
-    // PR #302 deep-review finding N7: the explicit-self-drop branch
-    // (no `--mention-all`) was previously only covered transitively via
-    // `expand_mentions_drops_self_mention`, which exercises the
-    // `mention_all=true` path. The drop is unconditional in
-    // `expand_mentions` regardless of the flag, but assertions on the
-    // explicit-only path keep regressions visible.
-    let mentions = expand_mentions(
-        &["alice".to_string(), "bob".to_string()],
-        false,
-        &[],
-        "alice",
-    );
+    // PR #302 deep-review finding N7: the explicit-self-drop is
+    // unconditional in `expand_mentions`, independent of the flag.
+    let mentions = expand_mentions(&["alice".to_string(), "bob".to_string()], false, "alice");
     assert_eq!(
         mentions,
         vec!["bob".to_string()],
@@ -126,8 +111,8 @@ fn expand_mentions_drops_explicit_self_mention_without_mention_all() {
 }
 
 #[test]
-fn expand_mentions_no_flag_no_members_is_empty() {
-    let mentions = expand_mentions(&[], false, &[], "alice");
+fn expand_mentions_no_flag_is_empty() {
+    let mentions = expand_mentions(&[], false, "alice");
     assert!(mentions.is_empty());
 }
 
@@ -398,6 +383,18 @@ fn validate_send_inputs_rejects_invalid_mention() {
     let err =
         validate_send_inputs("alice", &["bob".to_string(), "not_valid".to_string()]).unwrap_err();
     assert!(err.contains("mention"), "label names the field: {err}");
+}
+
+#[test]
+fn validate_send_inputs_accepts_everyone_sentinel() {
+    // `@everyone` is the D3 broadcast sentinel, not a participant id — it
+    // must clear client-side validation (mirrors the server-side carve-out,
+    // ISSUE-0094) so `--mention-all` (and an explicit `--mention @everyone`)
+    // is not rejected before it reaches the wire.
+    assert!(validate_send_inputs("alice", &[MENTION_EVERYONE.to_string()]).is_ok());
+    assert!(
+        validate_send_inputs("alice", &["bob".to_string(), MENTION_EVERYONE.to_string()]).is_ok()
+    );
 }
 
 // ─── full_page_warning_text (PR #302 deep-review finding 5) ─────────

--- a/docs/manual-tests/MT-CHANNEL-RELEVANCE-001.md
+++ b/docs/manual-tests/MT-CHANNEL-RELEVANCE-001.md
@@ -183,15 +183,23 @@ un-named `participant`s on it (adopted default, amendment OQ #5).
 ```bash
 ./bin/persatrix channel send planning \
   "Standup, everyone: one line on what you're blocked on. @ember-owl you too." \
-  --as operator --mention-all
+  --as operator --mention ember-owl --mention-all
 ```
 
-> `--mention-all` resolves the channel roster and emits the `@everyone`
-> broadcast sentinel; the gate treats its presence as "do not suppress."
+> `--mention-all` emits the roster-independent `@everyone` broadcast sentinel
+> (no member fetch); the gate treats its presence as "do not suppress the
+> un-named `participant`s." The sentinel disables the directed-elsewhere filter
+> for `participant`s, but it is **not** an implicit mention of an `addressed`
+> (`when_mentioned`) member — `ember-owl` still needs its **explicit**
+> `--mention ember-owl` to reply. So `--mention-all` **alone** draws the two
+> `participant`s (`iron-fox`, `nova-sparrow`); add `--mention ember-owl` to draw
+> all three. (Both the Go candidate set and the receiver gate key an `addressed`
+> member on its own id, not on the sentinel.)
 
 **Expected**:
-- All three personas reply (`ember-owl` because it is mentioned; `iron-fox` and
-  `nova-sparrow` because the broadcast disables the directed-elsewhere filter).
+- All three personas reply (`ember-owl` because it is **explicitly** mentioned;
+  `iron-fox` and `nova-sparrow` because the broadcast disables the
+  directed-elsewhere filter).
 
 **Verification**:
 - [ ] All three personas reply on the broadcast (no `directed_elsewhere`


### PR DESCRIPTION
## What

`channel send --mention-all` expanded client-side to the **explicit member roster** (`[ember-owl, iron-fox, nova-sparrow]`) instead of the RFC 0030 Tier A **D3 `@everyone` broadcast sentinel** the [MT recipe](docs/manual-tests/MT-CHANNEL-RELEVANCE-001.md) documents. Two consequences:

1. The genuine `@everyone` path was **unreachable from the CLI** — which is why the F-8 inbound-validation bug ([ISSUE-0094](https://github.com/mkhomutov/Persatrix/pull/562)) could only be reproduced via raw REST, never via the documented command.
2. A large roster could trip the server's `MAX_MENTIONS_PER_PUBLISH` cap.

## Change

`--mention-all` now emits the roster-independent `@everyone` sentinel (`MENTION_EVERYONE`), mirroring `internal/channels/channels.go`'s `MentionEveryone` and `agents.response_gate.MENTION_EVERYONE`:

- `expand_mentions` drops the `members` param and appends the sentinel — **no member fetch** (`fetch_channel_members` removed as dead), so the broadcast is roster-independent and can't trip the mention cap on its own.
- `validate_send_inputs` carves the sentinel out of the participant-id check (mirrors the server-side ISSUE-0094 fix). `sender_id` is **not** exempt.

## TDD (RED → GREEN)

Written failing first (confirmed `MENTION_EVERYONE` unresolved + arg-count mismatch), then implemented:

- `channel_tests.rs::expand_mentions_*` — `--mention-all` → `["@everyone"]`; explicit ids precede the sentinel; `--mention @everyone --mention-all` dedupes; self-drop still applies.
- `channel_tests.rs::validate_send_inputs_accepts_everyone_sentinel`.

`cargo test` **155 passed**; clippy + fmt clean.

## Semantics (verified live on the v0.3.7 Anthropic stack)

| Command | Emitted `mentions` | Replies |
|---------|--------------------|---------|
| `--mention-all` | `["@everyone"]` | the two `participant`s (D3 un-suppresses them) |
| `--mention ember-owl --mention-all` | `["ember-owl","@everyone"]` | **all three** |

The sentinel disables the directed-elsewhere filter for `participant`s but is **not** an implicit mention of an `addressed`/`when_mentioned` member — both the Go candidate set (`orderResponders`) and the receiver gate key an `addressed` member on its own id. `MT-CHANNEL-RELEVANCE-001` Step 4 is updated with the accurate command + this semantic note.

Depends on the merged F-8 server fix ([#562](https://github.com/mkhomutov/Persatrix/pull/562)) so the emitted sentinel is accepted end-to-end.