### PR TITLE
fix(channels): respond-policy comment sync + bounded unknown-policy metric label

### DIFF
--- a/agents/persona_runtime/salience_gate.py
+++ b/agents/persona_runtime/salience_gate.py
@@ -16,13 +16,17 @@ DM, an ``observer``, and the self-sender never reach the bid (TB1). Of that
 remainder, the bid runs only when the inbound event is **Tier-B-governed**
 (the channel-level ``salience_gated`` flag).
 
-**Activation note (PR 2a):** the bid inputs (``salience_gated``, per-member
-``threshold``, ``channel_size``) are carried across the store/wire boundary
-in **PR 2b** (the ``memberships.threshold`` SQLite migration + the
-``ChannelMessageEvent`` proto fields). Until then ``salience_gated`` is never
-set, so :func:`run_salience_gate` short-circuits to "not applicable" and the
-v0.3.7 response behaviour is unchanged — PR 2a is additive, mirroring the
-inertness of Tier B PR 1.
+**Activation (PR 2b, landed):** the bid inputs (``salience_gated``, per-member
+``threshold``, ``channel_size``) now cross the store/wire boundary end-to-end —
+the ``memberships.threshold``/``salience_gated`` SQLite columns persist them and
+the ``ChannelMessageEvent`` proto fields deliver them here (populated by the Go
+dispatcher in ``internal/channels/grpc_dispatcher.go``; lifted onto the event
+payload in ``agents/server_servicers.py``). :func:`run_salience_gate` therefore
+runs the bid for real on a Tier-B-governed open-floor admit. It still
+short-circuits to "not applicable" when the event is **not** governed
+(``salience_gated`` unset) — a bare legacy ``always`` member, which keeps
+replying unconditionally — so the feature stays additive over the v0.3.7
+response behaviour.
 """
 
 from __future__ import annotations
@@ -50,7 +54,8 @@ logger = logging.getLogger(__name__)
 __all__ = ["SalienceOutcome", "run_salience_gate"]
 
 # Bid inputs carried on the inbound ``CHANNEL_MESSAGE`` payload alongside
-# ``respond_policy`` / ``mentions``. Populated by the Go dispatcher in PR 2b.
+# ``respond_policy`` / ``mentions``. Populated by the Go dispatcher and lifted
+# onto the payload in ``server_servicers.py`` (RFC 0030 Tier B, PR 2b).
 _SALIENCE_GATED_KEY: str = "salience_gated"
 _SALIENCE_THRESHOLD_KEY: str = "threshold"
 _SALIENCE_CHANNEL_SIZE_KEY: str = "channel_size"

--- a/agents/response_gate.py
+++ b/agents/response_gate.py
@@ -83,6 +83,7 @@ __all__ = [
     "POLICY_NEVER",
     "POLICY_OBSERVER",
     "POLICY_PARTICIPANT",
+    "POLICY_UNKNOWN",
     "POLICY_WHEN_MENTIONED",
     "GateDecision",
     "evaluate_response_gate",
@@ -162,6 +163,15 @@ POLICY_DEFENSE_IN_DEPTH: Final[str] = "defense_in_depth"
 # breaking down ``gated`` by ``policy`` must be able to tell apart.
 POLICY_LOW_SALIENCE: Final[str] = "low_salience"
 
+# A bounded sentinel label for the fail-closed unknown/empty-policy branch.
+# The wire-side validator already rejects unknown ``respond_policy`` values, so
+# this branch should not fire in production; if it does, the metric ``policy``
+# label must stay low-cardinality rather than echo the raw (attacker- or
+# bug-supplied) wire string onto ``channel.messages.gated`` — the same bounded-
+# label discipline as POLICY_DEFENSE_IN_DEPTH / POLICY_LOW_SALIENCE. The raw
+# value is not lost: it is logged at warn (``raw_policy``) for diagnosis.
+POLICY_UNKNOWN: Final[str] = "unknown"
+
 # RFC 0030 relevance amendment Tier A (v0.3.7), decision D3 / amendment
 # OQ #5 (adopted default): the broadcast sentinel. A message addressed to
 # the *room* rather than to specific members carries this reserved token in
@@ -192,11 +202,15 @@ class GateDecision:
         respond: ``True`` when the persona runtime should proceed with
             memory recall + LLM invocation for this event; ``False`` when
             the gate suppresses the response.
-        policy: The effective policy used for the decision (string
-            value of :data:`POLICY_WHEN_MENTIONED` /
-            :data:`POLICY_ALWAYS` / :data:`POLICY_NEVER`). Used as the
-            ``policy`` label on the ``channel.messages.gated`` metric so
-            operators can break suppression counts down by intent.
+        policy: The effective policy used for the decision. Always one of a
+            **bounded** set of constants — the canonical legacy triple
+            (:data:`POLICY_WHEN_MENTIONED` / :data:`POLICY_ALWAYS` /
+            :data:`POLICY_NEVER`) or a synthetic routing-artifact label
+            (:data:`POLICY_DEFENSE_IN_DEPTH`, :data:`POLICY_LOW_SALIENCE`,
+            :data:`POLICY_UNKNOWN`); never a raw/unbounded wire string. Used as
+            the ``policy`` label on the ``channel.messages.gated`` metric so
+            operators can break suppression counts down by intent without a
+            cardinality blow-up.
         reason: Short, low-cardinality string explaining the branch.
             Suitable for log fields and span attributes; never a free-form
             error string.
@@ -413,4 +427,5 @@ def evaluate_response_gate(event: AgentEvent, *, agent_id: str) -> GateDecision:
         "Agent %s: unknown respond_policy %r on channel %s; suppressing",
         agent_id, raw_policy, channel_id,
     )
-    return GateDecision(respond=False, policy=policy, reason="unknown_policy")
+    # Bounded metric label, not the raw ``policy`` string — see POLICY_UNKNOWN.
+    return GateDecision(respond=False, policy=POLICY_UNKNOWN, reason="unknown_policy")

--- a/agents/response_gate.py
+++ b/agents/response_gate.py
@@ -202,15 +202,23 @@ class GateDecision:
         respond: ``True`` when the persona runtime should proceed with
             memory recall + LLM invocation for this event; ``False`` when
             the gate suppresses the response.
-        policy: The effective policy used for the decision. Always one of a
-            **bounded** set of constants — the canonical legacy triple
-            (:data:`POLICY_WHEN_MENTIONED` / :data:`POLICY_ALWAYS` /
-            :data:`POLICY_NEVER`) or a synthetic routing-artifact label
-            (:data:`POLICY_DEFENSE_IN_DEPTH`, :data:`POLICY_LOW_SALIENCE`,
-            :data:`POLICY_UNKNOWN`); never a raw/unbounded wire string. Used as
-            the ``policy`` label on the ``channel.messages.gated`` metric so
-            operators can break suppression counts down by intent without a
-            cardinality blow-up.
+        policy: The effective policy for the decision. The gate only ever
+            assigns a value from a **bounded** set — the canonical legacy
+            triple (:data:`POLICY_WHEN_MENTIONED` / :data:`POLICY_ALWAYS` /
+            :data:`POLICY_NEVER`), a synthetic routing-artifact label
+            (:data:`POLICY_DEFENSE_IN_DEPTH`, :data:`POLICY_UNKNOWN`), or the
+            empty string ``""`` on the two non-enforcing pass-through branches
+            (a non-CHANNEL_MESSAGE event or the legacy empty ``channel_id``,
+            both ``respond=True``); never a raw/unbounded wire string. On a
+            *suppressing* decision this value is the ``policy`` label on the
+            ``channel.messages.gated`` metric, so operators can break
+            suppression counts down by intent without a cardinality blow-up;
+            the ``""`` sentinel never reaches that counter because it only
+            fires when ``respond=False``. (The Tier-B salience suppression
+            rides the same counter with a :data:`POLICY_LOW_SALIENCE` label,
+            but that label is applied by the downstream salience stage in
+            :mod:`agents.observability._metrics_salience` — no
+            :class:`GateDecision` the gate returns ever carries it.)
         reason: Short, low-cardinality string explaining the branch.
             Suitable for log fields and span attributes; never a free-form
             error string.

--- a/agents/response_gate.py
+++ b/agents/response_gate.py
@@ -111,15 +111,15 @@ POLICY_OBSERVER: Final[str] = "observer"
 
 # RFC 0030 Tier B (v0.3.8): `chair` is a low-threshold facilitator — a
 # `participant` whose low salience `threshold` lets it clear the relevance
-# bid readily. On the wire it is normalized to `always` by the Go loader
-# (the low threshold rides on the in-memory Go config struct — it is not on
-# this wire, nor in the membership row), so the gate normally never sees
-# `chair`; it is recognized here as defence-in-depth, the same as the other
-# disposition aliases. The chair's behaviour (the low-threshold bid + the
-# inert Layer 5 hooks) lives in the Tier B bid stage downstream of this pure
-# gate, not here — and that stage cannot read the threshold until a later PR
-# carries it across the store/wire boundary (see MemberConfig.Threshold in
-# internal/channels/config.go).
+# bid readily. The Go loader normalizes it to `always` on both the membership
+# row and the wire `respond_policy`, so the gate normally never sees `chair`;
+# it is recognized here as defence-in-depth, the same as the other disposition
+# aliases. The chair's distinguishing low `threshold` does not ride
+# `respond_policy` — it travels on the separate `memberships.threshold` column
+# and the `ChannelMessageEvent.threshold` proto field (PR 2b, landed). The
+# chair's behaviour (the low-threshold bid + the inert Layer 5 hooks) lives in
+# the Tier B bid stage downstream of this pure gate
+# (agents/persona_runtime/salience_gate.py), not here.
 POLICY_CHAIR: Final[str] = "chair"
 
 # Disposition → legacy alias map, applied once to the incoming policy so

--- a/agents/salience_bid.py
+++ b/agents/salience_bid.py
@@ -34,13 +34,14 @@ Load-bearing invariants (amendment OQs / master-plan §Open-question status):
   :func:`skip_bid_for_channel_size` predicate lives here for testability;
   the caller owns the fallback.
 
-**Activation note (PR 2a):** this module is the bid *core*. The per-member
-``threshold`` and the ``channel_size`` it consumes are carried across the
-store/wire boundary in PR 2b (the SQLite ``memberships.threshold`` migration
-+ the ``ChannelMessageEvent`` proto field). Until then the action-loop seam
-(:func:`agents.persona_runtime.salience_gate.run_salience_gate`) is dormant — it
-fires only when the inbound event is flagged Tier-B-governed — so PR 2a is
-additive and the v0.3.7 response behaviour is unchanged.
+**Activation (PR 2b, landed):** this module is the bid *core*. The per-member
+``threshold`` and the ``channel_size`` it consumes now cross the store/wire
+boundary end-to-end (the SQLite ``memberships.threshold`` migration + the
+``ChannelMessageEvent`` proto fields). The action-loop seam
+(:func:`agents.persona_runtime.salience_gate.run_salience_gate`) therefore runs
+the bid for real, but only when the inbound event is flagged Tier-B-governed — a
+bare legacy ``always`` member is never governed, so the feature stays additive
+over the v0.3.7 response behaviour.
 """
 
 from __future__ import annotations

