### PR TITLE
fix(web): don't double the v prefix on the topbar version chip

### DIFF
--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -120,7 +120,10 @@
         authenticated = context?.authenticated === true;
         actingAs = id; // the override defaults to the real principal
         actingAsDraft = id; // and the box shows that default
-        version = config?.build?.version ?? "";
+        // Normalize away a leading "v": the chip renders "v{version}", and a
+        // binary built from a git checkout reports an already-v-prefixed Go
+        // pseudo-version ("v0.3.11-0.2026…") — un-stripped it displayed "vv…".
+        version = (config?.build?.version ?? "").replace(/^v/, "");
         panels = selectPanels(config);
         activeName = hashPanelName();
         canonicalizeHash(activeName);

--- a/web/src/App.test.js
+++ b/web/src/App.test.js
@@ -89,6 +89,30 @@ describe("App shell boot", () => {
     });
   });
 
+  it("does not double the v prefix when build.version already carries one", async () => {
+    // A binary built from a git checkout reports a Go pseudo-version, which is
+    // already v-prefixed ("v0.3.11-0.20260720…"); the chip prepends its own
+    // "v", so an un-normalized value rendered as "vv0.3.11-…". The shell strips
+    // one leading "v" before display, keeping bare versions ("0.3.6" → "v0.3.6")
+    // and prefixed ones ("v0.3.11-…" → "v0.3.11-…") uniform.
+    loadBootstrap.mockResolvedValue({
+      config: {
+        build: { version: "v0.3.11-0.20260720113407-d9cb5fba7e70" },
+        panels: { channel_timeline: { enabled: true, available: true } },
+      },
+      context: { principal: "local", tenant: "local", authenticated: false },
+    });
+
+    render(App);
+
+    await waitFor(() => {
+      const chip = screen.getByTitle("Orchestrator build");
+      expect(chip.textContent.trim()).toBe(
+        "v0.3.11-0.20260720113407-d9cb5fba7e70",
+      );
+    });
+  });
+
   it("omits the version chip when the config carries no build version", async () => {
     // build.version is optional; a payload without it shows no chip rather than a
     // bare "v" placeholder.


### PR DESCRIPTION
## The bug

Follow-up to #760. The redesigned topbar's version chip renders `v{version}`, but `/ui/config`'s `build.version` is **already v-prefixed** when the binary is built from a git checkout — a Go pseudo-version like `v0.3.11-0.20260720113407-d9cb5fba7e70` — so the chip displayed **`vv0.3.11-…`**. Pre-existing behaviour (the old topbar used the same `v{version}` template), but newly visible now that the chip is prominent; it never showed during #760's design verification because the mock backend served a bare `0.3.11-dev`.

## The fix

[`App.svelte`](web/src/App.svelte) strips one leading `v` from `build.version` before display, so both shapes render uniformly:

- bare `0.3.6` → `v0.3.6` (unchanged, pinned by the existing test)
- pseudo-version `v0.3.11-0.2026…` → `v0.3.11-0.2026…` (the fix, new test)
- absent → no chip (unchanged, pinned by the existing test)

## Verified

- TDD: the new pseudo-version case in [`App.test.js`](web/src/App.test.js) was red first; **311/311** web tests green after the one-line fix.
- Live: rebuilt via `make run-ui` — the chip on `http://localhost:8080/ui` now reads `v0.3.11-0.20260720113407-d9cb5fba7e70+dirty` (single prefix).