### PR TITLE
docs(auth): note that logging in does not partition persona memory

### DIFF
--- a/docs/guides/auth.md
+++ b/docs/guides/auth.md
@@ -22,6 +22,22 @@ becomes a verified claim instead of a body field.
 > channel)` memory continuity, unrelated to login sessions despite the shared
 > word. Logging in does not switch rooms; switching rooms does not touch auth.
 
+> **Known limitation — logging in does not partition persona memory.** What a
+> persona remembers is bounded by room membership and
+> [RFC 0037](../rfcs/0037-memory-confidentiality-channel-classification.md)
+> classification, **never by which account is speaking**. The per-room half of
+> the isolation rail is live (the orchestrator binds a session per `(agent,
+> channel)`), but it emits no per-request *principal*, so every caller —
+> authenticated or not — collapses to the single `local` tenant
+> ([ISSUE-0081](../issues/ISSUE-0081-session-id-process-global-not-task-local.md)
+> / [ISSUE-0082](../issues/ISSUE-0082-orchestrator-per-request-session-principal-emission.md)
+> Part 2, targeted **v0.3.14** per the [sequencing Amendment
+> 2026-08-02](../v0.3.x-sequencing.md#amendment-2026-08-02--v0313--v0314-the-two-release-tail-to-v040)).
+> So two accounts in one room share that room's memory session by design, and
+> the deliberately cross-room tiers (travelling facts, person identity) carry
+> across accounts too. Until then, give users who must not share a persona's
+> memory separate rooms — and classify those rooms.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## What

Adds one **Known limitation** note to [`docs/guides/auth.md`](docs/guides/auth.md), directly under the existing "three different identities" terminology block it depends on: enabling `auth.mode` gates the REST/console surface, but it does **not** partition what a persona remembers.

Stacked on #805 — it links that PR's [sequencing Amendment 2026-08-02](docs/v0.3.x-sequencing.md) anchor for the v0.3.14 target, so it needs #805's heading to exist. Retarget to `main` once #805 merges.

## Why

The guide's own framing makes the gap conspicuous. It promises the console is "safe to run beyond localhost" and that `participant_id` "becomes a verified claim" — and it has a dedicated section for *what enabling auth does not close* (the agent ingress), which an operator would reasonably read as the complete residual list. Memory isolation is missing from it.

The mechanism, per the same investigation that corrected #805's v0.3.14 scope:

- The **per-room** half of the isolation rail is live — the orchestrator binds a session per `(agent, channel)` and emits `persatrix-session` on dispatch (ISSUE-0082 Part 1, 2026-05-29).
- The **principal** half is not. Nothing emits `persatrix-principal`, so every caller — authenticated or not — collapses to the single `local` tenant (ISSUE-0081, open/high; ISSUE-0082 Part 2, targeted v0.3.14).

So persona memory is bounded by room membership and RFC 0037 classification, never by which account is speaking: two accounts in one room share that room's memory session, and the deliberately cross-room tiers (travelling facts; the person-identity record, whose primary key omits `session_id`) carry across accounts as well.

This is a **documentation** gap, not a new defect — the behaviour is tracked in ISSUE-0081/0082 and scheduled. But it became operator-visible when RFC 0039 Phases 1–2 shipped in v0.3.12 and made multi-user, non-localhost deployment a supported shape, so the guide should say so until v0.3.14 closes it.

The note ends with the mitigation actually available today: give users who must not share a persona's memory separate rooms, and classify those rooms.

## Verification

- `scripts/checks/doc_links.py` — 13,908 links / 489 files, all valid (includes the cross-file amendment anchor; the checker validates heading fragments)
- `scripts/checks/doc_audit.py` — green
- pre-commit 9/9

Docs-only; no source changes.