### PR TITLE
fix(memory): deterministic recent-interactions recall — rowid tiebreak

### DIFF
--- a/agents/memory/relationship_queries.py
+++ b/agents/memory/relationship_queries.py
@@ -274,7 +274,18 @@ async def get_relationship_summary(
         "WHERE participant_id = ? AND participant_type = ? "
         "AND other_participant_id = ? AND other_participant_type = ? "
         f"{int_sess_clause}{princ_clause}{epoch_clause} "
-        "ORDER BY created_at DESC LIMIT ?",
+        # Deterministic tiebreak (issue #740; follows #739). `created_at` can
+        # tie — e.g. several interactions recorded in one instant under the eval
+        # driver's FrozenClock — and with `LIMIT` a tie at the cutoff changes
+        # *which* rows are returned, not just their order, so a bare `created_at
+        # DESC` is non-portable for RFC 0044 goldens. `rowid` (insertion order)
+        # is the tiebreak: `interactions.id` is a random uuid4 (see
+        # `record_interaction`), so it is NOT a portable tiebreak; `rowid` is
+        # identical across record and replay, which INSERT the same interactions
+        # in the same order, and the table is not WITHOUT ROWID. Unlike the
+        # GROUP BY summary query below, this is a plain row SELECT, so `rowid`
+        # is unambiguous (one per row), not an arbitrary per-group pick.
+        "ORDER BY created_at DESC, rowid DESC LIMIT ?",
         (agent_id, participant_type, other_id,
          other_participant_type, *int_sess_params, *princ_params,
          *epoch_params, _MAX_RECENT_INTERACTIONS),

--- a/tests/unit/python/test_relationship_memory_interactions.py
+++ b/tests/unit/python/test_relationship_memory_interactions.py
@@ -137,6 +137,38 @@ class TestGetRelationshipSummary:
         types = [i.interaction_type for i in summary.recent_interactions]
         assert types == ["third", "second", "first"]
 
+    async def test_recent_interactions_equal_created_at_deterministic(
+        self, memory, monkeypatch,
+    ):
+        """Interactions sharing a ``created_at`` recall in a stable, defined
+        order — the ``rowid`` (insertion-order) tiebreak on ``created_at DESC``
+        (issue #740; follows #739).
+
+        The eval driver's FrozenClock can stamp several interactions in one
+        instant, and ``interactions.id`` is a random uuid4 — so without the
+        tiebreak SQLite's order among equal ``created_at`` is implementation-
+        defined. Because the recall is ``LIMIT``-ed, a tie at the cutoff would
+        also change *which* interactions surface, not just their order, making a
+        recorded RFC 0044 golden non-portable. The clock is frozen here so both
+        rows share ``created_at``; distinct-timestamp order is covered above."""
+        from types import SimpleNamespace
+
+        import agents.memory.relationship_mutations as rm
+        monkeypatch.setattr(rm, "time", SimpleNamespace(time=lambda: 1000.0))
+
+        first = await memory.record_interaction("bob", "first")
+        second = await memory.record_interaction("bob", "second")  # same instant
+
+        summary = await memory.get_relationship_summary("bob")
+        ids = [i.id for i in summary.recent_interactions]
+        assert ids == [second, first], (
+            "equal-created_at interactions must recall most-recently-inserted "
+            "first (rowid DESC tiebreak), not SQLite's implementation-defined order"
+        )
+        # Stable across repeated calls — the property a golden's hash needs.
+        again = await memory.get_relationship_summary("bob")
+        assert [i.id for i in again.recent_interactions] == ids
+
     async def test_limits_to_max_recent_interactions(self, memory):
         """Only the most recent _MAX_RECENT_INTERACTIONS are returned."""
         total = _MAX_RECENT_INTERACTIONS + 5


### PR DESCRIPTION
## What & why

The recent-interactions recall in `get_relationship_summary` ([`agents/memory/relationship_queries.py`](agents/memory/relationship_queries.py)) ordered by `created_at DESC` with **no secondary tiebreak**. `created_at` can tie — e.g. several interactions recorded in one instant under the eval driver's `FrozenClock` — and because the recall is **`LIMIT`-ed** (`_MAX_RECENT_INTERACTIONS = 10`), a tie at the cutoff changes *which* rows are returned, not just their order. That's a latent [RFC 0044](docs/rfcs/0044-eval-set-golden-traces.md) golden-trace portability gap: the returned interactions feed the assembled prompt that's hashed into every replay request.

Second item in #740; follows the same determinism-hardening as #739 and #741.

## The fix

```sql
ORDER BY created_at DESC, rowid DESC LIMIT ?
```

This site is the **`facts.recall` situation from #739**, not the `GROUP BY` situation from #741 — so the tiebreak differs by design from its sibling in the same file:

- **`rowid`, not `id`.** `interactions.id` is a random `uuid.uuid4()` ([`relationship_mutations.py:354`](agents/memory/relationship_mutations.py#L354)), so — like `fact_id` — it varies between the record and replay runs and can't be a portable tiebreak. `rowid` (insertion order) is identical across record and replay, which INSERT the same interactions in the same order; the table is not `WITHOUT ROWID`.
- **`rowid` is valid here.** Unlike the `get_all_relationships` `GROUP BY` query (#741), this is a **plain row `SELECT`**, so `rowid` is unambiguous — one per output row, not an arbitrary per-group pick.
- **Behavior-preserving.** A tiebreak only orders rows with *equal* `created_at`; the newest-first contract for distinct timestamps is unchanged.

## Testing

- New test `test_recent_interactions_equal_created_at_deterministic`, placed next to the existing `test_recent_interactions_ordered_newest_first` (distinct-timestamp case). It freezes the clock via an isolated module-level fake (no global mutation) so two interactions share `created_at`, then asserts the rowid-DESC order and stability across repeated calls.
- **Genuinely discriminating** (unlike #741's contract-guard): I verified it **fails without** the fix — the un-tiebroken query returns insertion/rowid-ASC order `[first, second]`, contradicting the pinned `[second, first]`. So this fix does real work; the `interactions` indexes cover the participant-lookup columns but not `created_at`, so nothing incidentally stabilizes tie order.
- No ripple: **1081 passed, 1 skipped** across the relationship/memory/session/identity/episodic/notes/shared-pool unit tests.
- Pre-commit gates green (ruff, filemap, doc-links, size, …).

## Scope

- Two-line SQL change + one test. No schema change, no new files (no `FILEMAP.md` delta), negligible sort cost.
- Remaining #740 sites (`episodic_procedural.py`, `episodic_closed.py`, `_notes_recall.py`, `shared_pool.py`, and the lowest-priority `_facts_supersede.py`) are **left for follow-up** — each is its own tier needing a separate scope check.

## Notes

- Branched off `main`; independent of the RFC 0044 feature work. Follows #739 / #741; addresses the second item in #740.