--- a/internal/channels/channels.go
+++ b/internal/channels/channels.go
@@ -239,15 +239,17 @@ type Member struct {
 	JoinedAt      time.Time
 
 	// SalienceGated marks this member as an open-floor *participant* subject to
-	// the RFC 0030 Tier B salience bid (v0.3.8). It is true iff the member was
-	// declared with the participant vocabulary (`participant`/`chair`) — the
-	// dispositions that opt into the bid — and false for a legacy `always`
-	// member, which keeps replying unconditionally. Because the disposition
-	// vocabulary collapses to the legacy `always` wire value on
-	// [RespondPolicy.Normalize], this boolean is the *only* thing that
-	// survives to distinguish a salience-gated participant from a legacy
-	// always-replier past the store/wire boundary; it rides the
-	// `ChannelMessageEvent.salience_gated` proto field to the agent-side seam.
+	// the RFC 0030 Tier B salience bid (v0.3.8). It is true when the member opts
+	// into the bid: declared with the participant vocabulary
+	// (`participant`/`chair`), OR a legacy `always` carrying an explicit
+	// `threshold` (the operator-set bar is itself the opt-in — see
+	// [ResolveSalienceSignal]). It is false for a *bare* legacy `always`, which
+	// keeps replying unconditionally. Because the disposition vocabulary
+	// collapses to the legacy `always` wire value on [RespondPolicy.Normalize],
+	// this boolean is the *only* thing that survives to distinguish a
+	// salience-gated participant from a bare-always replier past the store/wire
+	// boundary; it rides the `ChannelMessageEvent.salience_gated` proto field to
+	// the agent-side seam.
 	SalienceGated bool
 	// Threshold is the member's per-disposition salience `threshold` for the
 	// Tier B bid (the score it must clear to reach the quality turn). A

--- a/internal/channels/config.go
+++ b/internal/channels/config.go
@@ -241,12 +241,14 @@ type MemberConfig struct {
 	// bid. The PR-1 persistence/wire gap is closed.
 	Threshold *float64
 	// SalienceGated marks this member as a salience-bid participant (RFC 0030
-	// Tier B, v0.3.8). Set at load from the *declared* disposition (before
-	// normalization collapses `participant`/`chair` to the legacy `always`
-	// wire value), so the bid-ness survives the normalization that would
-	// otherwise make a `participant` indistinguishable from a legacy `always`.
-	// Carried by [ReconcileConfig] onto the store-side [Member.SalienceGated].
-	// See [ResolveSalienceSignal] for the derivation rule.
+	// Tier B, v0.3.8). Derived at load by [ResolveSalienceSignal] from the
+	// *declared* disposition (before normalization collapses `participant`/
+	// `chair` to the legacy `always` wire value) together with any explicit
+	// `threshold`: the participant vocabulary opts in, as does a legacy `always`
+	// that carries an explicit threshold. Deriving it before normalization is
+	// what lets the bid-ness survive the collapse that would otherwise make a
+	// `participant` indistinguishable from a bare legacy `always`. Carried by
+	// [ReconcileConfig] onto the store-side [Member.SalienceGated].
 	SalienceGated bool
 }
 

--- a/tests/unit/python/test_response_gate.py
+++ b/tests/unit/python/test_response_gate.py
@@ -25,6 +25,7 @@ from agents.persona_types import AgentEvent, EventType
 from agents.response_gate import (
     POLICY_ALWAYS,
     POLICY_DEFENSE_IN_DEPTH,
+    POLICY_LOW_SALIENCE,
     POLICY_NEVER,
     POLICY_UNKNOWN,
     POLICY_WHEN_MENTIONED,
@@ -226,6 +227,11 @@ class TestNonChannelEvents:
         d = evaluate_response_gate(evt, agent_id="bob")
         assert d.respond is True
         assert d.reason == "not_channel_message"
+        # Non-enforcing pass-through: the gate carries the empty-string
+        # sentinel here (not a named policy constant). It never reaches the
+        # ``channel.messages.gated`` metric because that counter only fires on
+        # suppression — see TestPolicyContract for the field-vs-label split.
+        assert d.policy == ""
 
     def test_legacy_chat_path_with_no_channel_id_passes_through(self):
         # The legacy ``SendChatMessage`` RPC builds CHANNEL_MESSAGE
@@ -239,6 +245,120 @@ class TestNonChannelEvents:
         d = evaluate_response_gate(evt, agent_id="bob")
         assert d.respond is True
         assert d.reason == "no_channel_id"
+        # Same empty-string sentinel as the non-CHANNEL_MESSAGE pass-through.
+        assert d.policy == ""
+
+
+# ─── GateDecision.policy contract ──────────────────────────────────
+
+
+class TestPolicyContract:
+    """Pin the ``GateDecision.policy`` field contract its docstring documents.
+
+    The docstring must keep two sets distinct (an earlier revision conflated
+    them):
+
+    * **Field values** the gate assigns to ``GateDecision.policy`` — the
+      legacy triple, the synthetic routing-artifact labels
+      (``defense_in_depth`` / ``unknown``), and the empty-string sentinel
+      ``""`` for the non-enforcing pass-through branches.
+    * **Metric labels** that can land on ``channel.messages.gated``. That set
+      is *not* the same: ``""`` never appears (the counter fires only on
+      suppression, and the ``""`` branches return ``respond=True``), while
+      ``low_salience`` *does* — but it is applied by the downstream salience
+      stage (``agents/observability/_metrics_salience.py``), never by this
+      pure gate.
+    """
+
+    # Every value evaluate_response_gate can put on GateDecision.policy.
+    _FIELD_VALUES = frozenset(
+        {
+            "",
+            POLICY_ALWAYS,
+            POLICY_NEVER,
+            POLICY_WHEN_MENTIONED,
+            POLICY_DEFENSE_IN_DEPTH,
+            POLICY_UNKNOWN,
+        }
+    )
+
+    def _all_branch_decisions(self):
+        """One representative event per gate branch."""
+        yield evaluate_response_gate(
+            AgentEvent(event_type=EventType.TICK), agent_id="bob"
+        )
+        yield evaluate_response_gate(
+            AgentEvent(
+                event_type=EventType.CHANNEL_MESSAGE,
+                sender_id="user-1",
+                payload={"content": "hi"},
+            ),
+            agent_id="bob",
+        )
+        # DM self-sender (defense_in_depth) and DM peer (always).
+        yield evaluate_response_gate(
+            _channel_event(channel_id="dm:bob:carol", sender_id="bob"),
+            agent_id="bob",
+        )
+        yield evaluate_response_gate(
+            _channel_event(channel_id="dm:bob:carol", sender_id="carol"),
+            agent_id="bob",
+        )
+        # Group self-sender (defense_in_depth).
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="always", sender_id="bob"),
+            agent_id="bob",
+        )
+        # never.
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="never"), agent_id="bob"
+        )
+        # always: open-floor, directed-elsewhere, mentioned, broadcast.
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="always", mentions=[]), agent_id="bob"
+        )
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="always", mentions=["carol"]),
+            agent_id="bob",
+        )
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="always", mentions=["bob"]),
+            agent_id="bob",
+        )
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="always", mentions=["@everyone"]),
+            agent_id="bob",
+        )
+        # when_mentioned: mentioned and not.
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="when_mentioned", mentions=["bob"]),
+            agent_id="bob",
+        )
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="when_mentioned", mentions=["carol"]),
+            agent_id="bob",
+        )
+        # unknown / empty policy.
+        yield evaluate_response_gate(
+            _channel_event(respond_policy="weekly"), agent_id="bob"
+        )
+
+    def test_emitted_policies_are_a_subset_of_the_documented_field_values(self):
+        emitted = {d.policy for d in self._all_branch_decisions()}
+        assert emitted <= self._FIELD_VALUES, emitted - self._FIELD_VALUES
+
+    def test_gate_never_emits_low_salience(self):
+        # low_salience is a metric-only label applied outside the gate; no
+        # GateDecision the gate returns may carry it.
+        emitted = {d.policy for d in self._all_branch_decisions()}
+        assert POLICY_LOW_SALIENCE not in emitted
+
+    def test_empty_sentinel_only_on_non_suppressing_decisions(self):
+        # ``""`` is a field value but never a gated-metric label: every
+        # decision that carries it must be a respond=True pass-through.
+        for d in self._all_branch_decisions():
+            if d.policy == "":
+                assert d.respond is True
 
 
 # ─── Unknown / empty policy fail-closed ────────────────────────────

