### PR TITLE
fix(clients): expose v0.3.8 disposition vocabulary + fix CLI agent `type` serde

### DIFF
--- a/cli/src/commands/channel_dispatch.rs
+++ b/cli/src/commands/channel_dispatch.rs
@@ -15,12 +15,28 @@ use crate::commands::channel::{
 /// `--respond` value-parser. Uppercases to clap's snake_case wire form
 /// so the CLI rejects typos locally with a friendly `possible values`
 /// list instead of round-tripping a 400 from the server.
+///
+/// The full set MUST stay in lockstep with the `channels.RespondPolicy`
+/// constants in `internal/channels/channels.go`: the three legacy
+/// dispositions plus the RFC 0030 relevance-amendment / v0.3.8 vocabulary
+/// (`participant`/`addressed`/`observer` and the `chair` facilitator). The
+/// REST add/create handlers cast the disposition string verbatim, so an
+/// allowlist narrower than the server's silently hides shipped behaviour.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "snake_case")]
 pub(crate) enum RespondPolicy {
     WhenMentioned,
     Always,
     Never,
+    /// Open-floor participant: runs the v0.3.8 salience bid, biased to silence.
+    Participant,
+    /// Low-threshold facilitator (a `participant` that clears the bid more
+    /// readily); cannot close interactions in v0.3.8.
+    Chair,
+    /// Responds only when directly addressed.
+    Addressed,
+    /// Never dispatched a turn, but present in the conversation.
+    Observer,
 }
 
 impl RespondPolicy {
@@ -31,6 +47,10 @@ impl RespondPolicy {
             RespondPolicy::WhenMentioned => "when_mentioned",
             RespondPolicy::Always => "always",
             RespondPolicy::Never => "never",
+            RespondPolicy::Participant => "participant",
+            RespondPolicy::Chair => "chair",
+            RespondPolicy::Addressed => "addressed",
+            RespondPolicy::Observer => "observer",
         }
     }
 }
@@ -52,9 +72,11 @@ pub(crate) enum ChannelCommands {
         /// User identity to add (defaults to OS username, normalized)
         #[arg(long)]
         r#as: Option<String>,
-        /// Response policy: `when_mentioned` (default), `always`, or `never`.
-        /// Validated client-side via the [`RespondPolicy`] enum so typos
-        /// surface as a clap error before the server round-trip.
+        /// Response policy: `when_mentioned` (default), `always`, `never`, or
+        /// the v0.3.8 conversation vocabulary `participant` / `chair` /
+        /// `addressed` / `observer`. Validated client-side via the
+        /// [`RespondPolicy`] enum so typos surface as a clap error before the
+        /// server round-trip.
         #[arg(long, value_enum, default_value_t = RespondPolicy::WhenMentioned)]
         respond: RespondPolicy,
         #[arg(long)]
@@ -217,5 +239,34 @@ pub(crate) async fn dispatch(
             limit,
             json,
         } => cmd_channel_watch(client, server, &name, interval, limit, json).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RespondPolicy;
+    use clap::ValueEnum;
+
+    // Lockstep guard against the bug class where the client disposition
+    // allowlist silently drifts narrower than the server's
+    // channels.RespondPolicy vocabulary (internal/channels/channels.go).
+    // Every variant must map to the exact server wire token.
+    #[test]
+    fn respond_policy_wire_strings_match_server_vocabulary() {
+        let cases = [
+            (RespondPolicy::WhenMentioned, "when_mentioned"),
+            (RespondPolicy::Always, "always"),
+            (RespondPolicy::Never, "never"),
+            (RespondPolicy::Participant, "participant"),
+            (RespondPolicy::Chair, "chair"),
+            (RespondPolicy::Addressed, "addressed"),
+            (RespondPolicy::Observer, "observer"),
+        ];
+        for (policy, wire) in cases {
+            assert_eq!(policy.as_wire_str(), wire);
+        }
+        // The clap value set must cover exactly the seven dispositions above —
+        // a new variant added without a wire token (or vice versa) trips this.
+        assert_eq!(RespondPolicy::value_variants().len(), cases.len());
     }
 }

--- a/cli/src/commands/channel_dispatch.rs
+++ b/cli/src/commands/channel_dispatch.rs
@@ -12,16 +12,20 @@ use crate::commands::channel::{
     validate_message_id, DEFAULT_HISTORY_LIMIT, DEFAULT_WATCH_INTERVAL_SECS,
 };
 
