### PR TITLE
docs(release): post-release follow-up for v0.3.7

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Persatrix Roadmap
 
-> **Last updated**: 2026-06-06 (v0.3.7 released-status flip — final pre-tag verification (PR 4) green on the post-bump tip; Version Map → ✅ Released. Only the mechanical `v0.3.7` tag + GitHub Release remain.)
+> **Last updated**: 2026-06-06 (v0.3.7 *Conversations worth watching* tagged + [GitHub Release](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) published; post-release hygiene done. Next phase: **v0.3.8** — conversations that converge.)
 > **Current phase**: v0.3.7 (Conversations worth watching — RFC 0034 Phase 2 + RFC 0030 relevance Tier A + peer-voice prompt) — ✅ Released
 > **Current milestone**: v0.3.7 *Conversations worth watching* — ✅ Released. The headline user-facing story: **a group channel reads like colleagues, not bots** — several personas see and build on the running transcript ([RFC 0034 Phase 2](docs/rfcs/0034-persona-conversational-working-memory.md) group working memory), the right people speak, and a question aimed at one persona isn't answered by everyone ([RFC 0030 relevance gate Tier A](docs/rfcs/0030-amendment-relevance-gated-response.md) addressing-aware eligibility + the `respond` disposition vocabulary), with a peer-voice prompt that frames personas as colleagues rather than assistants. Tier B salience, natural-language addressing, the `chair` disposition, and RFC 0030 Layers 1/2/4/5 are deferred to v0.3.8+. The next phase is **v0.3.8** (conversations that converge — brainstorm).
 