--- a/tests/unit/python/test_response_gate.py
+++ b/tests/unit/python/test_response_gate.py
@@ -26,6 +26,7 @@ from agents.response_gate import (
     POLICY_ALWAYS,
     POLICY_DEFENSE_IN_DEPTH,
     POLICY_NEVER,
+    POLICY_UNKNOWN,
     POLICY_WHEN_MENTIONED,
     evaluate_response_gate,
 )
@@ -253,4 +254,11 @@ class TestUnknownPolicy:
             d = evaluate_response_gate(evt, agent_id="bob")
         assert d.respond is False
         assert d.reason == "unknown_policy"
+        # The metric ``policy`` label must be the bounded sentinel, not the
+        # raw unknown wire value — an arbitrary string here is an unbounded-
+        # cardinality vector on ``channel.messages.gated`` (same precedent as
+        # POLICY_DEFENSE_IN_DEPTH / POLICY_LOW_SALIENCE). The raw value is
+        # still preserved in the warning log for diagnosis.
+        assert d.policy == POLICY_UNKNOWN
         assert any("unknown respond_policy" in r.message for r in caplog.records)
+        assert any("weekly" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Review of the respond-policy path (Go vocabulary/normalization → wire → Python response gate + Tier-B salience seam) surfaced comment/contract inconsistencies. The core machinery is sound; these are targeted fixes. Two commits, separated by kind:

### Commit 1 — `docs(channels)`: sync comments with landed PR 2b (comment-only, no behavior change)
The Tier-B salience-bid inputs (`salience_gated` / `threshold` / `channel_size`) now round-trip end-to-end (`grpc_dispatcher.go` populates the proto fields; `server_servicers.py` lifts them onto the payload; `salience_gate.py` reads them). But several comments still described PR 2b as future work, and one Go doc contradicted the code:

- **`salience_gate.py` / `salience_bid.py`** — "Activation note (PR 2a)" docstrings claimed `salience_gated` is "never set" and the seam/bid is "dormant". Updated to reflect that PR 2b has landed and the bid runs for real on a governed open-floor admit (still additive: a bare legacy `always` is never governed).
- **`response_gate.py` `POLICY_CHAIR`** — dropped the stale "cannot read the threshold until a later PR" note **and** the now-false claim that the chair threshold is "not on this wire, nor in the membership row" (it rides `memberships.threshold` + `ChannelMessageEvent.threshold`).
- **`channels.go` `Member.SalienceGated`** — doc said the flag is "false for a legacy `always` member", but `ResolveSalienceSignal` sets it **true** for a legacy `always` carrying an explicit `threshold` (the operator-set bar is itself the opt-in, already pinned by `TestLoadConfig_LegacyAlwaysWithThresholdIsSalienceGated`). Corrected to name that opt-in and say "bare legacy `always`". Same clarification on `config.go` `MemberConfig.SalienceGated`.

### Commit 2 — `fix(response-gate)`: bounded unknown-policy metric label (behavior change, TDD)
The fail-closed unknown/empty-policy branch returned `GateDecision(policy=<raw wire string>)`, which becomes the `policy` label on `channel.messages.gated` — an unbounded-cardinality vector if a junk value ever reaches the gate, and a contradiction of the `GateDecision.policy` contract. Added `POLICY_UNKNOWN = "unknown"` (same discipline as `POLICY_DEFENSE_IN_DEPTH` / `POLICY_LOW_SALIENCE`) and labelled the branch with it. The raw value is still logged at warn for diagnosis.

## Testing
- TDD on commit 2: extended `TestUnknownPolicy` to assert `d.policy == POLICY_UNKNOWN` and that the raw value still reaches the warn log (red via ImportError → green).
- `tests/unit/python/test_response_gate*.py` — 44 passed.
- `go build` / `go vet ./internal/channels/` clean; Go salience/config tests pass.
- Full Python unit suite: 3227 passed; the 5 `TestShellExec` failures are pre-existing on `main` (sandbox/env), unrelated to this change.