### PR TITLE
feat(web): surface interaction-summary participants

### DIFF
--- a/web/src/panels/ConversationFeed.svelte
+++ b/web/src/panels/ConversationFeed.svelte
@@ -253,5 +253,6 @@
     scope={channelId}
     agentIds={summaryAgentIds}
     {agentsById}
+    {userId}
   />
 {/if}

--- a/web/src/panels/ConversationFeed.svelte
+++ b/web/src/panels/ConversationFeed.svelte
@@ -249,5 +249,9 @@
      interaction, below the live turns. Self-fetching + additive — renders
      nothing while the conversation is open. -->
 {#if channelId}
-  <InteractionSummary scope={channelId} agentIds={summaryAgentIds} />
+  <InteractionSummary
+    scope={channelId}
+    agentIds={summaryAgentIds}
+    {agentsById}
+  />
 {/if}

--- a/web/src/panels/InteractionSummary.svelte
+++ b/web/src/panels/InteractionSummary.svelte
@@ -23,7 +23,9 @@
   //   channel the scope IS the `group:` id, scopes.py `scope_for_group`).
   // agentIds — the channel's participating personas to query (a DM's peer, or a
   //   group's members), already free of the human principal.
-  let { scope = "", agentIds = [] } = $props();
+  // agentsById — id → agent, to render the closed interaction's `participants`
+  //   as display names (falls back to the raw id when an agent is unknown).
+  let { scope = "", agentIds = [], agentsById = {} } = $props();
 
   // Re-poll cadence for a close that lands while the conversation is open. The
   // feed already head-polls messages; this is the parallel summary refresh,
@@ -117,6 +119,13 @@
   const triggerLabel = $derived(
     record ? closeTriggerLabel(record.close_reason) : "",
   );
+  // The closed-interaction DTO always carries `participants` as an array (the
+  // handler normalises null → []), so a converged brainstorm names who took
+  // part. Map ids to display names; fall back to the id for an agent the
+  // console doesn't know (e.g. one since deregistered).
+  const participantNames = $derived(
+    (record?.participants ?? []).map((id) => agentsById[id]?.name ?? id),
+  );
 </script>
 
 {#if record}
@@ -135,6 +144,12 @@
       <p class="unavailable">Summary unavailable for this interaction.</p>
     {:else}
       <p class="summary">{record.summary}</p>
+    {/if}
+    {#if participantNames.length > 0}
+      <p class="participants">
+        <span class="participants-label">Participants:</span>
+        {participantNames.join(", ")}
+      </p>
     {/if}
   </aside>
 {/if}
@@ -173,5 +188,13 @@
     margin: 0;
     font-style: italic;
     color: var(--text-muted, #71717a);
+  }
+  .participants {
+    margin: 0.4rem 0 0;
+    font-size: 0.75rem;
+    color: var(--text-muted, #71717a);
+  }
+  .participants-label {
+    font-weight: 600;
   }
 </style>

--- a/web/src/panels/InteractionSummary.svelte
+++ b/web/src/panels/InteractionSummary.svelte
@@ -18,6 +18,7 @@
     closeTriggerLabel,
     isSummaryUnavailable,
   } from "../lib/interactions.js";
+  import { senderLabel } from "../lib/format.js";
 
   // scope — the RFC 0020 scope to filter on (the active channel id; for a group
   //   channel the scope IS the `group:` id, scopes.py `scope_for_group`).
@@ -25,7 +26,12 @@
   //   group's members), already free of the human principal.
   // agentsById — id → agent, to render the closed interaction's `participants`
   //   as display names (falls back to the raw id when an agent is unknown).
-  let { scope = "", agentIds = [], agentsById = {} } = $props();
+  // userId — the human principal id, so a participant that is the operator
+  //   renders as "You": `participants` is the turn-SENDER set, which includes
+  //   the human, not only agents (scopes.py / episode_routing stash
+  //   `payload.sender`), so the surface must decode it the same way the message
+  //   feed does.
+  let { scope = "", agentIds = [], agentsById = {}, userId = "" } = $props();
 
   // Re-poll cadence for a close that lands while the conversation is open. The
   // feed already head-polls messages; this is the parallel summary refresh,
@@ -121,10 +127,15 @@
   );
   // The closed-interaction DTO always carries `participants` as an array (the
   // handler normalises null → []), so a converged brainstorm names who took
-  // part. Map ids to display names; fall back to the id for an agent the
-  // console doesn't know (e.g. one since deregistered).
+  // part. `participants` is the turn-SENDER set — the human principal as well
+  // as the agents — so decode each id with the same `senderLabel` the message
+  // feed uses: the operator → "You", a known agent → "Name — Role" (a blank
+  // name still falls back to the id), an unknown id (e.g. a since-deregistered
+  // agent) → the raw id.
   const participantNames = $derived(
-    (record?.participants ?? []).map((id) => agentsById[id]?.name ?? id),
+    (record?.participants ?? []).map((id) =>
+      senderLabel(id, userId, agentsById),
+    ),
   );
 </script>
 

--- a/web/src/panels/InteractionSummary.test.js
+++ b/web/src/panels/InteractionSummary.test.js
@@ -90,8 +90,11 @@ describe("InteractionSummary", () => {
 
     await screen.findByRole("status", { name: /interaction summary/i });
     const line = container.querySelector(".participants");
-    expect(line.textContent).toContain("You");
-    expect(line.textContent).not.toContain("local");
+    // Pin the exact rendered sequence: the principal decodes to "You" IN PLACE
+    // (first-seen order preserved), joined with ", ". This is strictly tighter
+    // than a "You" / not-"local" substring pair — it would also catch a mangled
+    // order or join, and inherently proves the raw principal id is gone.
+    expect(line.textContent).toMatch(/Participants:\s*You, iron-fox\b/);
   });
 
   it("falls back to the id for a known agent with a blank name", async () => {

--- a/web/src/panels/InteractionSummary.test.js
+++ b/web/src/panels/InteractionSummary.test.js
@@ -65,6 +65,45 @@ describe("InteractionSummary", () => {
     expect(region.textContent).toMatch(/ended|concluded/i);
   });
 
+  it("names the participants, mapping ids to display names with an id fallback", async () => {
+    // record() has participants ["ember-owl", "iron-fox"]; only ember-owl is in
+    // agentsById, so iron-fox falls back to its raw id.
+    stubFetch({ interactions: [record()] });
+
+    renderSummary({ agentsById: { "ember-owl": { id: "ember-owl", name: "Ember Owl" } } });
+
+    const region = await screen.findByRole("status", {
+      name: /interaction summary/i,
+    });
+    expect(region.textContent).toContain("Participants:");
+    expect(region.textContent).toContain("Ember Owl"); // mapped to display name
+    expect(region.textContent).toContain("iron-fox"); // unknown id falls back
+  });
+
+  it("renders participants even when the summary itself is unavailable", async () => {
+    // The close happened and who took part is known; only the synthesis failed.
+    stubFetch({
+      interactions: [record({ summary: "[interaction summary unavailable]" })],
+    });
+
+    renderSummary();
+
+    const region = await screen.findByRole("status", {
+      name: /interaction summary/i,
+    });
+    expect(region.textContent).toMatch(/unavailable/i);
+    expect(region.textContent).toContain("Participants:");
+  });
+
+  it("omits the participants line when the interaction recorded none", async () => {
+    stubFetch({ interactions: [record({ participants: [] })] });
+
+    const { container } = renderSummary();
+
+    await screen.findByRole("status", { name: /interaction summary/i });
+    expect(container.querySelector(".participants")).toBeNull();
+  });
+
   it("renders the failure sentinel as an explicit unavailable state, not a blank", async () => {
     stubFetch({
       interactions: [record({ summary: "[interaction summary unavailable]" })],

--- a/web/src/panels/InteractionSummary.test.js
+++ b/web/src/panels/InteractionSummary.test.js
@@ -80,6 +80,34 @@ describe("InteractionSummary", () => {
     expect(region.textContent).toContain("iron-fox"); // unknown id falls back
   });
 
+  it("renders the human principal as You, not its raw id", async () => {
+    // participants is the turn-sender set, which includes the human principal
+    // (sender_id === userId), not just agents. It must read "You", matching the
+    // ChannelMessage convention — never the raw principal id.
+    stubFetch({ interactions: [record({ participants: ["local", "iron-fox"] })] });
+
+    const { container } = renderSummary({ userId: "local" });
+
+    await screen.findByRole("status", { name: /interaction summary/i });
+    const line = container.querySelector(".participants");
+    expect(line.textContent).toContain("You");
+    expect(line.textContent).not.toContain("local");
+  });
+
+  it("falls back to the id for a known agent with a blank name", async () => {
+    // An agent present in agentsById but with an empty name must still render
+    // its id, never a blank token in the comma-joined list.
+    stubFetch({ interactions: [record({ participants: ["ember-owl"] })] });
+
+    const { container } = renderSummary({
+      agentsById: { "ember-owl": { id: "ember-owl", name: "" } },
+    });
+
+    await screen.findByRole("status", { name: /interaction summary/i });
+    const line = container.querySelector(".participants");
+    expect(line.textContent).toContain("ember-owl");
+  });
+
   it("renders participants even when the summary itself is unavailable", async () => {
     // The close happened and who took part is known; only the synthesis failed.
     stubFetch({


### PR DESCRIPTION
Follow-up to the web-console review (finding M1). The closed-interaction read DTO always returns `participants` (the handler normalises `null → []`, [interactions_handler.go:134-136](https://github.com/mkhomutov/Persatrix/blob/main/internal/server/interactions_handler.go#L134)), but the `InteractionSummary` surface rendered only the close trigger, turn count, and summary — **dropping who actually took part** in the converged interaction. This completes the surface.

## What's added
- **`InteractionSummary.svelte`**: a `Participants: …` line, mapping each participant id to its display name via a new optional `agentsById` prop. An unknown id (an agent the console doesn't know — e.g. one since deregistered) falls back to the raw id. The line:
  - renders **even when the summary itself is the unavailable sentinel** — who participated is known independently of whether the synthesis succeeded;
  - is **omitted when the interaction recorded no participants** (the `[]` case).
- **`ConversationFeed.svelte`**: threads its existing `agentsById` into the surface (no new data fetch).

## Scope
Additive — no behaviour change when `participants` is empty; the existing trigger/turns/summary/unavailable rendering is untouched.

## Verification
- `npm test`: **202 pass** — 3 new (id→name mapping with id fallback, render-under-unavailable-summary, omit-when-empty).
- `npm run build`: clean.
- All 7 pre-commit checks pass.

## Remaining review items
The CLI `--mention-all` count-cap off-by-one (B3) is the last quick correctness fix from the review. Beyond that, per-member `threshold` + governance knobs still need backend REST DTO fields before either client can expose them.