@@ -1142,6 +1142,47 @@ v0.5.0 complete
 | [#525](https://github.com/mkhomutov/Persatrix/pull/525) | docs(v036): v0.3.6 release-prep PR 2 — README + ROADMAP + guide verification + release checklist | v0.3.6 release prep | 2026-06-04 |
 | [#526](https://github.com/mkhomutov/Persatrix/pull/526) | chore(v036): release-prep PR 3 — version bump 0.3.5 → 0.3.6 + changelog [0.3.6] | v0.3.6 release prep | 2026-06-04 |
 | [#527](https://github.com/mkhomutov/Persatrix/pull/527) | docs(v036): release-prep PR 4 — final pre-tag verification & release notes | v0.3.6 release prep | 2026-06-04 |
+| [#528](https://github.com/mkhomutov/Persatrix/pull/528) | docs(release): post-release follow-up for v0.3.6 | v0.3.6 post-release | 2026-06-04 |
+| [#529](https://github.com/mkhomutov/Persatrix/pull/529) | docs(v03x): re-sequence tail for conversation realism & usefulness ahead of v0.4.0 | v0.3.x sequencing | 2026-06-04 |
+| [#530](https://github.com/mkhomutov/Persatrix/pull/530) | docs(v0.3.7): open v0.3.7 plan — Conversations worth watching | v0.3.7 plan | 2026-06-04 |
+| [#531](https://github.com/mkhomutov/Persatrix/pull/531) | chore(checks): split file_size allowlist into its own module | checks/tooling | 2026-06-04 |
+| [#532](https://github.com/mkhomutov/Persatrix/pull/532) | docs(v037): author Phase 1 PR plans — RFC 0034 P2 + RFC 0030 relevance Tier A | v0.3.7 plan (Phase 1) | 2026-06-04 |
+| [#533](https://github.com/mkhomutov/Persatrix/pull/533) | feat(v037): RFC 0034 P2 PR 1 — inline `[<peer_id>]:` prefix on replayed peer turns | 0034 P2 (1/3) | 2026-06-04 |
+| [#534](https://github.com/mkhomutov/Persatrix/pull/534) | feat(v037): RFC 0034 P2 PR 2 — multi-persona fetch-cache correctness | 0034 P2 (2/3) | 2026-06-04 |
+| [#535](https://github.com/mkhomutov/Persatrix/pull/535) | docs(v037): RFC 0034 P2 PR 3 — group-channel working-memory closeout | 0034 P2 (3/close) | 2026-06-04 |
+| [#536](https://github.com/mkhomutov/Persatrix/pull/536) | feat(v037): RFC 0030 relevance PR 1 — disposition vocabulary + back-compat (inert) | 0030 relevance (1/3) | 2026-06-05 |
+| [#537](https://github.com/mkhomutov/Persatrix/pull/537) | feat(v037): RFC 0030 relevance PR 2 — Tier A directed-elsewhere eligibility | 0030 relevance (2/3) | 2026-06-05 |
+| [#538](https://github.com/mkhomutov/Persatrix/pull/538) | feat(v037): peer-voice prompt — frame personas as colleagues, not assistants | 0030 peer-voice (1c) | 2026-06-05 |
+| [#539](https://github.com/mkhomutov/Persatrix/pull/539) | docs(v037): conversation test-findings PR plan from live group-channel probing | v0.3.7 test-findings (plan) | 2026-06-05 |
+| [#540](https://github.com/mkhomutov/Persatrix/pull/540) | fix(v037): scope external-data safety guard to flagged envelopes (F-1) | v0.3.7 test-findings (F-1) | 2026-06-05 |
+| [#541](https://github.com/mkhomutov/Persatrix/pull/541) | fix(v037): conversation-window self-awareness snippet (F-2) | v0.3.7 test-findings (F-2a) | 2026-06-05 |
+| [#542](https://github.com/mkhomutov/Persatrix/pull/542) | fix(v037): interim group-channel window sizing — 40/4096 for demo personas (F-2b) | v0.3.7 test-findings (F-2b) | 2026-06-05 |
+| [#543](https://github.com/mkhomutov/Persatrix/pull/543) | fix(v037): correct memory-tool-usage cross-conversation promise (F-3a) | v0.3.7 test-findings (F-3a) | 2026-06-05 |
+| [#544](https://github.com/mkhomutov/Persatrix/pull/544) | fix(v037): person-keyed contact notes recall cross-room (F-3b) | v0.3.7 test-findings (F-3b) | 2026-06-05 |
+| [#545](https://github.com/mkhomutov/Persatrix/pull/545) | fix(v037): make the external-data carve-out sender-aware (F-6) | v0.3.7 test-findings (F-6) | 2026-06-05 |
+| [#546](https://github.com/mkhomutov/Persatrix/pull/546) | fix(v037): restore agent_id on the tool-invocation metric (F-5) | v0.3.7 test-findings (F-5) | 2026-06-05 |
+| [#547](https://github.com/mkhomutov/Persatrix/pull/547) | feat(v037): channel-roster fetch + render module (F-4, slice A) | v0.3.7 test-findings (F-4a) | 2026-06-05 |
+| [#548](https://github.com/mkhomutov/Persatrix/pull/548) | feat(v037): inject the channel roster into per-event context (F-4, slice B) | v0.3.7 test-findings (F-4b) | 2026-06-05 |
+| [#549](https://github.com/mkhomutov/Persatrix/pull/549) | docs(v037): F-7 cross-room recall seam — finding + fix plan (A now / D target) | v0.3.7 test-findings (F-7) | 2026-06-05 |
+| [#550](https://github.com/mkhomutov/Persatrix/pull/550) | fix(v037): unify recall scope — contact notes cross-room in recall_notes (F-7, Option A) | v0.3.7 test-findings (F-7 A) | 2026-06-05 |
+| [#551](https://github.com/mkhomutov/Persatrix/pull/551) | docs(v037): ISSUE-0093 — F-7 Option D design (person identity on the cross-room tier) | 0093 F-7 D (design) | 2026-06-05 |
+| [#552](https://github.com/mkhomutov/Persatrix/pull/552) | docs(v037): ISSUE-0093 — RFC amendment for F-7 Option D (person identity on the cross-room tier) | 0093 F-7 D (RFC) | 2026-06-05 |
+| [#553](https://github.com/mkhomutov/Persatrix/pull/553) | feat(v037): ISSUE-0093 D1 — identity column + upsert_identity on the relationship tier (F-7 Option D) | 0093 F-7 D (1/4) | 2026-06-06 |
+| [#554](https://github.com/mkhomutov/Persatrix/pull/554) | feat(v037): ISSUE-0093 D2 — store_note(contact:*) identity write-through + cross-room render (F-7 Option D) | 0093 F-7 D (2/4) | 2026-06-06 |
+| [#555](https://github.com/mkhomutov/Persatrix/pull/555) | feat(v037): ISSUE-0093 D3 — retire F-7 Option-A contact-note carve-out (identity on relationship tier only) | 0093 F-7 D (3/4) | 2026-06-06 |
+| [#556](https://github.com/mkhomutov/Persatrix/pull/556) | feat(v037): ISSUE-0093 D4 — backfill pre-cutover contact notes onto relationship identity (F-7 Option D) | 0093 F-7 D (4/4) | 2026-06-06 |
+| [#557](https://github.com/mkhomutov/Persatrix/pull/557) | docs(v037): RFC 0030 relevance PR 3 — Tier A closeout (MT + disposition docs + status) | 0030 relevance (3/close) | 2026-06-06 |
+| [#558](https://github.com/mkhomutov/Persatrix/pull/558) | docs(v037): author v0.3.7 release-prep plan (master-plan Phase 2) | v0.3.7 release prep | 2026-06-06 |
+| [#559](https://github.com/mkhomutov/Persatrix/pull/559) | docs(v037): RFC 0049 — memory consolidation gradient + scope reconciliation (ratify cross-room topic knowledge) | 0049 (RFC) | 2026-06-06 |
+| [#560](https://github.com/mkhomutov/Persatrix/pull/560) | docs(v037): RFC 0049 amendment stubs — fact-scope re-root, cross-scope consolidation, decisions-as-memory | 0049 amendments | 2026-06-06 |
+| [#561](https://github.com/mkhomutov/Persatrix/pull/561) | docs(v037): PR 1 — MT execution report (realism surface) + ISSUE-0094 `@everyone` broadcast defect | v0.3.7 release prep | 2026-06-06 |
+| [#562](https://github.com/mkhomutov/Persatrix/pull/562) | fix(v037): accept the `@everyone` broadcast sentinel in agent inbound validation (ISSUE-0094) | 0094 F-8 (agent) | 2026-06-06 |
+| [#563](https://github.com/mkhomutov/Persatrix/pull/563) | fix(v037): emit the `@everyone` sentinel for `channel send --mention-all` (D3) | 0094 F-8 (CLI) | 2026-06-06 |
+| [#564](https://github.com/mkhomutov/Persatrix/pull/564) | docs(v037): re-run MT execution report on post-fix tip 92a5a00 (F-8 resolved) | v0.3.7 release prep | 2026-06-06 |
+| [#565](https://github.com/mkhomutov/Persatrix/pull/565) | docs(v037): PR 2 — README + ROADMAP + guide verification + release checklist | v0.3.7 release prep | 2026-06-06 |
+| [#566](https://github.com/mkhomutov/Persatrix/pull/566) | chore(v037): release-prep PR 3 — version bump 0.3.6 → 0.3.7 + changelog `[0.3.7]` | v0.3.7 release prep | 2026-06-06 |
+| [#567](https://github.com/mkhomutov/Persatrix/pull/567) | docs(v037): release-prep PR 4 — final pre-tag verification & release notes | v0.3.7 release prep | 2026-06-06 |
+| [#568](https://github.com/mkhomutov/Persatrix/pull/568) | docs(release): post-release follow-up for v0.3.7 (this PR) | v0.3.7 post-release | 2026-06-06 |
 
 ---
 

--- a/docs/v0.3.7-plan.md
+++ b/docs/v0.3.7-plan.md
@@ -1,8 +1,9 @@
 # v0.3.7 Plan — Conversations Worth Watching (realism: addressing + group working memory)
 
-**Status**: 📋 Proposed
+**Status**: ✅ Complete
 **Target version**: v0.3.7 (conversation realism — the first rung of the [usefulness ladder](v0.3.x-sequencing.md#the-usefulness-ladder))
 **Created**: 2026-06-04
+**Completed**: 2026-06-06 (`v0.3.7` tagged + [GitHub Release](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) published)
 **Branch prefix**: `feature/v037-`
 **Target**: `main`
 **Merge strategy**: Squash merge per [BRANCHING.md](BRANCHING.md)
@@ -110,8 +111,8 @@ Update as each PR merges; for multi-PR rows, roll up every constituent PR and us
 | 1b | 1 | RFC 0030 relevance gate Tier A — addressing-aware eligibility + disposition reframe + back-compat | `feature/v037-rfc0030-relevance-…` | ✅ Merged (PR 1 #536, PR 2 #537, PR 3 closeout #557) | [#536](https://github.com/mkhomutov/Persatrix/pull/536), [#537](https://github.com/mkhomutov/Persatrix/pull/537), [#557](https://github.com/mkhomutov/Persatrix/pull/557) | 2026-06-06 |
 | 1c | 1 | Peer-voice prompt section + prompt-assembly wiring | `feature/v037-peer-voice-prompt` | ✅ Merged | [#538](https://github.com/mkhomutov/Persatrix/pull/538) | 2026-06-05 |
 | 2 | 2 | v0.3.7 release-prep plan | `feature/v037-release-prep-plan` | ✅ Merged | [#558](https://github.com/mkhomutov/Persatrix/pull/558) | 2026-06-06 |
-| 3 | 3 | v0.3.7 release-prep execution (MT exec → doc sweep → version bump + changelog → final pre-tag verification) | `feature/v037-release-prep-…` | ✅ Merged (MT exec #561/#564, docs #565, version bump #566; final pre-tag PR open) | [#561](https://github.com/mkhomutov/Persatrix/pull/561), [#564](https://github.com/mkhomutov/Persatrix/pull/564), [#565](https://github.com/mkhomutov/Persatrix/pull/565), [#566](https://github.com/mkhomutov/Persatrix/pull/566) | 2026-06-06 |
-| 4 | 4 | v0.3.7 tag + post-release follow-up | `feature/v037-post-release` | ⬜ Not started | — | — |
+| 3 | 3 | v0.3.7 release-prep execution (MT exec → doc sweep → version bump + changelog → final pre-tag verification) | `feature/v037-release-prep-…` | ✅ Merged (MT exec #561/#564, docs #565, version bump #566, final pre-tag #567) | [#561](https://github.com/mkhomutov/Persatrix/pull/561), [#564](https://github.com/mkhomutov/Persatrix/pull/564), [#565](https://github.com/mkhomutov/Persatrix/pull/565), [#566](https://github.com/mkhomutov/Persatrix/pull/566), [#567](https://github.com/mkhomutov/Persatrix/pull/567) | 2026-06-06 |
+| 4 | 4 | v0.3.7 tag + post-release follow-up | `feature/v037-post-release` | 🔀 PR open (this PR) | [#568](https://github.com/mkhomutov/Persatrix/pull/568) | — |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged · ⏭ Deferred
 

--- a/docs/v0.3.7-release-checklist.md
+++ b/docs/v0.3.7-release-checklist.md
@@ -1,6 +1,6 @@
 # v0.3.7 Release Checklist
 
-> **Status**: ✅ Released — **final pre-tag verification (PR 4) green on the post-bump tip `45f414b`.** The full automated gate sweep re-ran green live on host, the persona-memory v12→v14 upgrade-on-open release gate passed, and the live Anthropic Docker smoke carries forward from the PR 1 run on `92a5a00`; see the [execution report § Re-Execution — Release-Prep PR 4](manual-tests/v0.3.7-execution-report.md#re-execution--release-prep-pr-4-post-version-bump-rc-tip). Only the mechanical `v0.3.7` tag + GitHub Release ([Phase 4](v0.3.7-plan.md#phase-4--tag-and-post-release-follow-up)) remain. This checklist is created by [release-prep plan PR 2](v0.3.7-release-prep-plan.md#pr-2--readme--roadmap--channelspersona-guide-verification--release-checklist) (docs surface). §1 (Pre-release Verification) and §2 (Version Alignment) are executed by [PR 3](v0.3.7-release-prep-plan.md#pr-3--version-bump--changelog-curation) (version bump + changelog) and re-certified live by [PR 4](v0.3.7-release-prep-plan.md#pr-4--final-pre-tag-verification--release-notes) on the post-version-bump tip; §3.1 (Upgrade Notes) is the canonical source PR 3 reconciles into `CHANGELOG.md`. §4 (Manual Test Sign-off) references the [MT execution report](manual-tests/v0.3.7-execution-report.md) landed by [PR 1](https://github.com/mkhomutov/Persatrix/pull/561) (re-run on the post-fix tip, [#564](https://github.com/mkhomutov/Persatrix/pull/564)) — a **clean pass**: both v0.3.7 headline gates and the combined realism walkthrough passed **live on Anthropic** (RC tip `92a5a00`), so no live hard-block is outstanding.
+> **Status**: ✅ Released — **final pre-tag verification (PR 4) green on the post-bump tip `45f414b`.** The full automated gate sweep re-ran green live on host, the persona-memory v12→v14 upgrade-on-open release gate passed, and the live Anthropic Docker smoke carries forward from the PR 1 run on `92a5a00`; see the [execution report § Re-Execution — Release-Prep PR 4](manual-tests/v0.3.7-execution-report.md#re-execution--release-prep-pr-4-post-version-bump-rc-tip). The mechanical [Phase 4](v0.3.7-plan.md#phase-4--tag-and-post-release-follow-up) steps are **done**: `v0.3.7` is tagged and the [GitHub Release](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) is published (2026-06-06). This checklist is created by [release-prep plan PR 2](v0.3.7-release-prep-plan.md#pr-2--readme--roadmap--channelspersona-guide-verification--release-checklist) (docs surface). §1 (Pre-release Verification) and §2 (Version Alignment) are executed by [PR 3](v0.3.7-release-prep-plan.md#pr-3--version-bump--changelog-curation) (version bump + changelog) and re-certified live by [PR 4](v0.3.7-release-prep-plan.md#pr-4--final-pre-tag-verification--release-notes) on the post-version-bump tip; §3.1 (Upgrade Notes) is the canonical source PR 3 reconciles into `CHANGELOG.md`. §4 (Manual Test Sign-off) references the [MT execution report](manual-tests/v0.3.7-execution-report.md) landed by [PR 1](https://github.com/mkhomutov/Persatrix/pull/561) (re-run on the post-fix tip, [#564](https://github.com/mkhomutov/Persatrix/pull/564)) — a **clean pass**: both v0.3.7 headline gates and the combined realism walkthrough passed **live on Anthropic** (RC tip `92a5a00`), so no live hard-block is outstanding.
 
 > v0.3.7 — "Conversations worth watching" — ships the **realism rung**: the three workstreams that make a group channel read like colleagues rather than bots. **[RFC 0034 Phase 2](rfcs/0034-persona-conversational-working-memory.md) group-channel working memory** — each persona sees the in-progress transcript with per-peer `[<peer_id>]: ` attribution and builds on a specific peer's contribution. **[RFC 0030 relevance Tier A](rfcs/0030-amendment-relevance-gated-response.md) + the `respond_policy → disposition` reframe** — a directed `@`-question is answered by exactly the addressee (others suppressed `directed_elsewhere`, zero-cost), open-floor admits all participants, and an `@everyone` broadcast disables the directed filter. **The peer-voice prompt** — personas address each other by name and build on the round rather than performing assistant-helpfulness. Folded in: the **F-1…F-7 conversation test-findings cluster**, capped by the **[F-7 Option D](issues/ISSUE-0093-person-identity-cross-room-tier.md) person-identity-on-the-cross-room-tier** migration. The user-facing promise: *open a multi-persona group channel, ask one persona a question, and exactly that persona answers — then ask the room and watch an ordered, mutually-aware round that reads like colleagues.*
 
@@ -150,11 +150,11 @@ git push origin v0.3.7
 
 GitHub Release checklist (post-merge manual steps after PR 4 merges, by [v0.3.7-plan Phase 4](v0.3.7-plan.md#phase-4--tag-and-post-release-follow-up)):
 
-- [ ] Create the GitHub Release from tag `v0.3.7`
-- [ ] Use the curated `[0.3.7]` changelog section as the release notes baseline
-- [ ] Include upgrade notes (§3.1 — incl. the identity migration) in the release body
-- [ ] Include known gaps (§6) in the release body
-- [ ] Attach binaries or container references if produced for this release — none expected (matches the v0.3.6 / v0.3.5 / v0.3.4 … pattern)
+- [x] Create the GitHub Release from tag `v0.3.7` — [v0.3.7 — Conversations worth watching](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) (published 2026-06-06)
+- [x] Use the curated `[0.3.7]` changelog section as the release notes baseline
+- [x] Include upgrade notes (§3.1 — incl. the identity migration) in the release body
+- [x] Include known gaps (§6) in the release body
+- [ ] Attach binaries or container references if produced for this release — none expected (matches the v0.3.6 / v0.3.5 / v0.3.4 … pattern); **none produced**
 
 ---
 
@@ -209,6 +209,6 @@ Single-page go/no-go gate. All items must be checked before tagging.
 [x] Persona-memory upgrade-on-open verified — pre-v0.3.7 DB → v14 clean (identity column + backfill, no data loss); already-v14 DB no-op; legacy respond_policy config loads unchanged (PR 4, release gate)
 [x] Docker smoke — directed→one reply + ordered mutually-aware open round + @everyone→all (REST + --mention-all) + DM turn + in-image v14 migration (PR 1 ran live on 92a5a00; PR 4 re-runs on the exact tag tip)
 [x] Known gaps documented for release notes (§6 above)
-[ ] git tag v0.3.7 created and pushed (Phase 4)
-[ ] GitHub Release published with changelog, upgrade notes, and known gaps (Phase 4)
+[x] git tag v0.3.7 created and pushed (Phase 4)
+[x] GitHub Release published with changelog, upgrade notes, and known gaps (Phase 4)
 ```

--- a/docs/v0.3.7-release-prep-plan.md
+++ b/docs/v0.3.7-release-prep-plan.md
@@ -1,6 +1,6 @@
 # v0.3.7 Release Preparation Plan
 
-**Status**: ✅ Complete — all release-prep PRs merged; PR 4 (final pre-tag verification) open. The only remaining work is the mechanical `v0.3.7` tag + GitHub Release ([Phase 4](v0.3.7-plan.md#phase-4--tag-and-post-release-follow-up)).
+**Status**: ✅ Complete — all release-prep PRs merged (PR 4 final pre-tag verification [#567](https://github.com/mkhomutov/Persatrix/pull/567)); the mechanical [Phase 4](v0.3.7-plan.md#phase-4--tag-and-post-release-follow-up) is done — `v0.3.7` is tagged and the [GitHub Release](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) is published (2026-06-06).
 **Target version**: v0.3.7 (Conversations worth watching — the realism rung: [RFC 0034 Phase 2](rfcs/0034-persona-conversational-working-memory.md) group working memory + [RFC 0030 relevance Tier A + the `respond_policy → disposition` reframe](rfcs/0030-amendment-relevance-gated-response.md) + the peer-voice prompt)
 **Created**: 2026-06-06
 **Branch prefix**: `feature/v037-release-prep-`
@@ -47,7 +47,7 @@ Update this table as each PR merges. Flip **Status** and add the GitHub PR numbe
 | 1 | A | MT execution report (`MT-CHANNEL-RELEVANCE-001` directedness + `MT-PERSONA-CONVERSATION-002` group continuity + the combined realism walkthrough + carried-forward v0.3.6 surface) | `feature/v037-release-prep-mt-exec` | ✅ Merged | [#561](https://github.com/mkhomutov/Persatrix/pull/561) (re-run on the post-F-8-fix tip [#564](https://github.com/mkhomutov/Persatrix/pull/564)) | 2026-06-06 |
 | 2 | A | README + ROADMAP + channels/persona guide verification + release checklist | `feature/v037-release-prep-docs` | ✅ Merged | [#565](https://github.com/mkhomutov/Persatrix/pull/565) | 2026-06-06 |
 | 3 | B | Version bump (`0.3.6` → `0.3.7`) + changelog `[0.3.7]` curation | `feature/v037-release-prep-version-bump` | ✅ Merged | [#566](https://github.com/mkhomutov/Persatrix/pull/566) | 2026-06-06 |
-| 4 | B | Final pre-tag verification (incl. identity-migration upgrade-on-open) & release notes | `feature/v037-release-prep-final` | 🔀 PR open (this PR) | — | — |
+| 4 | B | Final pre-tag verification (incl. identity-migration upgrade-on-open) & release notes | `feature/v037-release-prep-final` | ✅ Merged | [#567](https://github.com/mkhomutov/Persatrix/pull/567) | 2026-06-06 |
 
 **Status legend**: ⬜ Not started · 🔄 In progress · 🔀 PR open · ✅ Merged
 


### PR DESCRIPTION
`v0.3.7` was tagged and the [GitHub Release "Conversations worth watching"](https://github.com/mkhomutov/Persatrix/releases/tag/v0.3.7) published 2026-06-06. This is the Phase 4 **post-release follow-up** — it sweeps the status docs that still described the tag/Release as a *pending* step and flips them to the published state. Follows the established cadence ([#528](https://github.com/mkhomutov/Persatrix/pull/528) for v0.3.6, [#492](https://github.com/mkhomutov/Persatrix/pull/492) for v0.3.5, …).

## Ground truth verified
- Tag `v0.3.7` is pushed to `origin` (annotated, on `main` tip `182bf4f`).
- GitHub Release **v0.3.7 — Conversations worth watching** is published (2026-06-06, marked Latest, not a draft).

## Changes
- **ROADMAP.md** — concise "Last updated" note (links the GitHub Release, points at the next phase v0.3.8); **Merged PR History backfilled** with the full v0.3.7 cycle (#528 → this PR — the table had stopped at #527). The Version Map v0.3.7 row + header `Current phase` / `Current milestone` already flipped to ✅ Released in release-prep PR 4 ([#567](https://github.com/mkhomutov/Persatrix/pull/567)).
- **docs/v0.3.7-plan.md** — Status 📋 Proposed → ✅ Complete; `Completed: 2026-06-06`; Master Progress Overview row 3 → final pre-tag #567 merged; row 4 (Phase 4) → 🔀 PR open (this PR).
- **docs/v0.3.7-release-checklist.md** — status blurb → published-Release with the Release URL; §5 GitHub Release procedure items ticked; §7 tag/release summary gates ticked. *Attach binaries* left unchecked (none produced — matches the v0.3.6 / v0.3.5 / … pattern).
- **docs/v0.3.7-release-prep-plan.md** — Progress Overview PR 4 row → ✅ Merged (#567, 2026-06-06); status blurb → published-Release state.

## Deliberately untouched
- `docs/manual-tests/v0.3.7-execution-report.md` — a dated point-in-time record of PR 4's re-execution.
- `CHANGELOG.md` — by convention the follow-up lands in the next version's changelog.

## Verification
No code changes; no tests affected. Doc gates green:
- `doc_links` — 7663 links / 367 files OK
- `doc_status_markers` — OK
- `file_size --strict` — OK
- `doc_audit` — 0 violations