### PR TITLE
docs(v037): re-run MT execution report on post-fix tip 92a5a00 (F-8 resolved)

### DIFF
--- a/docs/manual-tests/MT-CHANNEL-RELEVANCE-001.md
+++ b/docs/manual-tests/MT-CHANNEL-RELEVANCE-001.md
@@ -279,6 +279,7 @@ answers every turn exactly as before.
 |------|--------|----|--------|-------|
 | _pending_ | | | ☐ | To be executed live at v0.3.7 release-prep (master-plan Phase 3) on the RC tip. |
 | 2026-06-06 | Claude (Opus 4.8) | macOS (Darwin 24.6.0) | ⚠️ **Steps 1–3 + idle-cost Pass; Step 4 (D3) Fail** | Live on Anthropic, RC tip `65303d7`. Directed→1, open→2, suppressed members zero-cost. **Step 4 `@everyone` broadcast draws 0 replies + 135 s publish block** — root-caused to `agents/channel_validation.py` rejecting the `@everyone` sentinel before the gate: [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md). See [v0.3.7-execution-report.md](v0.3.7-execution-report.md). |
+| 2026-06-06 | Claude (Opus 4.8) | macOS (Darwin 24.6.0) | ✅ **Pass (all 5 steps + idle-cost)** | Re-run on the post-fix tip `92a5a00` (after [#562](https://github.com/mkhomutov/Persatrix/pull/562)/[#563](https://github.com/mkhomutov/Persatrix/pull/563), [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) resolved). Directed→1, open→2, **broadcast→3** (reply counts 1/2/3), suppressed members zero-cost. Step 4 verified via both REST `@everyone` and the CLI `--mention-all` path (emits `mentions=["ember-owl","@everyone"]`); publish ~10 s, no block. See [v0.3.7-execution-report.md](v0.3.7-execution-report.md). |
 
 ---
 

--- a/docs/manual-tests/MT-PERSONA-CONVERSATION-002.md
+++ b/docs/manual-tests/MT-PERSONA-CONVERSATION-002.md
@@ -304,6 +304,7 @@ signal, not a memory bug.
 | Date | Tester | OS | Build | Result | Notes |
 |------|--------|----|-------|--------|-------|
 | 2026-06-06 | Claude (Opus 4.8) | macOS (Darwin 24.6.0) | RC tip `65303d7` (Anthropic) | ✅ **Pass** (both legs) | Leg 1 — `ember-owl` attributed *Iron Fox→Postgres, Nova Sparrow→SQLite* correctly (Edge Case 3 hit; re-seeded "opposite sides" per recipe). Leg 2 — bound *"their"* (operational simplicity) to Nova Sparrow and engaged her reasoning. See [v0.3.7-execution-report.md](v0.3.7-execution-report.md). |
+| 2026-06-06 | Claude (Opus 4.8) | macOS (Darwin 24.6.0) | tip `92a5a00` (Anthropic) | ✅ **Pass** (both legs) | Re-run on the post-fix tip. Leg 1 — `ember-owl`: *"Iron Fox took Postgres. Nova Sparrow took SQLite"* (opposite-sides seed). Leg 2 — first referent ("operational simplicity") was ambiguous (both peers used that framing) so `ember-owl` bound it to Iron Fox; per Edge Case 1, re-run with a referent unique to Nova Sparrow ("get us in front of customers fastest") → bound *"their"* to Nova Sparrow cleanly. See [v0.3.7-execution-report.md](v0.3.7-execution-report.md). |
 
 ---
 

--- a/docs/manual-tests/README.md
+++ b/docs/manual-tests/README.md
@@ -152,7 +152,7 @@ Tests are organised by **feature area**. IDs follow the pattern `MT-<AREA>-<NNN>
 | v0.3.4 | [v0.3.4-execution-report.md](v0.3.4-execution-report.md) | ✅ Complete |
 | v0.3.5 | [v0.3.5-execution-report.md](v0.3.5-execution-report.md) | ✅ Complete |
 | v0.3.6 | [v0.3.6-execution-report.md](v0.3.6-execution-report.md) | ✅ Complete |
-| v0.3.7 | [v0.3.7-execution-report.md](v0.3.7-execution-report.md) | ⚠️ Complete — release-blocking finding ([ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md), MT-CHANNEL-RELEVANCE-001 Step 4) |
+| v0.3.7 | [v0.3.7-execution-report.md](v0.3.7-execution-report.md) | ✅ Complete — clean pass on tip `92a5a00` (the first-run blocker [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) / MT-CHANNEL-RELEVANCE-001 Step 4 fixed in [#562](https://github.com/mkhomutov/Persatrix/pull/562)/[#563](https://github.com/mkhomutov/Persatrix/pull/563), re-verified live) |
 
 ---
 

--- a/docs/manual-tests/v0.3.7-execution-report.md
+++ b/docs/manual-tests/v0.3.7-execution-report.md
@@ -1,19 +1,20 @@
 # v0.3.7 Manual Test Execution Report
 
 **Version**: v0.3.7 (Conversations worth watching — the realism rung: [RFC 0034 Phase 2](../rfcs/0034-persona-conversational-working-memory.md) group working memory + [RFC 0030 relevance Tier A + the `respond_policy → disposition` reframe](../rfcs/0030-amendment-relevance-gated-response.md) + the peer-voice prompt)
-**Report status**: ⚠️ **Complete with one release-blocking finding.** The two headline-continuity legs and the combined realism walkthrough passed **live** on the rebuilt RC tip, and every structural release-blocker gate is green — **but** [`MT-CHANNEL-RELEVANCE-001`](MT-CHANNEL-RELEVANCE-001.md) **Step 4 (the `@everyone` broadcast, decision D3) FAILS live**: a broadcast draws **zero** persona replies and blocks the publish ~135 s. Root cause found and localized to the agent inbound validator (`agents/channel_validation.py` rejects the `@everyone` sentinel as an invalid participant id, dropping the message before the response gate) — filed as **[ISSUE-0094 / F-8](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md)**. Directed (Step 2) and open-floor (Step 3) directedness, [`MT-PERSONA-CONVERSATION-002`](MT-PERSONA-CONVERSATION-002.md) (both legs), the combined realism walkthrough, and the live idle-cost invariant all **Pass**. **The v0.3.7 directedness release gate is NOT met until F-8 lands.**
+**Report status**: ✅ Complete — **clean pass.** Re-executed **live** on the rebuilt RC tip after the F-8 fix landed. The release-blocking finding from the first execution ([`MT-CHANNEL-RELEVANCE-001`](MT-CHANNEL-RELEVANCE-001.md) Step 4 — the `@everyone` broadcast, decision D3) **now passes**: a broadcast draws **all three** persona replies and publishes in ~10 s (was 0 replies + a ~135 s block). The fix shipped as **[ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) → resolved** in two PRs — [#562](https://github.com/mkhomutov/Persatrix/pull/562) (accept the `@everyone` sentinel in the agent inbound validator) and [#563](https://github.com/mkhomutov/Persatrix/pull/563) (emit the sentinel for `channel send --mention-all`). All five MT-CHANNEL-RELEVANCE-001 steps + the idle-cost invariant, [`MT-PERSONA-CONVERSATION-002`](MT-PERSONA-CONVERSATION-002.md) (both legs), and the combined realism walkthrough **Pass live**, and every structural release-blocker gate is green on the new tip. **The v0.3.7 directedness release gate is met.**
 **Tester**: Claude (Opus 4.8) — Go 1.26.3 + Node 22.16 host build + live Docker stack on **Anthropic** (`quality` → `claude-sonnet-4-6`, `fast`/`summarizer` → `claude-haiku-4-5`)
-**Execution date**: 2026-06-06
-**Target commit**: `main` tip `65303d7` ([v0.3.7 release-prep plan PR 0 / #558](https://github.com/mkhomutov/Persatrix/pull/558)) — all three realism workstreams + the F-1…F-7 test-findings cluster merged ([#533](https://github.com/mkhomutov/Persatrix/pull/533)–[#556](https://github.com/mkhomutov/Persatrix/pull/556)) and the RFC 0049 docs-only ratification ([#559](https://github.com/mkhomutov/Persatrix/pull/559)/[#560](https://github.com/mkhomutov/Persatrix/pull/560)). This PR is [release-prep plan PR 1](../v0.3.7-release-prep-plan.md#pr-1--manual-test-execution-report-v037-surface).
+**Execution date**: 2026-06-06 (re-run on the post-fix tip)
+**Target commit**: `main` tip `92a5a00` ([D3 `--mention-all` sentinel fix / #563](https://github.com/mkhomutov/Persatrix/pull/563)) — the two F-8 fix PRs ([#562](https://github.com/mkhomutov/Persatrix/pull/562) inbound-validation carve-out + [#563](https://github.com/mkhomutov/Persatrix/pull/563) CLI `--mention-all`) on top of the realism workstreams + the F-1…F-7 cluster ([#533](https://github.com/mkhomutov/Persatrix/pull/533)–[#556](https://github.com/mkhomutov/Persatrix/pull/556)) and the RFC 0049 docs-only ratification ([#559](https://github.com/mkhomutov/Persatrix/pull/559)/[#560](https://github.com/mkhomutov/Persatrix/pull/560)). This report supersedes the first execution on `65303d7` (which surfaced F-8) — that run is preserved in git history.
 
-> **✅ Environment note (read first).** The host carries the full toolchain — Go 1.26.3 (`darwin/arm64`), Node 22.16, Docker 29.5.2 — and a valid Anthropic key (models endpoint `200`). A pre-existing demo stack was running from a **stale** image (built `2026-06-05`, before the F-7 Option D identity PRs [#553](https://github.com/mkhomutov/Persatrix/pull/553)–[#556](https://github.com/mkhomutov/Persatrix/pull/556) which merged `2026-06-06`; its channel store still showed the pre-disposition `respond` values). It was **torn down with volumes** (`docker compose down -v`) and the stack **rebuilt from the `65303d7` RC tip** (`docker compose -f docker-compose.yaml -f docker-compose.anthropic.yaml up -d --build`) so every result below represents the RC tip, not stale images — matching the v0.3.6 PR 1 precedent. All MTs ran live; the SPA render legs are out of scope for this surface (no web-console change in v0.3.7).
+> **✅ Environment note (read first).** The host carries the full toolchain — Go 1.26.3 (`darwin/arm64`), Node 22.16, Docker 29.5.2 — and a valid Anthropic key (models endpoint `200`). The prior demo stack was a **stale** image (the agent image was built ~19 min *before* the F-8 fix `ace98ec` landed, so it still rejected the `@everyone` sentinel). It was **torn down with volumes** (`docker compose … down -v`) and the stack **rebuilt from the `92a5a00` RC tip** (`docker compose -f docker-compose.yaml -f docker-compose.anthropic.yaml up -d --build`). The rebuilt **agent image is dated `2026-06-06T12:40Z` — after the F-8 fix** — so it carries the carve-out; the orchestrator image is a cache hit on unchanged Go source (the fixes were Python + Rust; the Go `@everyone` candidate-set logic was already correct, pinned by `TestOrderResponders_BroadcastDisablesDirectedFilter`). Every result below represents the RC tip, not a stale image. All MTs ran live; the SPA render legs are out of scope for this surface (no web-console change in v0.3.7).
 
 ---
 
 ## Scope
 
 This report executes the **v0.3.7 realism surface** scoped by
-[release-prep plan PR 1](../v0.3.7-release-prep-plan.md#pr-1--manual-test-execution-report-v037-surface):
+[release-prep plan PR 1](../v0.3.7-release-prep-plan.md#pr-1--manual-test-execution-report-v037-surface),
+re-run on the post-fix tip:
 
 - **2 headline MTs** — authored during implementation, **executed here**:
   - [`MT-CHANNEL-RELEVANCE-001`](MT-CHANNEL-RELEVANCE-001.md) — **primary v0.3.7 gate** — addressing-aware directedness: a directed `@`-mention → exactly one reply; an open-floor message → all `participant`s; an `@everyone` broadcast → the directed filter disabled (all reply).
@@ -24,7 +25,7 @@ This report executes the **v0.3.7 realism surface** scoped by
 ### Release gate
 
 - Every **directedness + conversation-window + identity-migration structural gate** is green on the RC tip (the automated release-blocker counterpart to the MTs). ✅ **Met, live.**
-- [`MT-CHANNEL-RELEVANCE-001`](MT-CHANNEL-RELEVANCE-001.md) — ⚠️ **Partial: Steps 1–3 + the idle-cost invariant Pass live; Step 4 (broadcast / D3) FAILS.** See [§ MT-CHANNEL-RELEVANCE-001](#mt-channel-relevance-001--addressing-aware-directedness-live-anthropic) and [§ Findings F-8](#findings--follow-ups). **The directedness gate is not fully met until [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) lands.**
+- [`MT-CHANNEL-RELEVANCE-001`](MT-CHANNEL-RELEVANCE-001.md) — ✅ **Pass: all five steps + the idle-cost invariant Pass live.** Step 4 (broadcast / D3) — the prior run's failure — now draws all three replies via **both** the REST `@everyone` wire shape and the documented `channel send --mention-all` CLI path. See [§ MT-CHANNEL-RELEVANCE-001](#mt-channel-relevance-001--addressing-aware-directedness-live-anthropic). **The directedness gate is met.**
 - [`MT-PERSONA-CONVERSATION-002`](MT-PERSONA-CONVERSATION-002.md) ✅ **Pass live** — both legs (attribution + cross-peer pronoun binding).
 - Combined realism walkthrough ✅ **captured** (one-reply-to-directed + mutually-aware open round naming peers + colleague voice).
 - Carried-forward **alias cost-attribution** + **session/epoch isolation** + **cost-regression (uninvolved persona costs zero)** gates green on the RC tip. ✅
@@ -39,45 +40,47 @@ This report executes the **v0.3.7 realism surface** scoped by
 | Go | **1.26.3** (`darwin/arm64`) — structural Go gates ran live |
 | Node | 22.16.0 (`make ui` / Vitest) |
 | Python | 3.12.13 (`.venv`), pytest |
-| Rust / cargo | 1.93.1 |
+| Rust / cargo | 1.93.1 (CLI rebuilt from `92a5a00` for the `--mention-all` path) |
 | Docker | 29.5.2 (build 79eb04c) |
-| Stack | `docker compose -f docker-compose.yaml -f docker-compose.anthropic.yaml up -d --build` (`make demo-anthropic` overlay) — orchestrator + 6 agents (planner, code-writer, code-reviewer, ember-owl, iron-fox, nova-sparrow) + otel-collector + jaeger + prometheus + loki; **rebuilt from `65303d7`** after `docker compose down -v`. |
+| Stack | `docker compose -f docker-compose.yaml -f docker-compose.anthropic.yaml up -d --build` (`make demo-anthropic` overlay) — orchestrator + 6 agents (planner, code-writer, code-reviewer, ember-owl, iron-fox, nova-sparrow) + otel-collector + jaeger + prometheus + loki; **rebuilt from `92a5a00`** after `docker compose down -v`. Agent image dated `2026-06-06T12:40Z` (post-F-8-fix); 11 services healthy; `/healthz` → `200`. |
 | Provider | **Anthropic** — `quality` → `claude-sonnet-4-6`, `fast`/`summarizer` → `claude-haiku-4-5-20251001` (config-driven, RFC 0033). Key valid (`200`). |
 
 ---
 
-## Structural / Automated Gates (live, on the RC tip `65303d7`)
+## Structural / Automated Gates (live, on the RC tip `92a5a00`)
 
-All run locally on `65303d7`. **All green.** These are the **automated release-blocker** counterpart to the MTs.
+All run locally on `92a5a00`. **All green.** These are the **automated release-blocker** counterpart to the MTs.
 
 | Gate | Command | Result |
 |------|---------|--------|
+| **F-8 fix — inbound `@everyone` carve-out (new)** | `pytest tests/unit/python/test_channel_validation.py` | ✅ **47 passed** — both inbound validators accept `@everyone` (alone + with a real id), still reject a malformed id / a sentinel `sender_id` / a miscased sentinel; the drift-guard ties the locally-pinned constant to `response_gate.MENTION_EVERYONE` |
+| **F-8 fix — delivery-chain repro (new)** | `pytest tests/integration/test_channel_relevance.py` | ✅ **5 passed** (was 4) — adds `test_broadcast_passes_inbound_validation_then_admits`: the full validate→gate chain a broadcast traverses (the previously-missing assertion that let the bug ship); plus `@ember-owl` → one reply, open-floor → all, directed-elsewhere still ingests |
+| **F-8 fix — CLI `--mention-all` emits the sentinel (new)** | `cargo test --manifest-path cli/Cargo.toml expand_mentions validate_send_inputs_accepts_everyone_sentinel` | ✅ **9 passed** — `--mention-all` → `["@everyone"]` (roster-independent, no member fetch); explicit ids precede the sentinel; explicit `@everyone`+`--mention-all` dedupes; self-drop applies; `validate_send_inputs` accepts the sentinel client-side |
 | **Directedness — receiver gate unit** | `pytest tests/unit/python/test_response_gate_relevance.py test_response_gate_disposition.py` | ✅ **18 passed** — directed-elsewhere suppresses other `participant`s; mentioned admitted; open-floor admits all; `@everyone` disables the filter (gate layer); disposition aliases resolve to legacy constants |
-| **Directedness — integration repro** | `pytest tests/integration/test_channel_relevance.py` | ✅ **4 passed** — `@ember-owl` → one reply; open-floor → all; a directed-elsewhere member still **ingests** (`test_directed_elsewhere_member_still_remembers`) |
 | **RFC 0034 Phase 2 conversation-window** | `pytest tests/integration/test_conversational_continuity.py` | ✅ **6 passed** — group-channel per-peer `[<peer_id>]: ` prefix + cross-peer substrate + the `(channel_id, limit)` cache-key shape |
-| **Identity migration (v12→v14 + backfill + crash-replay)** | `pytest tests/unit/python -k "migration_identity or identity_backfill"` · `-k migration` | ✅ **17 passed** (identity) · **137 passed** (full migration suite) — `MIGRATIONS` head = **14** (13 = relationship `identity` column, 14 = pre-cutover contact-note backfill) |
-| **Go directedness candidate-set parity + disposition normalization** | `go test ./internal/channels/ -run 'Relevance\|Directed\|Disposition\|Fanout\|Floor\|Config'` | ✅ PASS — incl. `TestOrderResponders_DirectedElsewhere`, `TestOrderResponders_BroadcastDisablesDirectedFilter`, `TestLoadConfig_NormalizesDispositionVocabulary`, `TestSQLiteStore_{AddMember,SetMemberPolicy,CreateChannelWithMembers}_NormalizesDisposition` |
-| **Full Go internal suite (race/cover)** | `go test ./internal/... -race -cover` | ✅ **all packages `ok`**, no FAIL, no data races (`server` 82.7%, `channels` 83.7%, `cost` 95.8%, `wallet` 100%) |
+| **Identity migration (v12→v14 + backfill)** | `pytest tests/unit/python -k "migration_identity or identity_backfill"` · `-k migration` | ✅ **12 passed** (identity-backfill) · **137 passed** (full migration suite) — `MIGRATIONS` head = **14** (13 = relationship `identity` column, 14 = pre-cutover contact-note backfill) |
+| **Go directedness candidate-set parity + disposition normalization** | `go test ./internal/channels/ -run 'Relevance\|Directed\|Disposition\|Fanout\|Floor\|Config\|Everyone\|Broadcast\|Mention'` | ✅ PASS — incl. `TestOrderResponders_DirectedElsewhere`, `TestOrderResponders_BroadcastDisablesDirectedFilter`, `TestLoadConfig_NormalizesDispositionVocabulary`, `TestSQLiteStore_{AddMember,SetMemberPolicy,CreateChannelWithMembers}_NormalizesDisposition` |
+| **Full Go internal suite (race/cover)** | `go test ./internal/... -race -cover` | ✅ **all packages `ok`**, no FAIL, no data races (`server` 82.7%, `channels` 83.9%, `cost` 95.8%, `wallet` 100%) |
 | **Alias cost-attribution gate** (carried-forward) | `go test ./internal/server/ ./internal/cost/ -run 'AliasRoutedAgent\|PricesAliasPhysicalModels'` | ✅ `TestCostSummary_AliasRoutedAgent_ReportsNonZeroCost` + `…PricesAliasPhysicalModels` PASS |
 | **Session + epoch structural-isolation gates** (carried-forward) | `pytest tests/integration/{test_session_recall_isolation,test_epoch_run_isolation,test_session_continuity,test_session_emission_isolation,test_session_id_cross_process}.py` | ✅ **20 passed** |
 | **Cost-regression — uninvolved persona costs zero** | live (see [§ Idle-cost invariant](#idle-cost-invariant-live-rfc-00230024)) + `test_response_gate_relevance::test_participant_not_mentioned_is_suppressed_when_message_directed` | ✅ live: 0 Anthropic calls for the two suppressed `participant`s during the directed turn |
+
+> **Gate-count note (corrected from the first execution).** The `migration_identity or identity_backfill` selector collects **12** tests (all in `test_identity_backfill.py`); the first report's "17 passed (identity)" was inaccurate. The full migration suite (137) is unchanged. The migration surface was untouched between `65303d7` and `92a5a00`, so 12 is the truthful count on both tips.
 
 ---
 
 ## Stack build (MT-INTEGRATION-001, live)
 
-✅ **Succeeded.** `docker compose … down -v` (purge stale volumes) → `… up -d --build` rebuilt the orchestrator (Go) + the agent image (Python source baked) and brought up all 11 services from `65303d7`. `/healthz` → `200`; all 6 agents `healthy`; orchestrator, Prometheus, Jaeger, Loki, otel-collector up. The persona-memory store opened fresh and **forward-migrated to schema v14 in-image** (`schema_version` head = `14`; the `relationships.identity` column present — verified by reading `ember-owl`'s `/app/data/memory.db` after the first persona write). This is the substrate for every MT below.
+✅ **Succeeded.** `docker compose … down -v` (purge stale volumes) → `… up -d --build` rebuilt the orchestrator (Go) + the agent image (Python source baked, dated `2026-06-06T12:40Z`) and brought up all 11 services from `92a5a00`. `/healthz` → `200`; all 6 agents `healthy`; orchestrator, Prometheus, Jaeger, Loki, otel-collector up. The `group:planning` channel opened fresh (`created_at` `12:40:24Z`). This is the substrate for every MT below.
 
 > **Note (REST disposition shape).** The `planning` channel's on-disk
 > [`config/channels.yaml`](../../config/channels.yaml) uses the **new** disposition
 > vocabulary (`ember-owl: addressed`, `iron-fox`/`nova-sparrow`: `participant`). The Go
 > config-load boundary **normalizes these to the legacy gate constants for storage**,
-> so `GET /api/v1/channels/group:planning` reports `when_mentioned` / `always` — the
-> canonical persisted form. This is the back-compat normalization working as designed
-> (`addressed↔when_mentioned`, `participant↔always`, `observer↔never`); the *behaviour*
-> is what the MT asserts, and it is verified live below. The MT recipe's Step 1
-> ("lists `addressed`/`participant`") describes the config-file view, not the REST view —
-> a recipe-vs-surface nuance worth a one-line note in the recipe.
+> so `GET /api/v1/channels/group:planning` reports `when_mentioned` / `always` / `always` — the
+> canonical persisted form (verified live this run). This is the back-compat normalization
+> working as designed (`addressed↔when_mentioned`, `participant↔always`, `observer↔never`);
+> the *behaviour* is what the MT asserts, and it is verified live below.
 
 ---
 
@@ -86,71 +89,69 @@ All run locally on `65303d7`. **All green.** These are the **automated release-b
 Driven over REST (`POST /api/v1/channels/group:planning/messages`) so the wire
 shape is unambiguous; the human `operator` was added as an `observer` member
 first (publish requires membership). Reply counts read back from
-`GET …/messages`.
+`GET …/messages`. Step 4 additionally re-run through the documented
+`channel send --mention-all` CLI path (the freshly-built `92a5a00` binary).
 
 | Step | Expected | Observed | Result |
 |------|----------|----------|--------|
-| 1 — dispositions | `ember-owl: addressed`, `iron-fox`/`nova-sparrow`: `participant` | config uses the disposition vocab; REST reports the normalized legacy form `when_mentioned` / `always` / `always` (see note above) | ✅ (with recipe note) |
-| 2 — directed `@ember-owl` → **exactly one** reply (the Trigger repro) | only `ember-owl` replies; the two `participant`s stay silent | post `@ember-owl what's your read?` `mentions=[ember-owl]` → **only `ember-owl` replied** (+14 s); `iron-fox` + `nova-sparrow` silent, made **0** Anthropic calls. The v0.3.6 "everyone answers, incl. *I'm not Ember Owl, but…*" defect is **demonstrably fixed**. | ✅ |
-| 3 — open-floor → admits all `participant`s | `iron-fox` + `nova-sparrow` reply; `ember-owl` silent | post open question (no mention) → **`iron-fox` (+14 s) then `nova-sparrow` (+26 s)** in a serialized floor round; `ember-owl` (`addressed`) silent | ✅ |
-| 4 — `@everyone` broadcast disables the directed filter (D3) | all three reply | post `Standup, everyone… @ember-owl you too.` `mentions=[ember-owl,@everyone]` → **ZERO persona replies**; the publish **blocked ~135 s** (3 × 45 s floor-turn timeouts) and returned 201. Reproduced twice. | ❌ **FAIL** |
-| 5 — REST reply counts | 1 / 2 / 3 (directed / open / broadcast) | observed **1 / 2 / 0** — the directed and open cases match; the broadcast is 0 (consequence of Step 4) | ⚠️ partial (1/2 ✅, broadcast ✗) |
+| 1 — dispositions | `ember-owl: addressed`, `iron-fox`/`nova-sparrow`: `participant` | config uses the disposition vocab; REST reports the normalized legacy form `when_mentioned` / `always` / `always` (see note above) | ✅ (with recipe note F-9) |
+| 2 — directed `@ember-owl` → **exactly one** reply | only `ember-owl` replies; the two `participant`s stay silent | `@ember-owl what's your read?` `mentions=[ember-owl]` → **only `ember-owl` replied** (+15 s); `iron-fox` + `nova-sparrow` silent, made **0** Anthropic calls (count stable on re-poll). | ✅ |
+| 3 — open-floor → admits all `participant`s | `iron-fox` + `nova-sparrow` reply; `ember-owl` silent | open question (no mention) → **`iron-fox` (+14 s) then `nova-sparrow` (+29 s)** in a serialized floor round (publish blocked ~30 s — the F-10 synchronous round); `ember-owl` (`addressed`) silent | ✅ |
+| 4 — `@everyone` broadcast disables the directed filter (D3) | all three reply | post `Standup, everyone… @ember-owl you too.` `mentions=[ember-owl,@everyone]` → **all three replied** (`ember-owl`, `iron-fox`, `nova-sparrow`); publish completed in **~10 s**, no block. Re-run via CLI `--mention ember-owl --mention-all` (emitted `mentions=["ember-owl","@everyone"]`) → all three replied again (~5 s). **The prior 0-replies / 135 s block is fixed.** | ✅ |
+| 5 — REST reply counts | 1 / 2 / 3 (directed / open / broadcast) | observed **1 / 2 / 3** — all three cases match | ✅ |
 
-### Step 4 root cause (filed as [ISSUE-0094 / F-8](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md))
+### Step 4 — the F-8 fix, verified live
 
-The candidate-set logic is **correct** — `orderResponders` admits all three on a
-broadcast, and a control proves the floor round itself is healthy:
+The first execution found Step 4 failing: an `@everyone` broadcast drew **zero**
+replies and blocked the publish ~135 s, root-caused to `agents/channel_validation.py`
+rejecting the `@everyone` sentinel against the participant-id regex before the
+response gate. The fix shipped in two PRs:
 
-```
-mentions=["ember-owl","iron-fox","nova-sparrow"]  (explicit, no @everyone) → all 3 reply ("Wait." ×3) in ~5 s
-mentions=[]  (open floor)                          → iron-fox + nova-sparrow reply in ~6 s
-mentions=["ember-owl","iron-fox"]                  → both reply (ember-owl as a floor speaker) in ~7 s
-mentions=["ember-owl","@everyone"]                 → 0 replies, 135 s block        ← only the sentinel fails
-```
+- **[#562](https://github.com/mkhomutov/Persatrix/pull/562)** carves `@everyone` out of mention-id validation in **both** inbound validators (gRPC + REST/catch-up), scoped to `mentions` only (`sender_id` still rejects the sentinel), with a drift-guard tying the constant to `response_gate.MENTION_EVERYONE` and a delivery-chain integration test.
+- **[#563](https://github.com/mkhomutov/Persatrix/pull/563)** changes the CLI `--mention-all` to emit the roster-independent `@everyone` sentinel (mirroring the Go/Python constants) instead of expanding the member roster client-side — so the documented recipe command actually drives the D3 broadcast path (and can't trip the publish mention cap).
 
-So the failure is **specific to the `@everyone` sentinel**. Tracing it:
-`r.fanout` runs synchronously from `Publish` (`internal/channels/router.go`); a
-floor round with ≥2 responders dispatches each speaker and waits up to
-`DefaultFloorTurnTimeoutSeconds = 45` for a reply. During both broadcasts the
-three personas made **no Anthropic calls and logged nothing** — they received
-the gRPC dispatch (no `channels: dispatch failed` warning) but discarded it
-**before the response gate**. The discard is `agents/channel_validation.py`:
-every `mentions` element is matched against `^[a-z0-9][a-z0-9-]*[a-z0-9]$`;
-`@everyone` fails (leading `@`), so `validate_channel_message` rejects the whole
-envelope. The Go orchestrator (`channels.MentionEveryone`, the floor-control
-directed bypass, mention persistence) and the Python `response_gate`
-(`MENTION_EVERYONE`) all special-case `@everyone`; **only the inbound validator
-does not.** The gates pass because they call `orderResponders` / `should_respond`
-with synthetic lists and never push an `@everyone` envelope through
-`validate_channel_message`. Full analysis + the suggested one-line carve-out + the
-missing delivery-layer test are in [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md).
+Both paths verified live this run: the REST `@everyone` envelope and the CLI
+`--mention-all` both draw all three persona replies with no block.
+[ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md)
+is **resolved** (`closed: 2026-06-06`).
 
-**MT-CHANNEL-RELEVANCE-001: ⚠️ Steps 1–3 + idle-cost Pass live; Step 4 (D3) Fail** — the headline directedness fix (a directed message draws exactly one reply; an open message admits all) holds end-to-end, but the broadcast escape hatch is non-functional. **Release gate not met until F-8 lands.**
+**MT-CHANNEL-RELEVANCE-001: ✅ Pass (all five steps + idle-cost, live)** — the
+headline directedness contract holds end-to-end: a directed message draws exactly
+one reply, an open message admits all `participant`s, and an `@everyone` broadcast
+re-admits everyone. **Release gate met.**
 
 ---
 
 ## MT-PERSONA-CONVERSATION-002 — Persona conversational continuity, group channel (live, Anthropic)
 
-Two legs over one session on `group:planning`. Leg-1 seeding hit Edge Case 3
-(both `always` peers first picked Postgres); per the recipe it was re-seeded with
-an "argue opposite sides" prompt to make the positions distinctly attributable:
-**`iron-fox` → Postgres**, **`nova-sparrow` → SQLite (operational simplicity)**.
+Two legs over one session on `group:planning`. Leg-1 seeding used an
+"argue opposite sides" prompt (the recipe's Edge Case 3 — both `always` peers
+otherwise tend to converge on the same pick) to make the positions distinctly
+attributable: **`iron-fox` → Postgres** (in-stack / known failure modes),
+**`nova-sparrow` → SQLite case** (zero-ops / speed to customer).
 
 | Step | Leg | Expected | Observed | Result |
 |------|-----|----------|----------|--------|
-| 1–2 | — | stack + personas up; operator joins | 11 services healthy; operator added | ✅ |
-| 3 | 1 | two `always` peers take distinct attributable positions | after re-seed: `iron-fox` argued Postgres (replication/PITR/locking), `nova-sparrow` argued SQLite (zero infra / operational simplicity) | ✅ |
-| 4 | 1 | `@`-mentioned `ember-owl` attributes each position to the right **named** peer | `ember-owl`: *"**Iron Fox** picked Postgres… **Nova Sparrow** argued SQLite when prompted to steelman it"* — both correct; even disambiguated the earlier same-pick round | ✅ |
-| 5 | 2 | `ember-owl` binds a pronoun to the correct peer's prior turn | trigger: *"one of them argued mostly on operational simplicity — do you agree with their reasoning?"* → `ember-owl`: *"**Nova Sparrow's** point on operational simplicity is valid… but… **Iron Fox's** point about replication and recovery is the one that actually matters"* — bound *"their"* to the right peer (nova-sparrow), engaged her specific reasoning, contrasted iron-fox's | ✅ |
+| 1–2 | — | stack + personas up; operator joins | 11 services healthy; operator added as `observer` | ✅ |
+| 3 | 1 | two `always` peers take distinct attributable positions | `iron-fox` argued Postgres (already in stack, on-call rotation), `nova-sparrow` argued SQLite (zero-ops, fastest to customer); `ember-owl` silent | ✅ |
+| 4 | 1 | `@`-mentioned `ember-owl` attributes each position to the right **named** peer | `ember-owl`: *"**Iron Fox** took Postgres. **Nova Sparrow** took SQLite…"* — both correct; even disambiguated that both ultimately leaned Postgres | ✅ |
+| 5 | 2 | `ember-owl` binds a pronoun to the correct peer's prior turn | trigger: *"one of them argued the lighter option would get us in front of customers fastest — do you agree with their reasoning?"* → `ember-owl`: *"That was **Nova Sparrow's** point…"* — bound *"their"* to the right peer, engaged her speed-to-customer reasoning, pushed back | ✅ |
 
 The trigger turns carried **no restated attribution** (they never named which peer
 took which position), so the attribution and the cross-peer referent could only
 be resolved from the `[iron-fox]: ` / `[nova-sparrow]: ` attributed transcript —
 exactly the RFC 0034 Phase 2 substrate.
 
-**MT-PERSONA-CONVERSATION-002: ✅ Pass (live)** — both legs. Promote the MT from
-`Draft scaffold` to `Active` (both legs passed in this combined execution, per its
-own promotion criterion).
+> **Leg 2 referent note.** The first Step-5 referent ("argued mostly on operational
+> simplicity") was **ambiguous** on this seed — *both* peers framed their cases on
+> operational simplicity (`iron-fox`: "zero new ops surface"; `nova-sparrow`:
+> "zero-ops, embedded") — and `ember-owl` reasonably bound it to `iron-fox`. Per the
+> recipe's Edge Case 1, the trigger was re-run with a referent unique to
+> `nova-sparrow`'s argument (speed to customer), which resolved cleanly. The mechanism
+> under test (cross-peer referent resolution off the attributed transcript) worked in
+> both runs; the re-run removes the seed ambiguity so the leg is conclusive.
+
+**MT-PERSONA-CONVERSATION-002: ✅ Pass (live)** — both legs.
 
 ---
 
@@ -159,49 +160,45 @@ own promotion criterion).
 One session on the multi-persona `group:planning`, exercising all three v0.3.7
 realism signals together.
 
-**(a) Directedness — a directed question draws exactly one reply.**
-`@iron-fox what is the single biggest operational risk in the Postgres plan?`
-→ **`iron-fox` alone** replied (*"No replication lag monitoring… if a standby
-falls behind and we fail over, we lose whatever events weren't yet flushed —
-silently"*); `ember-owl` + `nova-sparrow` silent. ✅
+**(a) Directedness — a directed question draws exactly one reply.** The Step-2
+directed `@ember-owl` turn drew `ember-owl` alone; the two `participant`s stayed
+silent (and cost zero). ✅
 
 **(b) Mutually-aware, ordered open-floor round naming peers.**
 `Open floor: given everything said, what should our v0.4 datastore decision
 actually be? Build on each other, do not repeat.` → a serialized floor round:
 
-> **[iron-fox]** Postgres, with three non-negotiables before we ship: replication
-> lag alerting, a tested failover runbook, and explicit producer backpressure…
-> Everything else said here I agree with — the operational simplicity argument for
-> SQLite dies the moment we need recovery under pressure.
+> **[iron-fox]** Postgres. Everything said this round confirms it — ops
+> familiarity, known failure modes, no migration cliff when retention requirements
+> grow. The only thing I'd add: we need retention policy and load-tested write
+> paths *before* any customer-facing surface lands on top of it…
 >
-> **[nova-sparrow]** Postgres, and we treat replication lag monitoring as a launch
-> blocker — not a nice-to-have. **Iron Fox named the exact failure mode that kills
-> us**, so we fix it before we ship, not after.
+> **[nova-sparrow]** Postgres, clearly — **Iron Fox's** ops familiarity point and
+> **Ember's** schema-is-the-real-bottleneck observation together close the case.
+> The only thing I'd add: let's define the retention policy *now*…
 
-`nova-sparrow` references **iron-fox by name**, builds on his replication-lag
-point without repeating it, and the round **converges** on a decision — the
+`nova-sparrow` references **iron-fox and ember-owl by name**, builds on their
+points without repeating them, and the round **converges** on a decision — the
 group-working-memory + floor-control + peer-voice signals together. ✅
 
 **(c) Colleagues, not assistants (qualitative).** Throughout, the personas read
-as colleagues: *"Fine, I'll take the brief"*, *"Test coverage isn't really my
-lane, but…"*, *"for the record, her real preference is Postgres too"*,
-*"Postgres wins on the merits"* — positions, disagreement, and convergence, not
-assistant-helpfulness performance. ✅
+as colleagues: *"Ember Owl, SQLite is yours to defend"*, *"I don't want to be the
+person explaining a SQLite migration to T.K. when retention requirements balloon"*,
+*"an event log… isn't the place to optimize for embedded simplicity"* — positions,
+disagreement, and convergence, not assistant-helpfulness performance. ✅
 
-**Combined realism walkthrough: ✅ captured** — the directedness leg is the one
-case the broadcast bug does not touch (it uses a single directed `@`-mention and
-an un-mentioned open floor, neither of which carries the `@everyone` sentinel).
+**Combined realism walkthrough: ✅ captured.**
 
 ---
 
 ## Idle-cost invariant (live, RFC 0023/0024)
 
-During the directed `@ember-owl` turn (Step 2), Anthropic API calls per agent
-(read from each container's logs over the turn window):
+During the directed `@ember-owl` turn (Step 2), Anthropic API call activity per
+agent (read from each container's logs over the turn window):
 
-| Agent | Disposition | Anthropic calls | |
-|-------|-------------|-----------------|--|
-| `ember-owl` | addressed (mentioned) | **2** (gate-pass + reply) | replied |
+| Agent | Disposition | Anthropic call log lines | |
+|-------|-------------|--------------------------|--|
+| `ember-owl` | addressed (mentioned) | **1** | replied |
 | `iron-fox` | participant (directed-elsewhere) | **0** | silent, **zero cost** |
 | `nova-sparrow` | participant (directed-elsewhere) | **0** | silent, **zero cost** |
 
@@ -218,27 +215,27 @@ Outcome legend: ✅ Pass · ⚠️ Accepted-with-known-gap / partial · ⊘ Depr
 
 | Test ID | Title | Outcome | Notes / Evidence |
 |---------|-------|---------|------------------|
-| [MT-CHANNEL-RELEVANCE-001](MT-CHANNEL-RELEVANCE-001.md) | Relevance gate Tier A — addressing-aware directedness | ❌ **Fail (Step 4 / D3)** | Steps 1–3 + idle-cost **Pass live** (directed→1, open→2, suppressed members zero-cost); **Step 4 broadcast (`@everyone`/D3) Fails** — 0 replies, 135 s block. Root-caused → [ISSUE-0094 / F-8](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md). See [§ MT-CHANNEL-RELEVANCE-001](#mt-channel-relevance-001--addressing-aware-directedness-live-anthropic). |
-| [MT-PERSONA-CONVERSATION-002](MT-PERSONA-CONVERSATION-002.md) | Persona conversational continuity (group channel) | ✅ **Pass (live)** | Both legs: named-peer attribution + cross-peer pronoun binding, off the per-peer attributed transcript. See [§ MT-PERSONA-CONVERSATION-002](#mt-persona-conversation-002--persona-conversational-continuity-group-channel-live-anthropic). Promote Draft scaffold → Active. |
+| [MT-CHANNEL-RELEVANCE-001](MT-CHANNEL-RELEVANCE-001.md) | Relevance gate Tier A — addressing-aware directedness | ✅ **Pass (live)** | All five steps + idle-cost **Pass** (directed→1, open→2, broadcast→3, suppressed members zero-cost). Step 4 (`@everyone`/D3) — the prior run's failure — fixed in [#562](https://github.com/mkhomutov/Persatrix/pull/562)/[#563](https://github.com/mkhomutov/Persatrix/pull/563) ([ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) resolved); verified live via both REST and CLI `--mention-all`. See [§ MT-CHANNEL-RELEVANCE-001](#mt-channel-relevance-001--addressing-aware-directedness-live-anthropic). |
+| [MT-PERSONA-CONVERSATION-002](MT-PERSONA-CONVERSATION-002.md) | Persona conversational continuity (group channel) | ✅ **Pass (live)** | Both legs: named-peer attribution + cross-peer pronoun binding, off the per-peer attributed transcript. See [§ MT-PERSONA-CONVERSATION-002](#mt-persona-conversation-002--persona-conversational-continuity-group-channel-live-anthropic). |
 | Combined realism walkthrough | directedness + mutually-aware open round + peer voice | ✅ **Captured (live)** | One session: directed→one reply; ordered open round naming peers + converging; colleague voice. See [§ Combined realism walkthrough](#combined-realism-walkthrough-authored--executed-here). |
 
 ### Carried-forward v0.3.6 surface — regression (against the v0.3.7 RC tip)
 
-The fresh green automated suites (full Go `-race -cover` · 20 session/epoch integration · the directedness + conversation-window + migration suites · the carried-forward alias/cost gates, all on `65303d7`) regression-cover the surface mechanically; the live Anthropic stack confirms the user-facing paths under the v0.3.7 (`floor-control-on` + disposition) config. Prior ref: [`v0.3.6-execution-report.md`](v0.3.6-execution-report.md).
+The fresh green automated suites (full Go `-race -cover` · 20 session/epoch integration · the directedness + conversation-window + migration suites · the carried-forward alias/cost gates, all on `92a5a00`) regression-cover the surface mechanically; the live Anthropic stack confirms the user-facing paths under the v0.3.7 (`floor-control-on` + disposition) config. Prior ref: [`v0.3.6-execution-report.md`](v0.3.6-execution-report.md).
 
 | Test ID | Title | Outcome | Notes (v0.3.7) |
 |---------|-------|---------|----------------|
-| [MT-CHANNEL-GOV-002](MT-CHANNEL-GOV-002.md) | Floor control — ordered, mutually-aware replies | ✅ Pass | Re-confirmed live in the combined walkthrough (serialized iron-fox→nova-sparrow round, mutual reference). v0.3.6 ref: ✅. |
+| [MT-CHANNEL-GOV-002](MT-CHANNEL-GOV-002.md) | Floor control — ordered, mutually-aware replies | ✅ Pass | Re-confirmed live in the combined walkthrough (serialized iron-fox→nova-sparrow round, mutual reference by name). v0.3.6 ref: ✅. |
 | [MT-PERSONA-CONVERSATION-001](MT-PERSONA-CONVERSATION-001.md) | Persona conversational continuity (DM) | ✅ Pass (by automated coverage) | Phase-1 DM mapping unchanged; `test_conversational_continuity.py` green. v0.3.6 ref: ✅. |
 | [MT-CONSOLE-001](MT-CONSOLE-001.md) | Web Console fresh-stack Interactions slice | ✅ Pass (by carry-forward) | No web-console change in v0.3.7; `build.version` reads `0.3.6` (pre-bump, PR 3). v0.3.6 ref: ✅ (live). |
-| [MT-INTEGRATION-001](MT-INTEGRATION-001.md) | Docker Compose full-stack smoke | ✅ Pass | Stack rebuilt from `65303d7`, 11 services healthy, `/healthz` 200, migrations →**v14**. See [§ Stack build](#stack-build-mt-integration-001-live). v0.3.6 ref: ✅. |
+| [MT-INTEGRATION-001](MT-INTEGRATION-001.md) | Docker Compose full-stack smoke | ✅ Pass | Stack rebuilt from `92a5a00`, 11 services healthy, `/healthz` 200, agent image post-fix. See [§ Stack build](#stack-build-mt-integration-001-live). v0.3.6 ref: ✅. |
 | [MT-ALIAS-001](MT-ALIAS-001.md) | Alias-routed agent reports correctly-keyed cost | ✅ Pass | Go alias cost-attribution gate green on host; live Anthropic turns recorded alias-keyed cost. v0.3.6 ref: ✅. |
 | [MT-ALIAS-002](MT-ALIAS-002.md) | One-line provider swap | ✅ Pass | Stack ran on the `anthropic` overlay (config-driven). v0.3.6 ref: ✅. |
 | [MT-SESSION-001](MT-SESSION-001.md) / [-002](MT-SESSION-002.md) / [-003](MT-SESSION-003.md) | Session surface + recall isolation | ✅ Pass (by automated coverage) | The 5-file session/epoch integration set (20 passed) green on the RC tip. v0.3.6 ref: ✅. |
 | [MT-EPOCH-001](MT-EPOCH-001.md) | Epoch structural run-isolation | ✅ Pass (by automated coverage) | `test_epoch_run_isolation.py` green; v14 migrations applied live at boot. v0.3.6 ref: ✅. |
-| [MT-MEMORY-001…004](MT-MEMORY-001.md) | Episodic / relationship / working / budget | ✅ Pass (by automated coverage) | Memory-tier suites green; the new `relationships.identity` column (migration 13/14) is additive. v0.3.6 ref: ✅. |
+| [MT-MEMORY-001…004](MT-MEMORY-001.md) | Episodic / relationship / working / budget | ✅ Pass (by automated coverage) | Memory-tier suites green; the `relationships.identity` column (migration 13/14) is additive. v0.3.6 ref: ✅. |
 | [MT-MEMORY-005](MT-MEMORY-005-dementia-test.md) | Persona Memory — Dementia Test (V5) | ⚠️ Accepted-with-known-gap | Single-session continuity + multi-session no-bleed carried by `test_session_continuity.py`; full 5-leg arc not re-run (no regression in the v0.3.7 memory change — identity is additive). v0.3.6 ref: ⚠️. |
-| [MT-CHANNEL-001…006](MT-CHANNEL-001.md) | Channel CLI / lifecycle | ✅ Pass | `members` add + `messages` publish/history exercised live across every MT above; cascade tests in the Go suite. v0.3.6 ref: ✅. |
+| [MT-CHANNEL-001…006](MT-CHANNEL-001.md) | Channel CLI / lifecycle | ✅ Pass | `members` add + `messages` publish/history exercised live across every MT above; `channel send --mention-all` exercised live (#563); cascade tests in the Go suite. v0.3.6 ref: ✅. |
 | [MT-CHANNEL-004](MT-CHANNEL-004.md) | Human-mentions-agent (live LLM reply) | ✅ Pass | Every directed `@`-mention above is this path, live. v0.3.6 ref: ✅. |
 | [MT-CHAT-001](MT-CHAT-001.md) | Chat REST endpoint | ✅ Pass (by automated coverage) | DM chat-as-DM façade path unchanged (`PublishAndAwait`); Go server suite green. v0.3.6 ref: ✅. |
 | [MT-OFFLINE-001](MT-OFFLINE-001.md) / [MT-OLLAMA-001](MT-OLLAMA-001.md) | Offline / Ollama providers | ✅ Pass (by carry-forward) | No provider-runtime change in v0.3.7. v0.3.6 ref: ✅. |
@@ -249,14 +246,14 @@ The fresh green automated suites (full Go `-race -cover` · 20 session/epoch int
 
 ## Findings & Follow-ups
 
-- **F-8 — `@everyone` broadcast (decision D3) is dropped by the agent inbound validator** (defect; severity: **high** — release-gate miss + a ~135 s publish-blocking hang). `agents/channel_validation.py` matches every `mentions` element against the participant-id regex with no `@everyone` carve-out, so a broadcast envelope is rejected before the response gate; every persona stays silent and a floor-controlled publish blocks N×45 s. Filed as **[ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md)** with the root cause, the four-control repro, the suggested one-line carve-out, and the missing delivery-layer test. **This blocks the v0.3.7 directedness release gate** (MT-CHANNEL-RELEVANCE-001 Step 4) — recommend a `fix/v037-` PR before PR 3/PR 4 certify the gate. Not a Known-Gap deferral: D3 is a shipped, documented contract, not a deferred Tier-B feature.
-- **F-9 — MT-CHANNEL-RELEVANCE-001 recipe Step 1 describes the config-file disposition view, not the REST view** (recipe-staleness; severity: low — doc, not a defect). The REST surface reports the **normalized legacy** `respond` constants (`when_mentioned`/`always`), while `config/channels.yaml` uses the new vocab (`addressed`/`participant`). Behaviour is correct; the recipe should add a one-line note that REST shows the normalized form. (Folded as a note here; the recipe edit is a doc follow-up, not in this report PR.)
-- **F-10 — the publish path is synchronous through the floor round** (observation, not a v0.3.7 defect; severity: none). `Publish` runs `fanout` inline, so a floor-controlled multi-persona round blocks the `POST /messages` handler for the round's duration (≤ N×45 s). Benign today (the directed/open cases complete in seconds), but it is the mechanism that turns the F-8 silent-drop into a 135 s hang. Worth tracking against RFC 0034 Phase 3 / the floor-round budget work (already a v0.3.8 item).
+- **F-8 — `@everyone` broadcast (decision D3) dropped by the agent inbound validator — RESOLVED.** Found on the first execution (`65303d7`): a broadcast drew zero replies and blocked a floor-controlled publish ~135 s because `agents/channel_validation.py` matched every `mentions` element against the participant-id regex with no `@everyone` carve-out. Fixed in [#562](https://github.com/mkhomutov/Persatrix/pull/562) (inbound carve-out in both validators + drift-guard + delivery-chain test) and [#563](https://github.com/mkhomutov/Persatrix/pull/563) (CLI `--mention-all` emits the sentinel). [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md) closed `2026-06-06`. Re-verified live this run (Step 4 passes via REST + CLI). **No longer a release blocker.**
+- **F-9 — MT-CHANNEL-RELEVANCE-001 recipe Step 1 describes the config-file disposition view, not the REST view** (recipe-staleness; severity: low — doc, not a defect). The REST surface reports the **normalized legacy** `respond` constants (`when_mentioned`/`always`), while `config/channels.yaml` uses the new vocab (`addressed`/`participant`). Behaviour is correct; the Step-1 expected-output could add a one-line note that REST shows the normalized form. (Step 4's recipe text was already corrected by [#563](https://github.com/mkhomutov/Persatrix/pull/563); the Step-1 note remains a minor doc follow-up.)
+- **F-10 — the publish path is synchronous through the floor round** (observation, not a defect; severity: none). `Publish` runs `fanout` inline, so a floor-controlled multi-persona round blocks the `POST /messages` handler for the round's duration (observed ~30 s on the open-floor round this run; the directed single-reply case returns immediately and the reply lands asynchronously). Benign today; it is the same mechanism that turned the (now-fixed) F-8 silent-drop into a 135 s hang. Worth tracking against RFC 0034 Phase 3 / the floor-round budget work (a v0.3.8 item).
 
 ---
 
 ## Notes
 
-- The stack was **rebuilt from `65303d7`** after `docker compose down -v` (a result against the stale `2026-06-05` images would not represent the RC tip). The working tree is clean (no UI bundle build this run; the report + issue are the only additions).
-- MT-CHANNEL-RELEVANCE-001 Step 4 was reproduced **twice** (two independent `@everyone` posts, both 0 replies / ~135 s) and isolated with four controls (explicit-3-mention, open-floor, two-mention, broadcast) to prove the failure is sentinel-specific, not a wedged stack or a candidate-set bug.
-- This is **not** a clean v0.3.7 sign-off: one headline release-gate MT step Fails. PR 1 records the finding and files [ISSUE-0094](../issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md); the directedness gate is certifiable only after F-8 lands. The remaining release-prep PRs (docs/checklist PR 2, version bump PR 3, final sweep PR 4) should treat F-8 as a pre-tag blocker.
+- The stack was **rebuilt from `92a5a00`** after `docker compose down -v`; the rebuilt agent image is dated `2026-06-06T12:40Z` (after the F-8 fix `ace98ec`), so the result represents the post-fix tip, not a stale image. The orchestrator image is a cache hit on unchanged Go source (the fixes were Python + Rust). The working tree is clean.
+- MT-CHANNEL-RELEVANCE-001 Step 4 was verified through **two** independent paths — the raw REST `@everyone` envelope (the exact wire shape that failed on `65303d7`) and the documented `channel send --mention-all` CLI command (rebuilt from `92a5a00`, confirmed to emit `mentions=["ember-owl","@everyone"]`) — both drawing all three replies with no block.
+- This is a **clean v0.3.7 sign-off** for the realism surface: every headline release-gate MT step passes, the prior blocker (F-8) is resolved and re-verified, and all structural gates are green on `92a5a00`. The remaining release-prep PRs (docs/checklist PR 2, version bump PR 3, final sweep PR 4) can proceed.


### PR DESCRIPTION
## Summary

Re-executes the **v0.3.7 realism-surface manual tests** on the post-fix RC tip `92a5a00` and flips the execution report from "⚠️ Complete with one release-blocking finding" to a **clean pass**.

The first execution (on `65303d7`, [#561](https://github.com/mkhomutov/Persatrix/pull/561)) surfaced **F-8 / [ISSUE-0094](https://github.com/mkhomutov/Persatrix/blob/main/docs/issues/ISSUE-0094-everyone-broadcast-rejected-by-agent-inbound-validation.md)**: an `@everyone` broadcast (RFC 0030 Tier A decision D3) drew **zero** persona replies and blocked a floor-controlled publish ~135 s, because the agent inbound validator rejected the `@everyone` sentinel before the response gate. That is now fixed by [#562](https://github.com/mkhomutov/Persatrix/pull/562) (inbound-validation carve-out) + [#563](https://github.com/mkhomutov/Persatrix/pull/563) (CLI `--mention-all` emits the sentinel); ISSUE-0094 is resolved.

## Re-run results (live on a stack rebuilt from `92a5a00`, Anthropic)

| Surface | Result |
|---|---|
| **MT-CHANNEL-RELEVANCE-001** | ✅ **Full pass** (all 5 steps + idle-cost). Step 4 (D3) now draws all three replies, publish ~10 s (was 0 + 135 s block) — verified via **both** the REST `@everyone` envelope and the CLI `--mention-all` path (confirmed to emit `mentions=["ember-owl","@everyone"]`). Reply counts 1/2/3. |
| **MT-PERSONA-CONVERSATION-002** | ✅ Pass, both legs (named-peer attribution + cross-peer pronoun binding). |
| **Combined realism walkthrough** | ✅ Captured (directedness + mutually-aware converging open round + colleague voice). |
| **Structural gates** | ✅ All green on `92a5a00`, incl. the new F-8 tests: `test_channel_validation.py` (47), `test_channel_relevance.py` (5, +delivery-chain), Rust `expand_mentions`/`validate_send_inputs` (9). |

## Notes
- Stack was torn down (`down -v`) and **rebuilt from `92a5a00`** because the prior running image was built ~19 min before the F-8 fix landed; the rebuilt agent image is dated `12:40Z` (post-fix).
- **Corrected** the prior report's "17 passed (identity)" gate count to the actual **12** (the `migration_identity or identity_backfill` selector; migrations untouched between tips).
- Adds re-run rows to the MT-CHANNEL-RELEVANCE-001 and MT-PERSONA-CONVERSATION-002 results tables and updates the README index.

## Test plan
- [x] Local automated gates (Go `-race -cover`, pytest, cargo) green on `92a5a00`
- [x] Live MTs re-run on rebuilt Anthropic stack
- [x] Pre-commit doc checks pass (links, status markers, filemap)

Docs-only change.