### PR TITLE
fix(deps): migrate serde_yml -> serde_yaml_ng (clears 2 Dependabot alerts)

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -765,16 +765,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +939,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_yaml_ng",
  "tabled",
  "tempfile",
  "tokio",
@@ -1252,18 +1242,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yml"
-version = "0.0.12"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
- "libyml",
- "memchr",
  "ryu",
  "serde",
- "version_check",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1599,6 +1587,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,12 +1627,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -29,8 +29,9 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 # YAML for the RFC 0050 `channel config export/import/diff` verbs
 # (cli/src/commands/channel_config_yaml.rs) — read the declared
 # `config/channels.yaml` per-channel block and regenerate it from the store.
-# serde_yaml is unmaintained; serde_yml is the maintained fork.
-serde_yml = "0.0.12"
+# serde_yaml is deprecated and serde_yml is now unmaintained/unsound
+# (RUSTSEC, via libyml). serde_yaml_ng is the maintained drop-in fork.
+serde_yaml_ng = "0.10"
 
 # Removed in PR review: tonic (gRPC — not used, CLI uses REST via reqwest),
 # indicatif (no progress bars yet). Re-add each when the corresponding feature

--- a/cli/src/commands/channel_config_yaml.rs
+++ b/cli/src/commands/channel_config_yaml.rs
@@ -22,7 +22,7 @@
 
 use colored::Colorize;
 use serde_json::{Map, Value};
-use serde_yml::Value as Yaml;
+use serde_yaml_ng::Value as Yaml;
 
 use crate::commands::channel::canonicalize_channel_id;
 use crate::commands::channel_config::{
@@ -63,7 +63,7 @@ pub(crate) fn yaml_to_knob_json(key: &str, ty: KnobType, y: &Yaml) -> Result<Val
             .as_i64()
             .map(|n| Value::Number(n.into()))
             .ok_or_else(|| format!("knob '{key}' expects an integer")),
-        // serde_yml parses an unquoted YAML scalar as Bool/Number where it can,
+        // serde_yaml_ng parses an unquoted YAML scalar as Bool/Number where it can,
         // so `escalation_chair_id: true` arrives as Bool, not String. Accept only
         // a genuine string — a non-string here is a typo, not a chair id.
         KnobType::Str => y
@@ -122,7 +122,7 @@ pub(crate) fn parse_channel_block(block: &Yaml) -> Result<ParsedChannel, String>
 /// An absent / non-sequence / empty `channels:` is a usage error — there is
 /// nothing to import or diff.
 pub(crate) fn parse_channels_doc(text: &str) -> Result<Vec<ParsedChannel>, String> {
-    let doc: Yaml = serde_yml::from_str(text).map_err(|e| format!("invalid YAML: {e}"))?;
+    let doc: Yaml = serde_yaml_ng::from_str(text).map_err(|e| format!("invalid YAML: {e}"))?;
     let channels = doc
         .as_mapping()
         .and_then(|m| m.get("channels"))
@@ -171,22 +171,22 @@ pub(crate) fn validate_channel_ids(channels: &[ParsedChannel]) -> Result<(), Str
 /// without the operator remembering to bump it. Knob order follows
 /// [`config_rows`] (the registry order), keeping exports stable and reviewable.
 pub(crate) fn render_export_doc(name: &str, view: &ChannelConfigView) -> Result<String, String> {
-    let mut block = serde_yml::Mapping::new();
+    let mut block = serde_yaml_ng::Mapping::new();
     block.insert(Yaml::from("name"), Yaml::from(name));
     block.insert(Yaml::from("revision"), Yaml::from(view.revision + 1));
     for (knob, field) in config_rows(view) {
         if field.source == "channel" {
-            let y = serde_yml::to_value(&field.value)
+            let y = serde_yaml_ng::to_value(&field.value)
                 .map_err(|e| format!("knob '{knob}': cannot encode value as YAML: {e}"))?;
             block.insert(Yaml::from(knob), y);
         }
     }
-    let mut doc = serde_yml::Mapping::new();
+    let mut doc = serde_yaml_ng::Mapping::new();
     doc.insert(
         Yaml::from("channels"),
         Yaml::Sequence(vec![Yaml::Mapping(block)]),
     );
-    serde_yml::to_string(&Yaml::Mapping(doc)).map_err(|e| format!("cannot serialize YAML: {e}"))
+    serde_yaml_ng::to_string(&Yaml::Mapping(doc)).map_err(|e| format!("cannot serialize YAML: {e}"))
 }
 
 /// Per-knob outcome of a `diff`: how the declared YAML value relates to the

--- a/cli/src/commands/channel_config_yaml_tests.rs
+++ b/cli/src/commands/channel_config_yaml_tests.rs
@@ -77,7 +77,7 @@ fn yaml_to_knob_json_rejects_wrong_type_naming_the_knob() {
 // ─── parse_channel_block ───────────────────────────────────────────────────
 
 fn yaml_block(text: &str) -> Yaml {
-    serde_yml::from_str(text).expect("test YAML parses")
+    serde_yaml_ng::from_str(text).expect("test YAML parses")
 }
 
 #[test]


### PR DESCRIPTION
## What

Replaces the unmaintained/unsound `serde_yml` dependency with the maintained drop-in fork `serde_yaml_ng` 0.10.

## Why

`serde_yml` and its `libyml` dependency are flagged by RUSTSEC with **no patched release available**, raising two open Dependabot alerts:

| Alert | Severity | Advisory | Issue |
|-------|----------|----------|-------|
| #15 | high | GHSA-gfxp-f68g-8x78 | `libyml::yaml_string_extend` unsound + unmaintained |
| #16 | moderate | GHSA-hhw4-xg65-fp2x | `serde_yml` unsound + unmaintained |

Both stem from the single direct dep `serde_yml = "0.0.12"` (it pulls in `libyml` transitively). Dependabot can't bump its way out — the fix is to migrate off the crate.

`serde_yaml_ng` is the actively-maintained continuation of `serde_yaml`. It backs onto the sound `unsafe-libyaml` instead of `libyml`, and exposes an identical API (`Value`, `Mapping`, `from_str`, `to_value`, `to_string`) to what `channel_config_yaml.rs` already uses — so this is a mechanical rename with **no behavior change**.

## Blast radius

The only consumer is one self-contained, recently-added module: `cli/src/commands/channel_config_yaml.rs` (RFC 0050 Phase 1) and its test.

## Verification

- `cargo build` — clean
- `cargo tree` — `serde_yml` and `libyml` are gone; replaced by `serde_yaml_ng` → `unsafe-libyaml`
- `cargo test channel_config_yaml` — 17/17 pass

Closes both Dependabot alerts once merged to `main`.