### PR TITLE
fix(agents): close-notification gate ordering, bounded label, no fabricated record (RFC 0030 amendment follow-up)

### DIFF
--- a/agents/persona_runtime/close_notification.py
+++ b/agents/persona_runtime/close_notification.py
@@ -39,7 +39,14 @@ invent. Sequence:
    identity: if the ingest itself closed or rotated the interaction
    (max-turns cap, wire-id rotation), that close's own cause stands
    and no second close is layered on a different interaction than the
-   one the notification found open.
+   one the notification found open. A rotation's fresh successor —
+   opened by the ingest, holding only the notification — is
+   deliberately left open for its own boundaries (idle, the next
+   rotation): closing it structurally would mint exactly the 1-turn
+   "ended" record step 3 refuses to invent. By CP2 construction the
+   notification carries the retired record's own wire id, so the
+   rotation corner should not fire in practice; the guard pins the
+   contract against a producer change.
 
 Conservative choice, deliberately: an interaction whose idle window
 expired BEFORE the notification landed closes by the idle rule (step
@@ -145,7 +152,10 @@ async def close_interaction_on_notification(
         # The ingest itself closed or replaced the interaction (the
         # max-turns inline close, a wire-id rotation): that close's own
         # cause stands; never layer a structural close on a different
-        # interaction than the one the notification found open.
+        # interaction than the one the notification found open. A
+        # rotation's 1-turn successor stays open for its own boundaries
+        # — closing it here would be the fabrication the no-open branch
+        # above refuses (module docstring, step 4).
         return
     closed = agent._interaction_tracker.close(scope, reason=REASON_STRUCTURAL)
     if closed is not None:

--- a/agents/persona_runtime/close_notification.py
+++ b/agents/persona_runtime/close_notification.py
@@ -14,6 +14,41 @@ the "ended" render (:mod:`.interaction_boundary`: the quorum close IS
 the explicit end the structural label claims) — instead of burying the
 converged discussion as "went idle" an idle window later.
 
+This dispatch owns the WHOLE receiver arc — including the final-turn
+ingest (PR #614 review finding 3). The ingest must come after the
+open-scope check, not before it in the caller: ``_store_event_episode``
+opens a fresh interaction when none is open, so an unconditional
+ingest-then-close would fabricate a 1-turn "ended" record (plus a
+summariser LLM call) for a scope that already closed — exactly the
+record the no-open-interaction no-op contract promises never to
+invent. Sequence:
+
+1. strict marker / event-type / scope checks — an impostor or
+   unroutable event touches nothing, not even the staleness pass;
+2. the same idle flush every ingest runs (the agent's own boundary
+   rules outrank the late signal — see the conservative-choice note
+   below);
+3. no interaction left open → done: the close stands recorded
+   orchestrator-side; nothing here invents a record to mirror it. The
+   notification is deliberately NOT ingested in this case — there is
+   no open window to land the final turn in, and ingesting would
+   either fabricate the record above or leave a 1-turn successor
+   dangling toward its own "went idle" burial;
+4. otherwise ingest (the closing vote lands as the record's final
+   turn) and close with :data:`REASON_STRUCTURAL` — guarded by
+   identity: if the ingest itself closed or rotated the interaction
+   (max-turns cap, wire-id rotation), that close's own cause stands
+   and no second close is layered on a different interaction than the
+   one the notification found open.
+
+Conservative choice, deliberately: an interaction whose idle window
+expired BEFORE the notification landed closes by the idle rule (step
+2), not as "ended" — relabelling it would put a structural cause on a
+window the agent's own boundary contract already ended, and the
+orchestrator's authoritative "ended" record exists regardless. The
+amendment fixes the *timely* path; a notification a full idle window
+late has, by the agent's own rules, missed the conversation.
+
 Extracted as a free function taking the composed persona agent — the
 :mod:`.cost_close` / :mod:`.vote_close` sibling, same extraction idiom,
 so ``action_loop.py`` stays a one-liner at the call site and under the
@@ -22,13 +57,14 @@ so ``action_loop.py`` stays a one-liner at the call site and under the
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Protocol
 
 from ..memory.boundary_detectors import REASON_STRUCTURAL
 
 if TYPE_CHECKING:
     from ..memory.interactions import Interaction, InteractionTracker
-    from ..persona_types import AgentEvent, EventType
+    from ..persona_types import AgentAction, AgentEvent, EventType
 
     class _CloseNotificationAgent(Protocol):
         """The composed-agent surface
@@ -41,7 +77,12 @@ if TYPE_CHECKING:
         async def _persist_closed_interaction(
             self, interaction: Interaction,
         ) -> None: ...
+        async def _store_event_episode(
+            self, event: AgentEvent, actions: list[AgentAction],
+        ) -> None: ...
 
+
+logger = logging.getLogger(__name__)
 
 __all__ = ["close_interaction_on_notification"]
 
@@ -49,31 +90,62 @@ __all__ = ["close_interaction_on_notification"]
 async def close_interaction_on_notification(
     agent: _CloseNotificationAgent, event: AgentEvent,
 ) -> None:
-    """Close + persist the open interaction in the notified scope.
+    """Ingest the final turn and close the open interaction in the
+    notified scope — or no-op entirely when nothing is open.
 
     Called from the action loop's gate-suppress path only for the
-    dedicated ``close_notification`` refusal. Defence-in-depth re-checks
-    here regardless (CP3's strict-bool rule): a truthy non-bool marker on
-    the cleartext port must not fabricate a close — burying an active
-    discussion is exactly the failure mode the strictness blocks — so an
-    impostor is a no-op even if a future caller wires this off a looser
-    signal. Scope resolution rides the same multi-turn routing as
-    :func:`.cost_close.close_interaction_on_cost`'s channel branch: a
-    notification is channel traffic by construction (the orchestrator
-    re-dispatches a channel publish), so a non-multi-turn event type has
-    no scope to close and returns quietly. No open interaction in the
-    scope (the agent's window already idled it out before the
-    notification landed) is the ``InteractionTracker.close``
-    unknown-scope no-op — the close stands recorded orchestrator-side;
-    nothing here invents a record to mirror it.
+    dedicated ``close_notification`` refusal; owns the ingest too (see
+    the module docstring for the ordering rationale). Defence-in-depth
+    re-checks the marker here regardless (CP3's strict-bool rule): a
+    truthy non-bool on the cleartext port must not fabricate a close —
+    burying an active discussion is exactly the failure mode the
+    strictness blocks — so an impostor is a no-op even if a future
+    caller wires this off a looser signal (a payload-less event reads
+    as unmarked for the same reason). Scope resolution rides the same
+    multi-turn routing as :func:`.cost_close.close_interaction_on_cost`'s
+    channel branch: a notification is channel traffic by construction
+    (the orchestrator re-dispatches a channel publish), so a
+    non-multi-turn event type has no scope to close and returns quietly.
     """
-    marked = event.payload.get("interaction_close_notification") is True
+    payload = event.payload or {}
+    marked = payload.get("interaction_close_notification") is True
     if not marked:
         return
     if event.event_type not in agent._MULTI_TURN_EVENT_TYPES:
         return
     scope = agent._scope_for_multi_turn_event(event)
     if scope is None:
+        return
+    # The staleness pass every ingest runs (episode_routing's flush
+    # loop, same warn contract): without it, ``get`` below would report
+    # an idle-EXPIRED interaction as open, the ingest's own internal
+    # flush would then close it as idle mid-arc, and the close at the
+    # bottom would pop the fresh 1-turn successor — the fabrication
+    # this function exists to prevent, one branch over.
+    for expired in agent._interaction_tracker.idle_check():
+        try:
+            await agent._persist_closed_interaction(expired)
+        except Exception:
+            logger.warning(
+                "Failed to flush idle interaction before close "
+                "notification (scope=%s, interaction_id=%s)",
+                expired.scope, expired.interaction_id,
+                exc_info=True,
+            )
+    open_interaction = agent._interaction_tracker.get(scope)
+    if open_interaction is None:
+        # Already idled out (or never tracked): the close stands
+        # recorded orchestrator-side; invent nothing locally.
+        return
+    # The closing vote lands as the closed record's final turn — ingest
+    # BEFORE close (closing first would strand the message in a
+    # successor interaction).
+    await agent._store_event_episode(event, [])
+    if agent._interaction_tracker.get(scope) is not open_interaction:
+        # The ingest itself closed or replaced the interaction (the
+        # max-turns inline close, a wire-id rotation): that close's own
+        # cause stands; never layer a structural close on a different
+        # interaction than the one the notification found open.
         return
     closed = agent._interaction_tracker.close(scope, reason=REASON_STRUCTURAL)
     if closed is not None:

--- a/agents/persona_runtime/gate_suppress.py
+++ b/agents/persona_runtime/gate_suppress.py
@@ -1,10 +1,12 @@
 """The action loop's gate-suppress path (RFC 0011 PR 4b / PR 5 + CP3).
 
 What happens to a CHANNEL_MESSAGE the response gate refused: the gated
-counter fires, the event still ingests memory (suppression decides
-*whether to respond*, not *whether to remember*), and — since the
-end-vote-close-propagation amendment — the dedicated
-``close_notification`` refusal runs the agent-local tracker close.
+counter fires, then the dedicated ``close_notification`` refusal hands
+the event to the close dispatch (which owns the conditional final-turn
+ingest *and* the agent-local tracker close — see
+:mod:`.close_notification`), while every other refusal still ingests
+memory (suppression decides *whether to respond*, not *whether to
+remember*).
 
 Extracted as a free function taking the composed persona agent — the
 :mod:`.cost_close` / :mod:`.close_notification` extraction idiom — so
@@ -67,6 +69,21 @@ async def suppressed_event_actions(
             channel_id=event.channel_id or "",
             policy=decision.policy or "unknown",
         ))
+    # End-vote-close-propagation amendment (CP3): the dedicated refusal
+    # is the close signal, and the close dispatch owns the WHOLE arc —
+    # staleness flush, open-scope check, the conditional final-turn
+    # ingest, then the structural ("ended") close. The ingest cannot be
+    # unconditional here (PR #614 review finding 3): for a scope that
+    # already idled out, ``_store_event_episode`` would open a fresh
+    # interaction holding only the re-delivered closing vote and the
+    # close would persist that fabricated 1-turn "ended" record. Whether
+    # to ingest depends on whether there is an open window to land the
+    # final turn in — only the dispatch knows, so it decides (the
+    # documented cost: a notification arriving after the scope closed is
+    # not remembered; the orchestrator persists the message regardless).
+    if decision.reason == "close_notification":
+        await close_interaction_on_notification(agent, event)
+        return [AgentAction(action_type=ActionType.DO_NOTHING, payload={})]
     # RFC 0011 PR 5: suppressed events still ingest memory so a
     # ``when_mentioned`` listener does not lose context between
     # mentions. The gate decides *whether to respond*, not
@@ -79,13 +96,4 @@ async def suppressed_event_actions(
     # do not echo our own outbound message into episodic memory.
     if decision.policy != POLICY_DEFENSE_IN_DEPTH:
         await agent._store_event_episode(event, [])
-    # End-vote-close-propagation amendment (CP3): the dedicated
-    # refusal doubles as the close signal — the ingest above kept
-    # the closing vote as the interaction's final turn; close the
-    # scope NOW with the structural ("ended") cause instead of
-    # letting it idle out a window later. After the ingest on
-    # purpose: closing first would strand the closing message in
-    # the successor interaction.
-    if decision.reason == "close_notification":
-        await close_interaction_on_notification(agent, event)
     return [AgentAction(action_type=ActionType.DO_NOTHING, payload={})]

--- a/agents/response_gate.py
+++ b/agents/response_gate.py
@@ -232,6 +232,21 @@ def evaluate_response_gate(event: AgentEvent, *, agent_id: str) -> GateDecision:
                 policy=POLICY_DEFENSE_IN_DEPTH,
                 reason="dm_self_sender",
             )
+        # End-vote-close-propagation amendment (CP3), PR #614 review
+        # finding 2: control outranks the DM always-override. The
+        # override exists because "a DM with no reply is broken by
+        # definition" — but a close NOTIFICATION is not a message
+        # awaiting a reply; admitting it would fire a full LLM turn on
+        # control traffic and skip the tracker close. DMs are
+        # interaction-tracked orchestrator-side (the resolver rotates
+        # `group`/`dm` alike) and `processEndVote` keys on the
+        # interaction id, not the channel type, so the lane is reachable
+        # by any publisher the agent-side DM-vote drop does not bind.
+        # Labelled with the POLICY_ALWAYS the override applies (bounded).
+        if payload.get("interaction_close_notification") is True:
+            return GateDecision(
+                respond=False, policy=POLICY_ALWAYS, reason="close_notification",
+            )
         return GateDecision(respond=True, policy=POLICY_ALWAYS, reason="dm")
 
     # Sender-side filter (defence in depth). The router already drops
@@ -246,6 +261,41 @@ def evaluate_response_gate(event: AgentEvent, *, agent_id: str) -> GateDecision:
             reason="self_sender",
         )
 
+    # End-vote-close-propagation amendment (CP3): the orchestrator's close
+    # NOTIFICATION — the closing quorum vote re-dispatched after an
+    # `end_votes` close so the local tracker can close with the truthful
+    # cause. Control, never stimulus: refused for EVERY policy (`never`
+    # included — the orchestrator excludes RespondNever members from the
+    # fan by contract, but if one arrives anyway the dedicated reason
+    # beats the routing-regression warn: the suppress path's close
+    # dispatch keys on it, and closing a stale record truthfully is
+    # strictly better than warning and letting it idle out), before any
+    # admitting lane (a notification may well @-mention the room — it is
+    # still not an invitation to speak), so no turn, no Tier B bid, no
+    # LLM call ever runs on it. Only the self-sender defence-in-depth
+    # refusals above outrank it: Go never fans the notification to the
+    # voter (its own vote_close owns its record), so a marked self-echo
+    # is spoofed or a contract break and refuses like any other
+    # self-echo. Strict `is True` — the `floor_mentions_resolved`
+    # posture: a spoofed truthy non-bool on the cleartext port must not
+    # fabricate a close signal (it falls through to the ordinary policy
+    # branches below). PR #614 review finding 1: the decision's `policy`
+    # is clamped to the canonical triple, else POLICY_UNKNOWN — it
+    # becomes the `channel.messages.gated` label, and the bounded-label
+    # discipline (see POLICY_UNKNOWN; the chair-escalation branch's
+    # explicit policy guard) forbids echoing a raw wire string there.
+    if payload.get("interaction_close_notification") is True:
+        if policy not in (POLICY_ALWAYS, POLICY_WHEN_MENTIONED, POLICY_NEVER):
+            logger.warning(
+                "Agent %s: close notification carries unknown "
+                "respond_policy %r on channel %s; labelling unknown",
+                agent_id, raw_policy, channel_id,
+            )
+            policy = POLICY_UNKNOWN
+        return GateDecision(
+            respond=False, policy=policy, reason="close_notification",
+        )
+
     if policy == POLICY_NEVER:
         # Fail-closed. The orchestrator filters ``RespondNever`` members
         # upstream of dispatch, so a ``never`` reaching the gate is a
@@ -258,23 +308,6 @@ def evaluate_response_gate(event: AgentEvent, *, agent_id: str) -> GateDecision:
             agent_id, channel_id,
         )
         return GateDecision(respond=False, policy=POLICY_NEVER, reason="policy_never")
-
-    # End-vote-close-propagation amendment (CP3): the orchestrator's close
-    # NOTIFICATION — the closing quorum vote re-dispatched after an
-    # `end_votes` close so the local tracker can close with the truthful
-    # cause. Control, never stimulus: refused for EVERY policy, before any
-    # admitting lane (a notification may well @-mention the room — it is
-    # still not an invitation to speak), so no turn, no Tier B bid, no LLM
-    # call ever runs on it; the action loop's ingest-on-suppress keeps the
-    # closing message in the window, and its suppress path runs the
-    # tracker-close dispatch off this dedicated reason. Strict `is True` —
-    # the `floor_mentions_resolved` posture: a spoofed truthy non-bool on
-    # the cleartext port must not fabricate a close signal (it falls
-    # through to the ordinary policy branches below).
-    if payload.get("interaction_close_notification") is True:
-        return GateDecision(
-            respond=False, policy=policy, reason="close_notification",
-        )
 
     # Chair-stall-escalation amendment (§C item 2): the orchestrator's forced
     # turn after a stalled floor round admits down the directed lane for

--- a/docs/guides/channels.md
+++ b/docs/guides/channels.md
@@ -543,7 +543,11 @@ Two boundary notes on those seams:
   (found live by [MT-CHANNEL-GOV-004](../manual-tests/MT-CHANNEL-GOV-004.md)).
   Fail-open: a dropped notification degrades to exactly that pre-amendment
   idle-out, observable per recipient on
-  `channel.conversation.close_notification{outcome}`.
+  `channel.conversation.close_notification{outcome}`. A notification that
+  arrives only *after* the member's own idle window already closed the
+  record degrades the same way — the agent's boundary rules outrank the
+  late signal, and no local record is invented to mirror the
+  orchestrator's (which stands regardless).
 - **The rotation carries its cause.** Every publish of the successor
   interaction names the retired id and what closed it
   (`ChannelMessageEvent.previous_interaction_id` +

--- a/tests/unit/python/test_close_notification_action_loop.py
+++ b/tests/unit/python/test_close_notification_action_loop.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import time
 
-from agents.memory.boundary_detectors import REASON_STRUCTURAL
+from agents.memory.boundary_detectors import REASON_IDLE_GAP, REASON_STRUCTURAL
 from agents.memory.interactions import Interaction
 from agents.persona import create_persona_agent
 from agents.persona_runtime import _LLMPersonaAgent
@@ -106,6 +106,44 @@ class TestCloseNotificationActionLoopWiring:
             "the closing vote is the closed record's final turn, "
             "after the opening turn it arrived behind"
         )
+
+    async def test_already_idle_scope_invents_no_record(self):
+        """PR #614 review finding 3, through the real loop: a
+        notification landing AFTER the scope already idled out (restart,
+        janitor flush, slow delivery) is a true no-op — the orchestrator's
+        "ended" record stands; the agent fabricates nothing. The pre-fix
+        composition ingested first, which ``add_turn``-opened a fresh
+        interaction holding only the re-delivered closing vote, then
+        closed it structurally — a spurious 1-turn "ended" record plus a
+        summariser LLM call, duplicating the record that already closed."""
+        agent, persisted = await _make_agent_with_persist_spy()
+        assert agent._interaction_tracker.get(_SCOPE) is None
+
+        actions = await agent.on_event(_notification_event())
+
+        assert len(actions) == 1
+        assert actions[0].action_type is ActionType.DO_NOTHING
+        assert persisted == [], "no record invented for an already-closed scope"
+        assert agent._interaction_tracker.get(_SCOPE) is None, (
+            "the notification must not re-open the scope"
+        )
+        agent._llm_client._provider.create_message.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_expired_scope_flushes_idle_with_no_structural_successor(self):
+        """The stale-open half of the same finding: an interaction whose
+        idle window expired before the notification arrived closes by the
+        agent's own idle rule (the staleness pass every ingest runs), and
+        the notification then finds nothing open — one idle record, no
+        fabricated structural successor riding behind it."""
+        agent, persisted = await _make_agent_with_persist_spy()
+        agent._interaction_tracker.add_turn(_SCOPE, now=time.time() - 100_000)
+
+        await agent.on_event(_notification_event())
+
+        assert [i.close_reason for i in persisted] == [REASON_IDLE_GAP], (
+            "exactly the idle flush — no structural record fabricated after it"
+        )
+        assert agent._interaction_tracker.get(_SCOPE) is None
 
     async def test_impostor_marker_takes_the_ordinary_path(self):
         """A truthy non-bool marker is no notification (strict-bool on

--- a/tests/unit/python/test_interaction_close_notification.py
+++ b/tests/unit/python/test_interaction_close_notification.py
@@ -40,14 +40,21 @@ non-bool impostor takes no close path on either seam.
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import grpc
 
-from agents.memory.boundary_detectors import REASON_STRUCTURAL
+from agents.memory.boundary_detectors import REASON_IDLE_GAP, REASON_STRUCTURAL
 from agents.memory.interactions import Interaction, InteractionTracker
-from agents.persona_types import AgentEvent, EventType
-from agents.response_gate import evaluate_response_gate
+from agents.persona_types import AgentAction, AgentEvent, EventType
+from agents.response_gate import (
+    POLICY_ALWAYS,
+    POLICY_DEFENSE_IN_DEPTH,
+    POLICY_NEVER,
+    POLICY_UNKNOWN,
+    evaluate_response_gate,
+)
 
 from ._receive_channel_message_helpers import (
     channel_event,
@@ -61,6 +68,8 @@ def _notification_event(
     marker: object = True,
     respond_policy: str = "always",
     mentions: list[str] | None = None,
+    channel_id: str = "group:planning",
+    channel_type: str = "group",
 ) -> AgentEvent:
     """The closing vote as the agent runtime sees it post-lift — the
     ``_escalation_event`` builder shape, marker on the payload port."""
@@ -68,20 +77,22 @@ def _notification_event(
         event_type=EventType.CHANNEL_MESSAGE,
         payload={
             "content": "Agreed — relay. Nothing further.",
-            "channel_type": "group",
+            "channel_type": channel_type,
             "mentions": mentions or [],
             "respond_policy": respond_policy,
             "thread_parent_sender_id": "",
             "interaction_close_notification": marker,
         },
-        channel_id="group:planning",
+        channel_id=channel_id,
         sender_id="iron-fox",
     )
 
 
 class _CloseNotificationAgent:
     """The ``_CostCloseAgent`` harness: a real tracker, a persistence spy,
-    and the scope surface the close dispatch resolves through."""
+    the scope surface the close dispatch resolves through, and (since the
+    PR #614 review fix) the ingest seam the dispatch drives — modelled as
+    the ``add_turn`` it amounts to, so the final-turn append is real."""
 
     _MULTI_TURN_EVENT_TYPES: frozenset[EventType] = frozenset(
         {EventType.CHANNEL_MESSAGE},
@@ -90,12 +101,20 @@ class _CloseNotificationAgent:
     def __init__(self, tracker: InteractionTracker) -> None:
         self._interaction_tracker = tracker
         self.persisted: list[Interaction] = []
+        self.ingested: list[AgentEvent] = []
 
     def _scope_for_multi_turn_event(self, event: AgentEvent) -> str | None:
         return event.channel_id
 
     async def _persist_closed_interaction(self, interaction: Interaction) -> None:
         self.persisted.append(interaction)
+
+    async def _store_event_episode(
+        self, event: AgentEvent, actions: list[AgentAction],
+    ) -> None:
+        self.ingested.append(event)
+        if event.channel_id is not None:
+            self._interaction_tracker.add_turn(event.channel_id)
 
 
 class TestCloseNotificationWireLift:
@@ -164,6 +183,84 @@ class TestCloseNotificationProducesNoTurn:
         assert decision.reason != "close_notification"
 
 
+class TestCloseNotificationGateOrdering:
+    """PR #614 review findings 1+2: the marked refusal must outrank
+    EVERY admitting lane — the DM always-override included — and the
+    decision's ``policy`` may only ever carry a bounded label onto the
+    ``channel.messages.gated`` counter (the :class:`GateDecision`
+    docstring contract; the ``chair_escalation`` branch's discipline).
+    Only the two self-sender defence-in-depth refusals stay ahead of
+    it: the orchestrator excludes the sender from the notification fan
+    by contract, and the voter's own ``vote_close`` owns its record —
+    honouring a marked self-echo would bypass the own-echo-ingest
+    guard and double-close."""
+
+    def test_marked_dm_event_is_refused(self):
+        """The DM override admits every ordinary message ("a DM with no
+        reply is broken by definition") — but a close notification is
+        control, not a message awaiting reply. DMs are interaction-
+        tracked orchestrator-side, so the lane is reachable; labelled
+        with the POLICY_ALWAYS the override applies (bounded)."""
+        decision = evaluate_response_gate(
+            _notification_event(channel_id="dm:ember-owl:iron-fox",
+                                channel_type="dm"),
+            agent_id="ember-owl",
+        )
+        assert decision.respond is False
+        assert decision.reason == "close_notification"
+        assert decision.policy == POLICY_ALWAYS
+
+    def test_marked_event_for_never_policy_takes_the_dedicated_reason(self):
+        """Refused for EVERY policy means `never` too: the orchestrator
+        excludes RespondNever members from the fan by contract, but if
+        one arrives anyway the dedicated reason (and the close dispatch
+        keyed on it) beats the `policy_never` routing-regression warn —
+        closing a stale local record truthfully is strictly better than
+        warning and letting it idle out."""
+        decision = evaluate_response_gate(
+            _notification_event(respond_policy="never"), agent_id="ember-owl",
+        )
+        assert decision.respond is False
+        assert decision.reason == "close_notification"
+        assert decision.policy == POLICY_NEVER
+
+    def test_marked_event_policy_label_is_bounded(self):
+        """A marked event with a garbage wire policy must NOT echo the
+        raw (attacker- or bug-supplied) string into the decision — the
+        POLICY_UNKNOWN bounded-label discipline, same as the fail-closed
+        unknown-policy branch the marked check sits ahead of."""
+        decision = evaluate_response_gate(
+            _notification_event(respond_policy="zz-spoofed-9f3a"),
+            agent_id="ember-owl",
+        )
+        assert decision.respond is False
+        assert decision.reason == "close_notification"
+        assert decision.policy == POLICY_UNKNOWN
+
+    def test_marked_event_empty_policy_label_is_bounded(self):
+        """The `""` sentinel is documented as never reaching the gated
+        counter (it only rides respond=True pass-throughs) — a marked
+        event with a missing policy must keep that true."""
+        decision = evaluate_response_gate(
+            _notification_event(respond_policy=""), agent_id="ember-owl",
+        )
+        assert decision.respond is False
+        assert decision.policy == POLICY_UNKNOWN
+
+    def test_marked_self_sender_keeps_the_defense_in_depth_refusal(self):
+        """Ordering pin: the self-sender re-check wins over the marker.
+        Go never fans the notification to the voter (its own vote_close
+        already closed its record), so a marked self-echo is spoofed or
+        a contract break — refuse it exactly like any other self-echo
+        (no ingest, no close)."""
+        decision = evaluate_response_gate(
+            _notification_event(), agent_id="iron-fox",
+        )
+        assert decision.respond is False
+        assert decision.policy == POLICY_DEFENSE_IN_DEPTH
+        assert decision.reason == "self_sender"
+
+
 class TestCloseNotificationClosesTracker:
     """CP3, the control half: the close dispatch (the planned
     ``agents.persona_runtime.close_notification``, the ``cost_close`` /
@@ -173,13 +270,17 @@ class TestCloseNotificationClosesTracker:
     async def test_marked_event_closes_scope_with_structural_cause(self):
         """Closed immediately with the established ``end_votes`` mapping
         — :data:`REASON_STRUCTURAL`, rendering "ended" — not an
-        idle-window later, not "went idle"."""
-        from agents.persona_runtime.close_notification import (  # type: ignore[import-not-found]
+        idle-window later, not "went idle". The open turn is seeded LIVE
+        (PR #614 review finding 3 follow-up): the dispatch now runs the
+        same staleness pass every ingest runs, so an epoch-stale seed
+        would model an interaction the idle rule already owns, not the
+        live one this test always meant."""
+        from agents.persona_runtime.close_notification import (
             close_interaction_on_notification,
         )
 
         tracker = InteractionTracker()
-        tracker.add_turn("group:planning", now=100.0)
+        tracker.add_turn("group:planning", now=time.time())
         agent = _CloseNotificationAgent(tracker)
 
         await close_interaction_on_notification(agent, _notification_event())
@@ -189,6 +290,9 @@ class TestCloseNotificationClosesTracker:
         )
         assert len(agent.persisted) == 1
         assert agent.persisted[0].close_reason == REASON_STRUCTURAL
+        assert agent.persisted[0].turn_count == 2, (
+            "the closing vote ingested as the closed record's final turn"
+        )
 
     async def test_impostor_marker_closes_nothing(self):
         """Defence-in-depth (CP3): a truthy non-bool marker must not
@@ -215,12 +319,82 @@ class TestCloseNotificationClosesTracker:
         """A notification for an already-idle scope degrades quietly —
         the ``InteractionTracker.close`` unknown-scope contract, the
         ``cost_close`` no-op posture."""
-        from agents.persona_runtime.close_notification import (  # type: ignore[import-not-found]
+        from agents.persona_runtime.close_notification import (
             close_interaction_on_notification,
         )
 
         agent = _CloseNotificationAgent(InteractionTracker())
 
         await close_interaction_on_notification(agent, _notification_event())
+
+        assert agent.persisted == []
+
+    async def test_already_idle_scope_ingests_nothing(self):
+        """PR #614 review finding 3: the no-op above must hold through
+        the INGEST half too. Ingesting first would ``add_turn`` the
+        notification into a freshly-opened interaction and the close
+        would then persist a fabricated 1-turn "ended" record — exactly
+        the record the no-op contract promises never to invent. So the
+        dispatch owns the whole arc: open-scope check first, ingest only
+        when there is an open interaction to land the final turn in."""
+        from agents.persona_runtime.close_notification import (
+            close_interaction_on_notification,
+        )
+
+        tracker = InteractionTracker()
+        agent = _CloseNotificationAgent(tracker)
+
+        await close_interaction_on_notification(agent, _notification_event())
+
+        assert agent.ingested == [], (
+            "no open interaction — nothing to land the final turn in"
+        )
+        assert tracker.get("group:planning") is None, (
+            "the dispatch must not open a scope just to close it"
+        )
+        assert agent.persisted == []
+
+    async def test_expired_open_scope_flushes_by_the_idle_rule(self):
+        """PR #614 review finding 3, the stale-open half: an interaction
+        whose idle window expired before the notification landed belongs
+        to the idle rule, not to the late signal — the dispatch runs the
+        same staleness pass every ingest runs, sees nothing left open,
+        and stops. Conservative by design: relabelling a window the
+        agent's own boundary rules already ended would put an "ended"
+        cause on turns the idle contract says are a different
+        conversation; the orchestrator's authoritative "ended" record
+        stands regardless. No structural successor is fabricated."""
+        from agents.persona_runtime.close_notification import (
+            close_interaction_on_notification,
+        )
+
+        tracker = InteractionTracker()
+        tracker.add_turn("group:planning", now=time.time() - 100_000)
+        agent = _CloseNotificationAgent(tracker)
+
+        await close_interaction_on_notification(agent, _notification_event())
+
+        assert [i.close_reason for i in agent.persisted] == [REASON_IDLE_GAP], (
+            "the expired window closes by the agent's own idle rule only"
+        )
+        assert agent.ingested == []
+        assert tracker.get("group:planning") is None
+
+    async def test_payloadless_event_is_a_noop_not_a_crash(self):
+        """The docstring invites future callers off looser signals — a
+        ``None`` payload must read as unmarked (no-op), not raise."""
+        from agents.persona_runtime.close_notification import (
+            close_interaction_on_notification,
+        )
+
+        agent = _CloseNotificationAgent(InteractionTracker())
+        event = AgentEvent(
+            event_type=EventType.CHANNEL_MESSAGE,
+            payload=None,  # type: ignore[arg-type]
+            channel_id="group:planning",
+            sender_id="iron-fox",
+        )
+
+        await close_interaction_on_notification(agent, event)
 
         assert agent.persisted == []

--- a/tests/unit/python/test_interaction_close_notification.py
+++ b/tests/unit/python/test_interaction_close_notification.py
@@ -45,7 +45,11 @@ from unittest.mock import MagicMock
 
 import grpc
 
-from agents.memory.boundary_detectors import REASON_IDLE_GAP, REASON_STRUCTURAL
+from agents.memory.boundary_detectors import (
+    REASON_IDLE_GAP,
+    REASON_MAX_TURNS,
+    REASON_STRUCTURAL,
+)
 from agents.memory.interactions import Interaction, InteractionTracker
 from agents.persona_types import AgentAction, AgentEvent, EventType
 from agents.response_gate import (
@@ -209,6 +213,22 @@ class TestCloseNotificationGateOrdering:
         assert decision.respond is False
         assert decision.reason == "close_notification"
         assert decision.policy == POLICY_ALWAYS
+
+    def test_dm_impostor_marker_keeps_the_dm_admit(self):
+        """Strict ``is True`` on the DM branch too — the group branch's
+        ``test_marker_is_strictly_boolean`` twin: a truthy non-bool
+        marker is no notification, so the event keeps the ordinary DM
+        always-admit. Pinned per site: the strict-bool rule is checked
+        inline at each consumer (the ``chair_escalation`` convention —
+        no shared helper to drift in lockstep)."""
+        decision = evaluate_response_gate(
+            _notification_event(marker="true",
+                                channel_id="dm:ember-owl:iron-fox",
+                                channel_type="dm"),
+            agent_id="ember-owl",
+        )
+        assert decision.respond is True
+        assert decision.reason == "dm"
 
     def test_marked_event_for_never_policy_takes_the_dedicated_reason(self):
         """Refused for EVERY policy means `never` too: the orchestrator
@@ -398,3 +418,82 @@ class TestCloseNotificationClosesTracker:
         await close_interaction_on_notification(agent, event)
 
         assert agent.persisted == []
+
+    async def test_ingest_max_turns_close_stands_alone(self):
+        """Identity-guard pin, the cap half: when the notification's own
+        ingest pushes the interaction over the max-turns cap, ``add_turn``
+        closes it inline with :data:`REASON_MAX_TURNS` and the ingest
+        persists it in the same step (the ``episode_routing`` contract).
+        That close's own cause stands — exactly one persisted record,
+        labelled by the cap, with nothing layered after it."""
+        from agents.persona_runtime.close_notification import (
+            close_interaction_on_notification,
+        )
+
+        class _CappingIngestAgent(_CloseNotificationAgent):
+            async def _store_event_episode(
+                self, event: AgentEvent, actions: list[AgentAction],
+            ) -> None:
+                self.ingested.append(event)
+                self._interaction_tracker.add_turn("group:planning")
+                capped = self._interaction_tracker.close(
+                    "group:planning", reason=REASON_MAX_TURNS,
+                )
+                assert capped is not None
+                await self._persist_closed_interaction(capped)
+
+        tracker = InteractionTracker()
+        tracker.add_turn("group:planning", now=time.time())
+        agent = _CappingIngestAgent(tracker)
+
+        await close_interaction_on_notification(agent, _notification_event())
+
+        assert [i.close_reason for i in agent.persisted] == [REASON_MAX_TURNS], (
+            "exactly the cap's own close — no structural close layered on"
+        )
+        assert agent.persisted[0].turn_count == 2
+        assert tracker.get("group:planning") is None
+
+    async def test_ingest_rotation_leaves_the_successor_to_its_boundaries(self):
+        """Identity-guard pin, the rotation half: a notification whose
+        wire id no longer matches the open record rotates it during the
+        ingest — the retired record closes with the wire-carried cause
+        and a fresh successor opens holding only the notification. The
+        rotation's own close stands, and the 1-turn successor is
+        deliberately left OPEN for its own boundaries: closing it
+        structurally would mint exactly the fabricated 1-turn "ended"
+        record the no-open branch refuses to invent (module docstring,
+        step 4). By CP2 construction the notification carries the
+        retired record's own id, so this corner should not fire in
+        practice — pinned so a producer change surfaces here."""
+        from agents.persona_runtime.close_notification import (
+            close_interaction_on_notification,
+        )
+
+        class _RotatingIngestAgent(_CloseNotificationAgent):
+            async def _store_event_episode(
+                self, event: AgentEvent, actions: list[AgentAction],
+            ) -> None:
+                self.ingested.append(event)
+                rotated = self._interaction_tracker.close(
+                    "group:planning", reason=REASON_STRUCTURAL,
+                )
+                assert rotated is not None
+                await self._persist_closed_interaction(rotated)
+                self._interaction_tracker.add_turn("group:planning")
+
+        tracker = InteractionTracker()
+        tracker.add_turn("group:planning", now=time.time())
+        agent = _RotatingIngestAgent(tracker)
+
+        await close_interaction_on_notification(agent, _notification_event())
+
+        assert len(agent.persisted) == 1, (
+            "only the rotation's own close — the successor must not be "
+            "closed (and persisted) structurally behind it"
+        )
+        successor = tracker.get("group:planning")
+        assert successor is not None and successor.is_open, (
+            "the 1-turn successor stays open for its own boundaries"
+        )
+        assert successor.turn_count == 1


### PR DESCRIPTION
## Summary

Follow-up to the merged CP3 receiver ([#614](https://github.com/mkhomutov/Persatrix/pull/614)): three deep-review findings, each contradicting an invariant the workstream itself documents. All three were reproduced red-first against the merged code, fixed, and pinned.

### Finding 1 — the marked refusal leaked a raw wire string onto the gated counter

`evaluate_response_gate` returned the alias-normalized **wire** `respond_policy` as `GateDecision.policy` on the `close_notification` refusal — and that value is the `channel.messages.gated` metric label. A marked event with a garbage policy skipped the fail-closed `unknown_policy` bounding entirely (`policy='zz-attacker-supplied-9f3a'` reproduced), violating the bounded-set contract in the `GateDecision` docstring and the `POLICY_UNKNOWN` discipline; the adjacent chair-escalation branch guards exactly this. Now clamped to the canonical triple else `POLICY_UNKNOWN` (raw value preserved in the warn). The `""` sentinel can no longer ride a suppressing decision either — same root cause.

### Finding 2 — the DM lane admitted a close notification as stimulus

The branch comment claimed *"refused for EVERY policy, before any admitting lane"*, but the DM always-override ran first: a marked event on a `dm:` channel admitted with `reason=dm` — a full LLM turn on control traffic and no tracker close. Reachable: DMs are interaction-tracked (the resolver rotates `group`/`dm` alike) and `processEndVote` keys on `interaction_id`, not channel type; the agent-side DM-vote drop is producer discipline, not a trust-boundary guarantee. The marked check now precedes every admitting lane **and** `policy_never` (the dedicated reason beats the routing-regression warn — closing a stale record truthfully beats letting it idle out), staying behind only the two self-sender defence-in-depth refusals (Go excludes the voter by contract; its `vote_close` owns its record). Each ordering choice is pinned by a dedicated test.

### Finding 3 — an already-idle scope fabricated the very record the no-op contract forbade

The suppress path ingested unconditionally before the close, so for a scope with nothing open `_store_event_episode` **opened a fresh interaction** holding only the re-delivered closing vote, and the close persisted a spurious 1-turn *ended* record plus a summariser LLM call (`persisted: [(1, 'structural')]` reproduced through the real `on_event`) — while the module docstring promised *"nothing here invents a record to mirror it"*. The dispatch now owns the whole receiver arc:

1. marker / type / scope checks — an impostor touches nothing, not even the flush;
2. the same staleness pass every ingest runs (without it, `get` reports an idle-**expired** interaction as open and the fabrication recurs one branch over);
3. nothing open → true no-op (the orchestrator's record stands; the notification is deliberately not ingested — no open window to land the final turn in);
4. else ingest (final turn) + structural close, **identity-guarded**: a max-turns/rotation close during the ingest stands on its own cause.

Deliberately conservative: an idle-window-expired interaction closes as *went idle*, not relabelled *ended* — the agent's boundary rules outrank a signal a full window late; documented in the module and the channels-guide boundary note. Hardening from the same review: a `None` payload reads as unmarked instead of raising.

## TDD

9 new tests written red-first (all 9 failed on the merged code for the predicted reasons):
- gate ordering class: DM refusal, `never` dedicated reason, bounded garbage/empty labels, self-sender ordering pin
- dispatch level: no-ingest-on-idle-scope, expired-scope idle flush, payload-less no-crash
- loop level (real `on_event`): no invented record, idle flush with no structural successor

The committed acceptance **assertions are unchanged**; its fixture grew the ingest seam the dispatch now drives, and the happy-path seed moved from the epoch-stale `now=100.0` to a live timestamp (the staleness pass now correctly treats a 56-year-old open turn as idle — the live interaction is what the test always meant).

## Test plan

- `pytest tests/unit/python/` — 3359 passed (the 5 `test_builtin_tools_filesystem_shell` failures pre-exist on clean `main`, environment-specific)
- `mypy agents/` clean; `ruff check` clean; all 7 pre-commit gates pass