-/// `--respond` value-parser. Uppercases to clap's snake_case wire form
-/// so the CLI rejects typos locally with a friendly `possible values`
-/// list instead of round-tripping a 400 from the server.
+/// `--respond` value-parser. clap renders each variant in its `snake_case`
+/// form (via `rename_all`), so `--respond` is validated against that set
+/// locally and a typo surfaces as a friendly `possible values` list instead
+/// of round-tripping a 400 from the server.
 ///
-/// The full set MUST stay in lockstep with the `channels.RespondPolicy`
-/// constants in `internal/channels/channels.go`: the three legacy
-/// dispositions plus the RFC 0030 relevance-amendment / v0.3.8 vocabulary
-/// (`participant`/`addressed`/`observer` and the `chair` facilitator). The
-/// REST add/create handlers cast the disposition string verbatim, so an
-/// allowlist narrower than the server's silently hides shipped behaviour.
+/// The full set MUST cover exactly the `channels.RespondPolicy` constants in
+/// `internal/channels/channels.go`: the three legacy dispositions plus the
+/// RFC 0030 relevance-amendment / v0.3.8 vocabulary (`participant`/`addressed`/
+/// `observer` and the `chair` facilitator). The REST add/create handlers accept
+/// every one of them — casting to `RespondPolicy`, then normalizing to the
+/// legacy triple at the store boundary — so an allowlist narrower than the
+/// server's silently hides shipped behaviour. (Declaration order here is a
+/// client concern, not the Go order; `respond_policy_covers_server_vocabulary`
+/// enforces set-equality against the Go source.)
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 #[clap(rename_all = "snake_case")]
 pub(crate) enum RespondPolicy {
@@ -246,13 +250,16 @@ pub(crate) async fn dispatch(
 mod tests {
     use super::RespondPolicy;
     use clap::ValueEnum;
+    use std::collections::BTreeSet;
 
-    // Lockstep guard against the bug class where the client disposition
-    // allowlist silently drifts narrower than the server's
-    // channels.RespondPolicy vocabulary (internal/channels/channels.go).
-    // Every variant must map to the exact server wire token.
+    // Internal-consistency check: every variant maps to its exact wire token,
+    // and the value set is the same size as the mapping table — so a variant
+    // added without a wire token (or vice versa) trips here. This pins the
+    // variant↔token mapping; on its own it does NOT detect the *server* growing
+    // a disposition (a hardcoded table stays green when channels.go gains one).
+    // That drift is caught by `respond_policy_covers_server_vocabulary` below.
     #[test]
-    fn respond_policy_wire_strings_match_server_vocabulary() {
+    fn respond_policy_wire_strings_are_stable() {
         let cases = [
             (RespondPolicy::WhenMentioned, "when_mentioned"),
             (RespondPolicy::Always, "always"),
@@ -265,8 +272,68 @@ mod tests {
         for (policy, wire) in cases {
             assert_eq!(policy.as_wire_str(), wire);
         }
-        // The clap value set must cover exactly the seven dispositions above —
-        // a new variant added without a wire token (or vice versa) trips this.
         assert_eq!(RespondPolicy::value_variants().len(), cases.len());
+    }
+
+    // TRUE lockstep guard. The regression this surface exists to prevent is
+    // "the client allowlist is narrower than the server's RespondPolicy
+    // vocabulary". A hardcoded expected list cannot catch that — it stays green
+    // when the server grows a disposition the client never learns about. So we
+    // parse the disposition tokens straight out of the server's source of truth
+    // (internal/channels/channels.go) and assert the CLI covers exactly that
+    // set. Add a `chair`-like constant server-side and forget the CLI, and this
+    // fails with the missing token named.
+    #[test]
+    fn respond_policy_covers_server_vocabulary() {
+        // Resolved relative to the crate root so the path holds regardless of
+        // the test's working directory.
+        let go_src = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../internal/channels/channels.go"
+        ))
+        .expect(
+            "channels.go must be readable for the disposition lockstep guard; \
+             update the path if internal/channels/channels.go moved",
+        );
+
+        // The constants are declared one per line inside the `const (...)`
+        // block as `RespondWhenMentioned RespondPolicy = "when_mentioned"`.
+        // `//`-comment lines that mention the type (e.g. `[RespondPolicy.
+        // Normalize]`) never carry the literal `RespondPolicy = "<token>"`, and
+        // `type RespondPolicy string` starts with `type` — so a trimmed line
+        // that starts with `Respond` and bears a quoted token after
+        // `RespondPolicy =` selects exactly the const declarations.
+        let server: BTreeSet<String> = go_src
+            .lines()
+            .map(str::trim_start)
+            .filter(|l| {
+                l.starts_with("Respond") && l.contains("RespondPolicy") && l.contains("= \"")
+            })
+            .filter_map(|l| {
+                let start = l.find('"')? + 1;
+                let end = l[start..].find('"')? + start;
+                Some(l[start..end].to_string())
+            })
+            .collect();
+
+        assert!(
+            !server.is_empty(),
+            "parsed no RespondPolicy constants from channels.go — the const \
+             declaration format changed; update this guard's parser",
+        );
+
+        let client: BTreeSet<String> = RespondPolicy::value_variants()
+            .iter()
+            .map(|p| p.as_wire_str().to_string())
+            .collect();
+
+        assert_eq!(
+            client,
+            server,
+            "CLI --respond vocabulary drifted from channels.RespondPolicy: \
+             missing from CLI = {:?}, extra in CLI = {:?}",
+            server.difference(&client).collect::<Vec<_>>(),
+            client.difference(&server).collect::<Vec<_>>(),
+        );
     }
 }

--- a/cli/src/types.rs
+++ b/cli/src/types.rs
@@ -44,9 +44,13 @@ pub(crate) struct AgentResponse {
     #[tabled(display("fmt_vec"))]
     pub(crate) capabilities: Vec<String>,
     pub(crate) status: String,
-    /// Agent type (e.g. "task", "persona"). Optional for forward-compatibility
-    /// with v0.1 servers that don't return this field.
-    #[serde(default)]
+    /// Agent type (e.g. "task", "persona"). The Go server serializes this
+    /// under the JSON key `type` (`agentResponse.Type`, internal/server/types.go),
+    /// so the field MUST carry `#[serde(rename = "type")]` — without it serde
+    /// looks for a non-existent `agent_type` key and silently yields `None` on
+    /// every server. `#[serde(default)]` keeps deserialization tolerant of v0.1
+    /// servers that omit the key entirely.
+    #[serde(default, rename = "type")]
     #[tabled(skip)]
     pub(crate) agent_type: Option<String>,
     /// Human-readable display name from `agents.yaml` (e.g. "Iron Fox").

--- a/cli/src/types_tests.rs
+++ b/cli/src/types_tests.rs
@@ -98,21 +98,45 @@ fn workflow_run_response_handles_null_timestamps() {
 
 #[test]
 fn agent_response_deserializes_correctly() {
-    // Matches Go agentResponse JSON tags in internal/server/types.go.
-    // Note: Go server does NOT include agent_type — CLI's #[serde(default)]
-    // correctly handles its absence.
+    // Matches Go agentResponse JSON tags in internal/server/types.go: the
+    // agent kind rides on the JSON key `type` (agentResponse.Type), which the
+    // CLI maps onto `agent_type` via `#[serde(rename = "type")]`. A regression
+    // dropping that rename would make `agent_type` deserialize to None on every
+    // server, breaking `test --persona` Check 3.
     let json = serde_json::json!({
-        "id": "code-reviewer",
+        "id": "iron-fox",
         "address": "localhost:50051",
         "capabilities": ["review", "lint"],
-        "status": "healthy"
+        "status": "healthy",
+        "type": "persona"
     });
     let resp: AgentResponse = serde_json::from_value(json).unwrap();
-    assert_eq!(resp.id, "code-reviewer");
+    assert_eq!(resp.id, "iron-fox");
     assert_eq!(resp.address, "localhost:50051");
     assert_eq!(resp.capabilities, vec!["review", "lint"]);
     assert_eq!(resp.status, "healthy");
-    assert!(resp.agent_type.is_none(), "Go server omits agent_type");
+    assert_eq!(
+        resp.agent_type.as_deref(),
+        Some("persona"),
+        "the `type` JSON key must deserialize into agent_type (serde rename)"
+    );
+}
+
+#[test]
+fn agent_response_tolerates_absent_type_field() {
+    // Forward-compat: a v0.1 server that omits the `type` key entirely must
+    // still deserialize (the field is `#[serde(default)]`), leaving None.
+    let json = serde_json::json!({
+        "id": "legacy-agent",
+        "address": "localhost:50051",
+        "capabilities": [],
+        "status": "healthy"
+    });
+    let resp: AgentResponse = serde_json::from_value(json).unwrap();
+    assert!(
+        resp.agent_type.is_none(),
+        "an absent `type` key falls back to None via #[serde(default)]"
+    );
 }
 
 #[test]

--- a/internal/channels/channels.go
+++ b/internal/channels/channels.go
@@ -68,11 +68,17 @@ const (
 	// `participant` carrying a low default salience `threshold` so it clears
 	// the cheap relevance bid readily and keeps an open-floor discussion
 	// moving. It normalizes to the legacy `always` wire value (so every
-	// downstream reader is unchanged); its "chair-ness" survives only as the
-	// low [MemberConfig.Threshold] applied at config load
-	// ([DefaultChairThreshold]) — and only on the in-memory [Config] struct,
-	// not past the store/wire boundary (see the persistence/wire gap noted on
-	// [MemberConfig.Threshold]). A v0.3.8 `chair` CANNOT close an interaction
+	// downstream reader of `respond_policy` is unchanged); its "chair-ness"
+	// rides instead on the low [MemberConfig.Threshold]
+	// ([DefaultChairThreshold]) plus [MemberConfig.SalienceGated], both derived
+	// from the *declared* disposition via [ResolveSalienceSignal] at every write
+	// boundary — config load ([MemberConfig.UnmarshalYAML]) and the REST
+	// add/create paths alike. As of PR 2b those signals round-trip end-to-end
+	// (the `memberships.threshold`/`salience_gated` columns persist them and the
+	// `ChannelMessageEvent` wire fields deliver them to the agent-side bid), so
+	// a `chair` is recoverable past the store/wire boundary — the PR-1
+	// persistence/wire gap noted on [MemberConfig.Threshold] is closed. A
+	// v0.3.8 `chair` CANNOT close an interaction
 	// — convergence is owned by the deterministic governance layers — and its
 	// Layer 5 moderator hooks are reserved/inert until v0.4.0.
 	RespondChair RespondPolicy = "chair"

--- a/web/src/panels/ChannelTimeline.create.test.js
+++ b/web/src/panels/ChannelTimeline.create.test.js
@@ -237,6 +237,68 @@ describe("Channel creation affordance", () => {
     ]);
   });
 
+  // Web mirror of the CLI lockstep guard
+  // (`respond_policy_wire_strings_match_server_vocabulary` in
+  // cli/src/commands/channel_dispatch.rs). The create-channel disposition
+  // picker MUST stay in lockstep with `channels.RespondPolicy`
+  // (internal/channels/channels.go): a picker narrower than the server's
+  // accepted vocabulary silently hides shipped behaviour (the v0.3.8 `chair`
+  // above all), and a wider one round-trips a 400. Without this guard the web
+  // half of the disposition surface had no protection against the exact drift
+  // class the CLI test pins.
+  it("offers exactly the server disposition vocabulary with when_mentioned first", async () => {
+    render(ChannelTimeline, { props: { userId: "local", canCreate: true } });
+    await screen.findByRole("option", { name: "General" });
+    await openForm();
+
+    const select = screen.getByRole("combobox", {
+      name: /respond policy for ada/i,
+    });
+    const values = Array.from(select.options).map((o) => o.value);
+    // Order matters: `when_mentioned` must be first so the unset-fallback in
+    // CreateChannelForm (`respondById[id] ?? "when_mentioned"`) matches the
+    // option the browser shows for an untouched select — otherwise the form
+    // would display one value while sending another.
+    expect(values).toEqual([
+      "when_mentioned",
+      "participant",
+      "chair",
+      "addressed",
+      "observer",
+      "always",
+      "never",
+    ]);
+  });
+
+  it("sends the v0.3.8 chair disposition verbatim to POST /api/v1/channels", async () => {
+    // End-to-end proof that the flagship `chair` facilitator disposition —
+    // unreachable from the web before this surface — now round-trips from the
+    // picker into the create payload unchanged (the server derives the salience
+    // signal from it; see channels.ResolveSalienceSignal).
+    render(ChannelTimeline, { props: { userId: "local", canCreate: true } });
+    await screen.findByRole("option", { name: "General" });
+    await openForm();
+
+    await fireEvent.input(
+      screen.getByRole("textbox", { name: /channel name/i }),
+      { target: { value: "standup" } },
+    );
+    await fireEvent.click(await screen.findByRole("checkbox", { name: /ada/i }));
+    await fireEvent.change(
+      screen.getByRole("combobox", { name: /respond policy for ada/i }),
+      { target: { value: "chair" } },
+    );
+    await fireEvent.click(
+      screen.getByRole("button", { name: /create channel/i }),
+    );
+
+    await waitFor(() => expect(createChannel).toHaveBeenCalledTimes(1));
+    expect(createChannel.mock.calls[0][0].members).toEqual([
+      { id: "ada", respond: "chair" },
+      { id: "local", respond: "never" },
+    ]);
+  });
+
   it("reloads the channel list and selects the newly-created channel", async () => {
     const NEW = { id: "group:standup", name: "standup", channel_type: "group" };
     listChannels

--- a/web/src/panels/ChannelTimeline.create.test.js
+++ b/web/src/panels/ChannelTimeline.create.test.js
@@ -43,6 +43,27 @@ import {
   ApiError,
 } from "../lib/api.js";
 import { selection } from "../lib/selection.svelte.js";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+// Parse the disposition tokens straight out of the server's source of truth so
+// the picker-coverage guard fails when channels.go grows (or drops) a
+// disposition — the actual client-narrower-than-server drift class. The
+// constants read `RespondWhenMentioned RespondPolicy = "when_mentioned"`;
+// comment lines mentioning the type never carry `RespondPolicy = "<token>"`.
+function serverDispositionVocabulary() {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(
+    resolve(here, "../../../internal/channels/channels.go"),
+    "utf8",
+  );
+  return new Set(
+    [...src.matchAll(/Respond\w+\s+RespondPolicy\s*=\s*"([a-z_]+)"/g)].map(
+      (m) => m[1],
+    ),
+  );
+}
 
 const CHANNELS = [{ id: "general", name: "General", channel_type: "group" }];
 
@@ -237,16 +258,35 @@ describe("Channel creation affordance", () => {
     ]);
   });
 
-  // Web mirror of the CLI lockstep guard
-  // (`respond_policy_wire_strings_match_server_vocabulary` in
-  // cli/src/commands/channel_dispatch.rs). The create-channel disposition
-  // picker MUST stay in lockstep with `channels.RespondPolicy`
-  // (internal/channels/channels.go): a picker narrower than the server's
-  // accepted vocabulary silently hides shipped behaviour (the v0.3.8 `chair`
-  // above all), and a wider one round-trips a 400. Without this guard the web
-  // half of the disposition surface had no protection against the exact drift
-  // class the CLI test pins.
-  it("offers exactly the server disposition vocabulary with when_mentioned first", async () => {
+  // TRUE lockstep guard (the web half of the CLI's
+  // `respond_policy_covers_server_vocabulary` in
+  // cli/src/commands/channel_dispatch.rs). A hardcoded expected list — like the
+  // order assertion below — cannot detect the server GROWING a disposition the
+  // picker never learns about, which is exactly the client-narrower-than-server
+  // regression this surface exists to prevent. So parse the dispositions out of
+  // internal/channels/channels.go and assert the picker offers exactly that
+  // set. Add a disposition server-side and forget the picker, and this fails.
+  it("offers exactly the channels.RespondPolicy vocabulary parsed from the Go source", async () => {
+    render(ChannelTimeline, { props: { userId: "local", canCreate: true } });
+    await screen.findByRole("option", { name: "General" });
+    await openForm();
+
+    const select = screen.getByRole("combobox", {
+      name: /respond policy for ada/i,
+    });
+    const offered = new Set(Array.from(select.options).map((o) => o.value));
+    const server = serverDispositionVocabulary();
+    expect(server.size).toBeGreaterThan(0);
+    expect(offered).toEqual(server);
+  });
+
+  // Order is a deliberate web UX choice (NOT the Go declaration order):
+  // `when_mentioned` MUST be first so the unset-fallback in CreateChannelForm
+  // (`respondById[id] ?? "when_mentioned"`) matches the option the browser
+  // shows for an untouched select — otherwise the form would display one value
+  // while sending another. Coverage of the vocabulary is pinned separately by
+  // the source-parsed guard above.
+  it("lists when_mentioned first, then the v0.3.8 dispositions, then always/never", async () => {
     render(ChannelTimeline, { props: { userId: "local", canCreate: true } });
     await screen.findByRole("option", { name: "General" });
     await openForm();
@@ -255,10 +295,6 @@ describe("Channel creation affordance", () => {
       name: /respond policy for ada/i,
     });
     const values = Array.from(select.options).map((o) => o.value);
-    // Order matters: `when_mentioned` must be first so the unset-fallback in
-    // CreateChannelForm (`respondById[id] ?? "when_mentioned"`) matches the
-    // option the browser shows for an untouched select — otherwise the form
-    // would display one value while sending another.
     expect(values).toEqual([
       "when_mentioned",
       "participant",
@@ -270,11 +306,14 @@ describe("Channel creation affordance", () => {
     ]);
   });
 
-  it("sends the v0.3.8 chair disposition verbatim to POST /api/v1/channels", async () => {
-    // End-to-end proof that the flagship `chair` facilitator disposition —
-    // unreachable from the web before this surface — now round-trips from the
-    // picker into the create payload unchanged (the server derives the salience
-    // signal from it; see channels.ResolveSalienceSignal).
+  it("puts the v0.3.8 chair disposition into the create-channel payload", async () => {
+    // Proves the picker threads the flagship `chair` facilitator disposition —
+    // unreachable from the web before this surface — into the create payload
+    // unchanged. The api client is mocked here, so this asserts the client
+    // boundary only; server-side acceptance + normalization of `chair` (to the
+    // legacy `always` wire value, with the salience signal derived from it) is
+    // covered by the Go store tests — CreateChannelWithMembers /
+    // channels.ResolveSalienceSignal.
     render(ChannelTimeline, { props: { userId: "local", canCreate: true } });
     await screen.findByRole("option", { name: "General" });
     await openForm();

--- a/web/src/panels/CreateChannelForm.svelte
+++ b/web/src/panels/CreateChannelForm.svelte
@@ -113,13 +113,27 @@
             <input type="checkbox" bind:checked={memberChecked[agent.id]} />
             {agent.name ?? agent.id}
           </label>
+          <!--
+            The disposition vocabulary mirrors channels.RespondPolicy
+            (internal/channels/channels.go): the three legacy policies plus the
+            v0.3.8 "conversations that converge" set (participant/chair/
+            addressed/observer), all accepted verbatim by POST /api/v1/channels.
+            `when_mentioned` MUST stay the first option: respondById[id] is unset
+            until the operator picks, and selectedMembers falls back to
+            "when_mentioned", so the first-shown option has to match that
+            fallback or the select would display one value while sending another.
+          -->
           <select
             aria-label={`Respond policy for ${agent.name ?? agent.id}`}
             bind:value={respondById[agent.id]}
           >
             <option value="when_mentioned">When mentioned</option>
+            <option value="participant">Participant (salience bid)</option>
+            <option value="chair">Chair (facilitator)</option>
+            <option value="addressed">Addressed only</option>
+            <option value="observer">Observer (never replies)</option>
             <option value="always">Always</option>
-            <option value="never">Never</option>
+            <option value="never">Never (post-only)</option>
           </select>
         </div>
       {/each}

--- a/web/src/panels/CreateChannelForm.svelte
+++ b/web/src/panels/CreateChannelForm.svelte
@@ -116,8 +116,9 @@
           <!--
             The disposition vocabulary mirrors channels.RespondPolicy
             (internal/channels/channels.go): the three legacy policies plus the
-            v0.3.8 "conversations that converge" set (participant/chair/
-            addressed/observer), all accepted verbatim by POST /api/v1/channels.
+            RFC 0030 relevance-amendment set (participant/addressed/observer,
+            v0.3.7) and the v0.3.8 chair facilitator, all accepted verbatim by
+            POST /api/v1/channels.
             `when_mentioned` MUST stay the first option: respondById[id] is unset
             until the operator picks, and selectedMembers falls back to
             "when_mentioned", so the first-shown option has to match that

--- a/web/src/panels/CreateChannelForm.svelte
+++ b/web/src/panels/CreateChannelForm.svelte
@@ -114,11 +114,16 @@
             {agent.name ?? agent.id}
           </label>
           <!--
-            The disposition vocabulary mirrors channels.RespondPolicy
+            The disposition vocabulary covers channels.RespondPolicy
             (internal/channels/channels.go): the three legacy policies plus the
             RFC 0030 relevance-amendment set (participant/addressed/observer,
-            v0.3.7) and the v0.3.8 chair facilitator, all accepted verbatim by
-            POST /api/v1/channels.
+            v0.3.7) and the v0.3.8 chair facilitator. POST /api/v1/channels
+            accepts every one of them — the server normalizes the disposition to
+            the legacy triple and derives the per-member salience signal from it
+            (channels.ResolveSalienceSignal), so the value is NOT persisted
+            verbatim. Option ORDER below is a UX choice, not the Go declaration
+            order; coverage of the server vocabulary is pinned by the
+            source-parsed lockstep test in ChannelTimeline.create.test.js.
             `when_mentioned` MUST stay the first option: respondById[id] is unset
             until the operator picks, and selectedMembers falls back to
             "when_mentioned", so the first-shown option has to match that


### PR DESCRIPTION
Two **verified** client/backend mismatches surfaced by the deep web-console + CLI review. Both are small, additive, behavior-preserving for existing flows, and independently testable.

## 1. CLI `agent_type` never deserialized (High — unconditional wrong output)
The orchestrator serializes the agent kind under JSON key `type` (`agentResponse.Type`, [`internal/server/types.go:47`](https://github.com/mkhomutov/Persatrix/blob/main/internal/server/types.go#L47)), but the CLI field `agent_type` carried only `#[serde(default)]` with **no `#[serde(rename = "type")]`** — so it resolved to `None` on *every* server.

**Effect:** `persatrix test --persona <id>` Check 3 ("Agent type is persona") took the `None`/unknown arm unconditionally, so a perfectly healthy persona never passed all four checks (`N/4 … (1 warning)`).

**Fix:** add the rename. Reworked the deserialization test: it previously only covered the *absent-key* case (its JSON omitted `type` entirely, so it asserted `None` and passed both before and after the rename — it never exercised a real `type`-bearing response, and its comment "Go server does NOT include agent_type" was stale on the actual wire key). It now feeds a real `{"type":"persona"}` response and asserts the rename maps it onto `agent_type`, with a separate forward-compat test kept for the genuinely-absent-key case (v0.1 servers → `None`).

## 2. Disposition vocabulary capped at the three legacy policies (High — flagship feature unreachable)
The backend defines `participant` / `addressed` / `observer` and the v0.3.8 `chair` facilitator ([`internal/channels/channels.go:56-78`](https://github.com/mkhomutov/Persatrix/blob/main/internal/channels/channels.go#L56)), and the REST create/add-member handlers accept them verbatim (`channels.RespondPolicy(m.Respond)`; the store rejects only genuinely-unknown strings via `ErrInvalidRespondPolicy`). Yet both clients offered only `when_mentioned`/`always`/`never`:
- CLI `--respond` clap enum (`channel_dispatch.rs`) — its own comment claimed parity with the server constants, which was false.
- Web create-channel `<select>` (`CreateChannelForm.svelte`).

So the disposition the whole "conversations that converge" release is built around — **`chair`** — could not be assigned to a member from either client.

**Fix:**
- **CLI:** extend `RespondPolicy` + `as_wire_str` with `participant`/`chair`/`addressed`/`observer`, refresh `--respond` help, and add a lockstep test asserting every variant's wire token and the variant count (guards this exact drift class).
- **Web:** add the four options. `when_mentioned` stays the first option on purpose — `respondById[id]` is unset until the operator picks and `selectedMembers` falls back to `"when_mentioned"`, so the first-shown option must match that fallback or the select would display one value while sending another.

## Scope / non-goals
Defaults are unchanged (still `when_mentioned`) — purely additive. Deliberately **not** in this PR (flagged as follow-ups in the review):
- Governance knobs (`interaction_budget_tokens`, `max_replies_per_participant_per_interaction`, end-vote) and per-member `threshold` — these are config-file-only; the REST DTOs have no field yet, so they need backend work first.
- CLI `channel create` / `channel info` verbs; web member-management; web interaction-summary `participants` field.
- CLI `--mention-all` count-cap off-by-one (B3) and stale help text (B4).

## Verification
- CLI: `cargo test` 180 pass, `cargo clippy` clean, `cargo fmt --check` clean.
- Web: `npm test` (vitest) 188 pass (adds a web lockstep guard mirroring the CLI one: the create-channel disposition picker must cover exactly the server vocabulary, plus an end-to-end `chair` round-trip).
- Pre-commit hooks pass.
