### PR TITLE
fix(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained) (#578)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,15 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    # Add justified exceptions here with TODO follow-up dates
+    # RUSTSEC-2026-0173 — proc-macro-error2 is unmaintained (not a vulnerability;
+    # informational "unmaintained" advisory). Pulled in transitively and only at
+    # compile time: tabled_derive 0.11 (the latest release) → proc-macro-error2.
+    # There is no safe upgrade — tabled 0.21 (also latest) still depends on
+    # tabled_derive 0.11, and we rely on tabled's `#[derive(Tabled)]` throughout
+    # the CLI, so dropping the derive feature is not viable. Zero runtime impact.
+    # TODO(2026-09-15): re-check; drop this once tabled_derive migrates off
+    # proc-macro-error2 (upstream: GnomedDev/proc-macro-error-2#17).
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Resolves the failing **Scheduled Dependency Audit** (#578).

`cargo deny check advisories` fails on **RUSTSEC-2026-0173**: `proc-macro-error2` is unmaintained. It enters the dependency tree transitively and **compile-time only**:

```
proc-macro-error2 v2.0.1
└── tabled_derive v0.11.0 (proc-macro)
    └── tabled v0.20.0
        └── persatrix
```

## Why an exception instead of an upgrade

- **No safe upgrade exists.** The advisory itself states "No safe upgrade is available!"
- `tabled` 0.21.0 (latest) still pins `tabled_derive` 0.11.0, which still depends on `proc-macro-error2` — verified locally, so bumping `tabled` does not help.
- The CLI relies on `tabled`'s `#[derive(Tabled)]` throughout (`src/types.rs`, `src/commands/session.rs`, etc.), so disabling the `derive` feature to drop `tabled_derive` is not viable.
- The advisory is **informational** (`unmaintained`, not a vulnerability) with **zero runtime impact** (macro crate, compile-time only).

This follows the precedent set for the earlier `tabled`-related advisory (RUSTSEC-2024-0370, #162).

## Change

Add a justified `ignore` entry to `deny.toml` with a **2026-09-15** follow-up to re-check and remove once `tabled_derive` migrates off `proc-macro-error2` (tracking: GnomedDev/proc-macro-error-2#17).

## Verification

```
$ cd cli && cargo deny check advisories bans sources licenses
advisories ok, bans ok, licenses ok, sources ok
```

Closes #578