### PR TITLE
fix(memory): deterministic procedural recall — rowid tiebreak

### DIFF
--- a/agents/memory/episodic_procedural.py
+++ b/agents/memory/episodic_procedural.py
@@ -244,17 +244,27 @@ async def recall_procedures(
             " AND (? - COALESCE(last_validated_at, created_at)) <= ?"
         )
         params.extend([timestamp, sql_cutoff_seconds])
+    # Deterministic tiebreak (issue #740; follows #739 / #742) on BOTH
+    # branches below. `created_at` can tie — several procedures stored in one
+    # instant under the eval driver's FrozenClock — and this recall over-fetches
+    # `limit*2` then decay-filters in Python, so a tie at the SQL `LIMIT` cutoff
+    # changes *which* rows reach the filter, not just their order — a
+    # non-portable RFC 0044 golden-trace gap. `rowid` (insertion order) is the
+    # tiebreak: `episodes.id` is a random uuid4 (`insert_episode`), so it is NOT
+    # a portable tiebreak; `rowid` is identical across record and replay, which
+    # INSERT the same episodes in the same order, and the table is not WITHOUT
+    # ROWID. This is a plain row SELECT, so `rowid` is unambiguous (one per row).
     if query:
         # PR #225 review S1: escape LIKE meta-chars in ``query`` so a
         # ``%`` / ``_`` in caller-supplied search text does not widen
         # the match.  Pair with ``ESCAPE '\\'``.
         sql = (
             sql_base + " AND summary LIKE ? ESCAPE '\\'"
-            " ORDER BY created_at DESC LIMIT ?"
+            " ORDER BY created_at DESC, rowid DESC LIMIT ?"
         )
         params.extend([f"%{_escape_like(query)}%", max(limit * 2, limit)])
     else:
-        sql = sql_base + " ORDER BY created_at DESC LIMIT ?"
+        sql = sql_base + " ORDER BY created_at DESC, rowid DESC LIMIT ?"
         params.append(max(limit * 2, limit))
     async with db.execute(sql, tuple(params)) as cursor:
         rows = list(await cursor.fetchall())

--- a/tests/unit/python/test_memory_decay.py
+++ b/tests/unit/python/test_memory_decay.py
@@ -158,6 +158,42 @@ async def test_recall_procedures_query_filter(facade: MemoryStore) -> None:
     assert results[0].key == "a"
 
 
+async def test_recall_procedures_equal_created_at_deterministic(
+    facade: MemoryStore,
+) -> None:
+    """Procedures sharing a ``created_at`` recall in a stable, defined order —
+    the ``rowid`` (insertion-order) tiebreak on ``created_at DESC`` (issue #740;
+    follows #739 / #742).
+
+    ``episodes.id`` is a random uuid4, so without the tiebreak SQLite's order
+    among equal ``created_at`` is implementation-defined — and because the recall
+    over-fetches ``2 * limit`` then decay-filters in Python, a tie at the ``LIMIT``
+    cutoff could change *which* rows survive, not just their order, making a
+    recorded RFC 0044 golden non-portable. Both procedures are stored, then their
+    ``created_at`` is forged to a single instant (mirrors the eval driver's
+    FrozenClock); insertion order is preserved by ``rowid``, so the
+    newest-inserted must recall first."""
+    await facade.store_procedure("first", "alpha", confidence=0.9)
+    await facade.store_procedure("second", "beta", confidence=0.9)
+    db = facade.episodic._ensure_db()  # noqa: SLF001 — forge a created_at tie
+    await db.execute(
+        "UPDATE episodes SET created_at = 1000.0 "
+        "WHERE agent_id = ? AND tags_json LIKE '%\"procedure:%'",
+        ("proc-test",),
+    )
+    await db.commit()
+
+    results = await recall_procedures(db, "proc-test", c_min=0.0)
+    keys = [e.key for e in results]
+    assert keys == ["second", "first"], (
+        "equal-created_at procedures must recall most-recently-inserted first "
+        "(rowid DESC tiebreak), not SQLite's implementation-defined order"
+    )
+    # Stable across repeated calls — the property a golden's request hash needs.
+    again = await recall_procedures(db, "proc-test", c_min=0.0)
+    assert [e.key for e in again] == keys
+
+
 # ─── refresh_confidence ───────────────────────────────────────
 
 


### PR DESCRIPTION
## What & why

`recall_procedures` in [`agents/memory/episodic_procedural.py`](agents/memory/episodic_procedural.py) ordered by `created_at DESC` on **both** its branches (the query-filtered and unfiltered SQL) with **no secondary tiebreak**. `created_at` can tie — e.g. several procedures stored in one instant under the eval driver's `FrozenClock` — and this recall **over-fetches `2 * limit`** then decay-filters in Python, so a tie at the SQL `LIMIT` cutoff changes *which* rows reach the filter, not just their order. That's a latent [RFC 0044](docs/rfcs/0044-eval-set-golden-traces.md) golden-trace portability gap.

Third item in #740; follows #739 / #742.

## The fix

```sql
ORDER BY created_at DESC, rowid DESC LIMIT ?
```

...applied to **both** branches. This is the `facts.recall` / #742 situation (not the `GROUP BY` situation from #741):

- **`rowid`, not `id`.** `episodes.id` is a random `uuid.uuid4()` ([`episodic_queries.py:424`](agents/memory/episodic_queries.py#L424)), so — like `fact_id` / `interactions.id` — it varies between the record and replay runs and can't be a portable tiebreak. `rowid` (insertion order) is identical across record and replay, which INSERT the same episodes in the same order; `episodes` is `TEXT PRIMARY KEY`, not `WITHOUT ROWID`.
- **`rowid` is unambiguous here.** Plain row `SELECT`, one `rowid` per output row (unlike the `get_all_relationships` `GROUP BY` in #741).
- **Behavior-preserving.** A tiebreak only orders rows with *equal* `created_at`; distinct-timestamp order is unchanged.

## Testing

- New test `test_recall_procedures_equal_created_at_deterministic` in [`test_memory_decay.py`](tests/unit/python/test_memory_decay.py), next to the existing `recall_procedures` tests. Stores two procedures, forges both `created_at` to one instant (mirrors the FrozenClock), and asserts rowid-DESC recall + stability across repeated calls.
- **Genuinely discriminating** — verified it **fails without** the fix. Notably `episodes` carries an `idx_episodes_created ON episodes(created_at DESC)` index whose entries are `(created_at DESC, rowid ASC)`, so the un-tiebroken query returns insertion order `['first', 'second']`, the *opposite* of the pinned `['second', 'first']`. So the fix does real work.
- No ripple: **1190 passed, 1 skipped** across the decay/episodic/procedural/memory/eviction/session/scope unit tests.
- Pre-commit gates green (ruff, filemap, doc-links, size, …).

## Scope

- Two-line SQL change (both branches) + one test. No schema change, no new files (no `FILEMAP.md` delta), negligible sort cost.
- Remaining #740 sites (`episodic_closed.py`, `_notes_recall.py`, `shared_pool.py`, and the lowest-priority `_facts_supersede.py`) are **left for follow-up** — each is its own tier needing a separate scope check.

## Notes

- Branched off `main`; independent of the RFC 0044 feature work. Follows #739 / #742; addresses the third item in #740.
