### PR TITLE
docs(diagrams): mark channels/ and security/ as shipped, not stubs

### DIFF
--- a/docs/diagrams/component-architecture.md
+++ b/docs/diagrams/component-architecture.md
@@ -28,12 +28,12 @@ graph TB
         TELE["telemetry/<br/>OTEL"]
         MCPG["mcp/"]
         PROTOS["protocols/"]
+        CHAN["channels/"]
+        SEC["security/"]
 
         A2A["a2a/ (stub)"]:::stub
         BRIDGES["bridges/ (stub)"]:::stub
-        CHAN["channels/ (stub)"]:::stub
         RES["resilience/ (stub)"]:::stub
-        SEC["security/ (stub)"]:::stub
         MESH["mesh/ (stub)"]:::stub
 
         SERVER --> PLANNER
@@ -104,8 +104,9 @@ graph TB
 | v0.1 | `planner/`, `scheduler/`, `executor/`, `registry/`, `state/`, `server/`, `mcp/`, `protocols/`, `agents/task_agent.py`, `agents/tools/` |
 | v0.2 | `cost/`, `telemetry/`, `agents/persona*`, `agents/persona_runtime/`, `agents/memory/`, `agents/sub_agents/` |
 | v0.2.1 | `agents/participant.py` (`UserParticipant`, `UserStore`), `internal/server/chat_handler.go` (`POST /api/v1/agents/{id}/chat`), `internal/executor/` chat path (`SendChatMessage` gRPC), `cli/src/commands/chat` (`persatrix chat`) |
+| v0.3.0 | `internal/channels/` (RFC 0011 — internal agent-to-agent messaging), `internal/security/` (RFC 0009 Phases 1–2 — redactor, audit log, rate limiter) |
 | v0.3.2 | `internal/wallet/` (RFC 0023 — LLM-call leasing `WalletService`; Phases 1–6 implemented: enforcement + TTL reaper + per-agent active-lease cap composed over `cost/`, with the Python `WalletClient` wired into all five LLM-call origins — workflow task, chat, autonomous TICK, sub-agent, channel-message) |
-| v0.3+ (stubs) | `a2a/`, `bridges/`, `channels/`, `resilience/`, `security/`, `mesh/` |
+| v0.3+ (stubs) | `a2a/`, `bridges/`, `resilience/`, `mesh/` |
 
 The labeled `SERVER -->|chat dispatch| EXECUTOR` edge represents the chat
 path (`POST /api/v1/agents/{id}/chat` → `GRPCChatExecutor.SendChatMessage`);


### PR DESCRIPTION
## Summary

`docs/diagrams/component-architecture.md` drew `internal/channels/` and `internal/security/` as dashed `(stub)` boxes, but both have shipped since ~v0.3.0. This pre-existing staleness made the diagram misleading; it is independent of any current feature work.

Verified by counting non-test source files:

| package | non-test `.go` | status |
|---|---|---|
| `internal/channels/` | **51** | shipped — RFC 0011 (v0.3.0 internal channels), grown through v0.3.10 |
| `internal/security/` | **15** | shipped — RFC 0009 Phases 1–2 (v0.3.0: redactor, audit log, rate limiter) |
| `internal/a2a/`, `bridges/`, `resilience/`, `mesh/` | **1** each | genuine skeletons — left as stubs |

## Changes

- **Mermaid graph:** moved `CHAN["channels/"]` and `SEC["security/"]` out of the dashed cluster into the solid-box block (dropped the ` (stub)` suffix and `:::stub` class), matching shipped boxes like `registry/`/`state/`. The dashed group now contains only the four real stubs.
- **Phase-ownership table:** added a `v0.3.0` shipped row for `internal/channels/` + `internal/security/`, and trimmed the `v0.3+ (stubs)` row to `a2a/`, `bridges/`, `resilience/`, `mesh/`.

No other diagram or doc touched.

## Validation

- `python3 scripts/checks/doc_audit.py` → ✅ ALL PASSED (doc-links, doc-status-markers, file-size: 0 violations)
- Mermaid block balanced (5 `subgraph` / 5 `end`), `classDef stub` retained with exactly 4 stub nodes, fences balanced
- Pre-commit hooks green (8/8)

## Notes

Also tracked as a fallback in `docs/rfcs/0052-pr-plan.md` (RFC 0052 PR 5 "Documentation & diagrams"); landing this independently means that PR won't need to carry it. Branched from `main` (not the v0.3.11 planning branch) as an independent docs fix.
